### PR TITLE
feat(#3): 接入 subsystem-sdk 并实现 Ex-0 注册与心跳闭环

### DIFF
--- a/src/subsystem_announcement/__main__.py
+++ b/src/subsystem_announcement/__main__.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 
 from . import __version__
 from .config import load_config
+from .logging_setup import configure_logging
 
 try:
     import typer
@@ -40,6 +42,62 @@ if typer is not None:
             typer.echo(f"doctor failed: {exc}", err=True)
             raise typer.Exit(code=1) from exc
         typer.echo("ok")
+
+    @app.command("ping")
+    def ping_command(
+        config: Path | None = typer.Option(
+            None,
+            "--config",
+            "-c",
+            help="Optional announcement TOML config path.",
+        ),
+    ) -> None:
+        """Run registration, one heartbeat, and one Ex-0 submit."""
+
+        try:
+            configure_logging()
+            runtime_config = load_config(config)
+            from .runtime.lifecycle import ping
+            from .runtime.sdk_adapter import SDK_AVAILABLE
+
+            if not SDK_AVAILABLE:
+                typer.echo("subsystem-sdk unavailable; using local SDK stub", err=True)
+            asyncio.run(ping(runtime_config))
+        except Exception as exc:
+            typer.echo(f"ping failed: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+        typer.echo("ok")
+
+    @app.command("run")
+    def run_command(
+        config: Path | None = typer.Option(
+            None,
+            "--config",
+            "-c",
+            help="Optional announcement TOML config path.",
+        ),
+        once: bool = typer.Option(
+            False,
+            "--once",
+            help="Run one lifecycle iteration and exit.",
+        ),
+    ) -> None:
+        """Run the announcement subsystem lifecycle."""
+
+        try:
+            configure_logging()
+            runtime_config = load_config(config)
+            from .runtime.lifecycle import run
+            from .runtime.sdk_adapter import SDK_AVAILABLE
+
+            if not SDK_AVAILABLE:
+                typer.echo("subsystem-sdk unavailable; using local SDK stub", err=True)
+            asyncio.run(run(runtime_config, once=once))
+        except KeyboardInterrupt:
+            raise typer.Exit(code=130) from None
+        except Exception as exc:
+            typer.echo(f"run failed: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
 else:
     app = None
 
@@ -60,8 +118,44 @@ def _fallback_main(argv: list[str]) -> int:
             return 1
         print("ok")
         return 0
+    if command in {"ping", "run"}:
+        once = command == "ping" or "--once" in argv
+        config_path: Path | None = None
+        if "--config" in argv:
+            index = argv.index("--config")
+            if index + 1 < len(argv):
+                config_path = Path(argv[index + 1])
+        elif "-c" in argv:
+            index = argv.index("-c")
+            if index + 1 < len(argv):
+                config_path = Path(argv[index + 1])
+        try:
+            configure_logging()
+            runtime_config = load_config(config_path)
+            from .runtime.lifecycle import ping, run
+            from .runtime.sdk_adapter import SDK_AVAILABLE
 
-    print("usage: python -m subsystem_announcement [version|doctor]", file=sys.stderr)
+            if not SDK_AVAILABLE:
+                print(
+                    "subsystem-sdk unavailable; using local SDK stub",
+                    file=sys.stderr,
+                )
+            if command == "ping":
+                asyncio.run(ping(runtime_config))
+            else:
+                asyncio.run(run(runtime_config, once=once))
+        except KeyboardInterrupt:
+            return 130
+        except Exception as exc:
+            print(f"{command} failed: {exc}", file=sys.stderr)
+            return 1
+        print("ok")
+        return 0
+
+    print(
+        "usage: python -m subsystem_announcement [version|doctor|ping|run]",
+        file=sys.stderr,
+    )
     return 1
 
 

--- a/src/subsystem_announcement/__main__.py
+++ b/src/subsystem_announcement/__main__.py
@@ -98,6 +98,7 @@ if typer is not None:
         except Exception as exc:
             typer.echo(f"run failed: {exc}", err=True)
             raise typer.Exit(code=1) from exc
+        typer.echo("ok")
 else:
     app = None
 

--- a/src/subsystem_announcement/config.py
+++ b/src/subsystem_announcement/config.py
@@ -7,7 +7,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 DEFAULT_CONFIG_PATH = Path("config/announcement.toml")
 
@@ -23,8 +23,8 @@ class AnnouncementConfig(BaseModel):
     reasoner_endpoint: str | None = None
     entity_registry_endpoint: str | None = None
     sdk_endpoint: str | None = None
-    heartbeat_interval_seconds: int = 60
-    registration_ttl_seconds: int = 900
+    heartbeat_interval_seconds: int = Field(60, gt=0, le=86_400)
+    registration_ttl_seconds: int = Field(900, gt=0, le=604_800)
 
 
 def load_config(path: Path | None = None) -> AnnouncementConfig:

--- a/src/subsystem_announcement/config.py
+++ b/src/subsystem_announcement/config.py
@@ -22,7 +22,9 @@ class AnnouncementConfig(BaseModel):
     llama_index_version: str = "not-configured"
     reasoner_endpoint: str | None = None
     entity_registry_endpoint: str | None = None
+    sdk_endpoint: str | None = None
     heartbeat_interval_seconds: int = 60
+    registration_ttl_seconds: int = 900
 
 
 def load_config(path: Path | None = None) -> AnnouncementConfig:

--- a/src/subsystem_announcement/runtime/_sdk_stub.py
+++ b/src/subsystem_announcement/runtime/_sdk_stub.py
@@ -1,0 +1,78 @@
+"""Protocol-compatible SDK placeholders used when subsystem-sdk is absent."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RegistrationSpec(BaseModel):
+    """Minimal registration metadata consumed by the announcement runtime."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    module_id: str
+    owned_ex_types: tuple[str, ...]
+    parser_version: str
+    registration_ttl_seconds: int
+    sdk_endpoint: str | None = None
+
+
+class HeartbeatPayload(BaseModel):
+    """Minimal Ex-0 heartbeat shape for offline SDK-compatible execution."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    timestamp: datetime
+    last_ex_id: str | None = None
+    status: str
+    interval_seconds: int
+
+
+class ExPayload(BaseModel):
+    """Base payload placeholder; concrete Ex payloads remain contract-owned."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ex_type: str
+
+
+class Ex0Payload(ExPayload):
+    """Stage-0 metadata heartbeat payload placeholder."""
+
+    ex_type: Literal["Ex-0"] = "Ex-0"
+    run_id: str
+    reason: str
+    emitted_at: datetime
+
+
+class SubmitResult(BaseModel):
+    """Normalized submit result used by the offline shim."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    accepted: bool
+    receipt_id: str
+    ex_type: str
+    warnings: tuple[str, ...] = Field(default_factory=tuple)
+    errors: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class SubsystemBaseInterface(ABC):
+    """Small abstract surface matching the SDK hooks used by this subsystem."""
+
+    @abstractmethod
+    def on_register(self) -> RegistrationSpec:
+        """Return registration metadata for this subsystem."""
+
+    @abstractmethod
+    def on_heartbeat(self) -> HeartbeatPayload:
+        """Return the current heartbeat payload."""
+
+    @abstractmethod
+    def submit(self, candidate: ExPayload) -> SubmitResult:
+        """Submit one Ex payload through the SDK surface."""

--- a/src/subsystem_announcement/runtime/ex0.py
+++ b/src/subsystem_announcement/runtime/ex0.py
@@ -1,0 +1,17 @@
+"""Ex-0 placeholder payload builder."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from .sdk_adapter import Ex0Payload
+
+
+def build_ex0_envelope(run_id: str, reason: str) -> Ex0Payload:
+    """Build the stage-0 Ex-0 placeholder payload."""
+
+    return Ex0Payload(
+        run_id=run_id,
+        reason=reason,
+        emitted_at=datetime.now(timezone.utc),
+    )

--- a/src/subsystem_announcement/runtime/heartbeat.py
+++ b/src/subsystem_announcement/runtime/heartbeat.py
@@ -7,14 +7,12 @@ from uuid import uuid4
 
 from .sdk_adapter import HeartbeatPayload
 
-DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 60
-
 
 def build_heartbeat(
     now: datetime,
     last_run_id: str | None,
     *,
-    interval_seconds: int = DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
+    interval_seconds: int,
     last_ex_id: str | None = None,
     status: str = "ok",
 ) -> HeartbeatPayload:

--- a/src/subsystem_announcement/runtime/heartbeat.py
+++ b/src/subsystem_announcement/runtime/heartbeat.py
@@ -1,0 +1,34 @@
+"""Heartbeat payload builders."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from .sdk_adapter import HeartbeatPayload
+
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 60
+
+
+def build_heartbeat(
+    now: datetime,
+    last_run_id: str | None,
+    *,
+    interval_seconds: int = DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
+    last_ex_id: str | None = None,
+    status: str = "ok",
+) -> HeartbeatPayload:
+    """Build one heartbeat payload.
+
+    ``last_run_id`` is retained for the interface named in the project plan.
+    The lifecycle passes the active run id so repeated heartbeats are stable.
+    """
+
+    timestamp = now if now.tzinfo is not None else now.replace(tzinfo=timezone.utc)
+    return HeartbeatPayload(
+        run_id=last_run_id or str(uuid4()),
+        timestamp=timestamp,
+        last_ex_id=last_ex_id,
+        status=status,
+        interval_seconds=interval_seconds,
+    )

--- a/src/subsystem_announcement/runtime/lifecycle.py
+++ b/src/subsystem_announcement/runtime/lifecycle.py
@@ -34,7 +34,9 @@ async def run(
     if not SDK_AVAILABLE:
         _log_info("subsystem_sdk_degraded", sdk_available=False)
 
-    await _submit_ex0_once(subsystem)
+    submit_ok = await _submit_ex0_once(subsystem, raise_on_error=once)
+    if not submit_ok:
+        _emit_heartbeat(subsystem)
     if once:
         return
 
@@ -51,7 +53,9 @@ async def run(
             except Exception as exc:
                 _log_error("heartbeat_failed", exc, run_id=subsystem.run_id)
                 continue
-            await _submit_ex0_once(subsystem)
+            submit_ok = await _submit_ex0_once(subsystem)
+            if not submit_ok:
+                _emit_heartbeat(subsystem)
 
 
 async def ping(config: AnnouncementConfig) -> None:
@@ -60,12 +64,29 @@ async def ping(config: AnnouncementConfig) -> None:
     await run(config, once=True)
 
 
-async def _submit_ex0_once(subsystem: AnnouncementSubsystem) -> None:
+async def _submit_ex0_once(
+    subsystem: AnnouncementSubsystem,
+    *,
+    raise_on_error: bool = False,
+) -> bool:
     payload = build_ex0_envelope(subsystem.run_id, reason="stage0-placeholder")
     try:
         subsystem.submit(payload)
     except Exception as exc:
+        subsystem.last_submit_failed = True
         _log_error("ex0_submit_failed", exc, run_id=subsystem.run_id)
+        if raise_on_error:
+            raise
+        return False
+    subsystem.last_submit_failed = False
+    return True
+
+
+def _emit_heartbeat(subsystem: AnnouncementSubsystem) -> None:
+    try:
+        subsystem.on_heartbeat()
+    except Exception as exc:
+        _log_error("heartbeat_failed", exc, run_id=subsystem.run_id)
 
 
 def _log_error(event: str, exc: Exception, **fields: Any) -> None:

--- a/src/subsystem_announcement/runtime/lifecycle.py
+++ b/src/subsystem_announcement/runtime/lifecycle.py
@@ -1,0 +1,83 @@
+"""Runtime lifecycle for the stage-0 announcement subsystem."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from subsystem_announcement.config import AnnouncementConfig
+
+from .ex0 import build_ex0_envelope
+from .sdk_adapter import AnnouncementSubsystem, SDK_AVAILABLE
+
+try:
+    import structlog
+except ModuleNotFoundError:
+    structlog = None
+
+_STD_LOGGER = logging.getLogger(__name__)
+_STRUCT_LOGGER = structlog.get_logger(__name__) if structlog is not None else None
+
+
+async def run(
+    config: AnnouncementConfig,
+    *,
+    stop_event: asyncio.Event | None = None,
+    once: bool = False,
+) -> None:
+    """Run registration, heartbeat, and Ex-0 submission until stopped."""
+
+    subsystem = AnnouncementSubsystem(config)
+    subsystem.on_register()
+    subsystem.on_heartbeat()
+    if not SDK_AVAILABLE:
+        _log_info("subsystem_sdk_degraded", sdk_available=False)
+
+    await _submit_ex0_once(subsystem)
+    if once:
+        return
+
+    active_stop_event = stop_event or asyncio.Event()
+    while not active_stop_event.is_set():
+        try:
+            await asyncio.wait_for(
+                active_stop_event.wait(),
+                timeout=config.heartbeat_interval_seconds,
+            )
+        except TimeoutError:
+            try:
+                subsystem.on_heartbeat()
+            except Exception as exc:
+                _log_error("heartbeat_failed", exc, run_id=subsystem.run_id)
+                continue
+            await _submit_ex0_once(subsystem)
+
+
+async def ping(config: AnnouncementConfig) -> None:
+    """Run a one-shot offline health check."""
+
+    await run(config, once=True)
+
+
+async def _submit_ex0_once(subsystem: AnnouncementSubsystem) -> None:
+    payload = build_ex0_envelope(subsystem.run_id, reason="stage0-placeholder")
+    try:
+        subsystem.submit(payload)
+    except Exception as exc:
+        _log_error("ex0_submit_failed", exc, run_id=subsystem.run_id)
+
+
+def _log_error(event: str, exc: Exception, **fields: Any) -> None:
+    payload = {"error": str(exc), **fields}
+    if _STRUCT_LOGGER is not None:
+        _STRUCT_LOGGER.error(event, **payload)
+        return
+    _STD_LOGGER.error("%s %s", event, payload)
+
+
+def _log_info(event: str, **fields: Any) -> None:
+    if _STRUCT_LOGGER is not None:
+        _STRUCT_LOGGER.info(event, **fields)
+        return
+    _STD_LOGGER.info("%s %s", event, fields)

--- a/src/subsystem_announcement/runtime/registration.py
+++ b/src/subsystem_announcement/runtime/registration.py
@@ -1,0 +1,22 @@
+"""Registration metadata builders for the announcement subsystem."""
+
+from __future__ import annotations
+
+from subsystem_announcement.config import AnnouncementConfig
+
+from .sdk_adapter import RegistrationSpec
+
+MODULE_ID = "subsystem-announcement"
+OWNED_EX_TYPES = ("Ex-0", "Ex-1", "Ex-2", "Ex-3")
+
+
+def build_registration_spec(config: AnnouncementConfig) -> RegistrationSpec:
+    """Build the SDK registration spec for the announcement subsystem."""
+
+    return RegistrationSpec(
+        module_id=MODULE_ID,
+        owned_ex_types=OWNED_EX_TYPES,
+        parser_version=config.docling_version,
+        registration_ttl_seconds=config.registration_ttl_seconds,
+        sdk_endpoint=config.sdk_endpoint,
+    )

--- a/src/subsystem_announcement/runtime/sdk_adapter.py
+++ b/src/subsystem_announcement/runtime/sdk_adapter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from typing import Any, TypeAlias
 from uuid import uuid4
@@ -17,7 +19,10 @@ try:
         SubmitResult,
         SubsystemBaseInterface,
     )
-except (ImportError, ModuleNotFoundError):
+except ModuleNotFoundError as exc:
+    if exc.name != "subsystem_sdk":
+        raise
+
     from ._sdk_stub import (
         Ex0Payload,
         ExPayload,
@@ -32,6 +37,7 @@ else:
     SDK_AVAILABLE = True
 
 PayloadLike: TypeAlias = ExPayload | dict[str, Any]
+SdkHook: TypeAlias = Callable[[Any], Any]
 
 
 class AnnouncementSubsystem(SubsystemBaseInterface):
@@ -41,6 +47,7 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
         self.config = config
         self.run_id = str(uuid4())
         self.last_ex_id: str | None = None
+        self.last_submit_failed = False
         self._submit_seq = 0
 
     def on_register(self) -> RegistrationSpec:
@@ -48,30 +55,63 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
 
         from .registration import build_registration_spec
 
-        return build_registration_spec(self.config)
+        spec = build_registration_spec(self.config)
+        if SDK_AVAILABLE:
+            _call_sdk_hook(
+                ("subsystem_sdk", "subsystem_sdk.base.registration"),
+                ("register_subsystem",),
+                spec,
+                "registration",
+            )
+        return spec
 
     def on_heartbeat(self) -> HeartbeatPayload:
         """Return this subsystem's current heartbeat payload."""
 
         from .heartbeat import build_heartbeat
 
-        return build_heartbeat(
+        payload = build_heartbeat(
             datetime.now(timezone.utc),
             self.run_id,
             interval_seconds=self.config.heartbeat_interval_seconds,
             last_ex_id=self.last_ex_id,
-            status="ok",
+            status="degraded" if self.last_submit_failed else "ok",
         )
+        if SDK_AVAILABLE:
+            _call_sdk_hook(
+                (
+                    "subsystem_sdk.heartbeat",
+                    "subsystem_sdk.heartbeat.client",
+                    "subsystem_sdk",
+                ),
+                ("send_heartbeat", "heartbeat"),
+                _payload_to_mapping(payload),
+                "heartbeat",
+            )
+        return payload
 
     def submit(self, candidate: ExPayload) -> SubmitResult:
-        """Submit a candidate through the SDK surface.
-
-        The offline shim returns a deterministic local receipt. When the real
-        SDK is present this override still keeps the subsystem API stable; SDK
-        transport integration remains owned by the imported base interface.
-        """
+        """Submit a candidate through the SDK surface."""
 
         ex_type = _payload_ex_type(candidate)
+        if SDK_AVAILABLE:
+            result = _coerce_submit_result(
+                _call_sdk_hook(
+                    (
+                        "subsystem_sdk.submit",
+                        "subsystem_sdk.submit.client",
+                        "subsystem_sdk",
+                    ),
+                    ("submit",),
+                    _payload_to_mapping(candidate),
+                    "submit",
+                ),
+                ex_type,
+            )
+            if getattr(result, "accepted", False):
+                self.last_ex_id = getattr(result, "receipt_id", None)
+            return result
+
         self._submit_seq += 1
         receipt_id = f"{self.run_id}:{self._submit_seq}"
         self.last_ex_id = receipt_id
@@ -85,7 +125,7 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
 
 
 def _payload_ex_type(candidate: PayloadLike) -> str:
-    if isinstance(candidate, dict):
+    if isinstance(candidate, Mapping):
         ex_type = candidate.get("ex_type")
     else:
         ex_type = getattr(candidate, "ex_type", None)
@@ -95,3 +135,72 @@ def _payload_ex_type(candidate: PayloadLike) -> str:
     if not isinstance(ex_type, str) or not ex_type:
         raise ValueError("Ex payload must include a non-empty ex_type")
     return ex_type
+
+
+def _payload_to_mapping(candidate: PayloadLike) -> dict[str, Any]:
+    if isinstance(candidate, Mapping):
+        return dict(candidate)
+    if hasattr(candidate, "model_dump"):
+        return candidate.model_dump()
+    payload = {
+        key: value
+        for key, value in vars(candidate).items()
+        if not key.startswith("_")
+    }
+    if not payload:
+        raise TypeError("Ex payload must be mapping-like or expose model_dump()")
+    return payload
+
+
+def _call_sdk_hook(
+    module_names: tuple[str, ...],
+    hook_names: tuple[str, ...],
+    payload: Any,
+    hook_kind: str,
+) -> Any:
+    hook = _load_sdk_hook(module_names, hook_names)
+    if hook is None:
+        raise RuntimeError(f"subsystem-sdk {hook_kind} transport is unavailable")
+    return hook(payload)
+
+
+def _load_sdk_hook(
+    module_names: tuple[str, ...],
+    hook_names: tuple[str, ...],
+) -> SdkHook | None:
+    for module_name in module_names:
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            if exc.name is not None and (
+                exc.name == module_name or module_name.startswith(f"{exc.name}.")
+            ):
+                continue
+            raise
+
+        for hook_name in hook_names:
+            hook = getattr(module, hook_name, None)
+            if callable(hook):
+                return hook
+    return None
+
+
+def _coerce_submit_result(raw_result: Any, ex_type: str) -> SubmitResult:
+    if isinstance(raw_result, SubmitResult):
+        return raw_result
+
+    if isinstance(raw_result, Mapping):
+        result_data = dict(raw_result)
+    elif hasattr(raw_result, "model_dump"):
+        result_data = raw_result.model_dump()
+    else:
+        result_data = {
+            field: getattr(raw_result, field)
+            for field in ("accepted", "receipt_id", "warnings", "errors")
+            if hasattr(raw_result, field)
+        }
+
+    result_data.setdefault("ex_type", ex_type)
+    result_data.setdefault("warnings", ())
+    result_data.setdefault("errors", ())
+    return SubmitResult(**result_data)

--- a/src/subsystem_announcement/runtime/sdk_adapter.py
+++ b/src/subsystem_announcement/runtime/sdk_adapter.py
@@ -1,0 +1,97 @@
+"""SDK adapter for registration, heartbeat, and Ex payload submission."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, TypeAlias
+from uuid import uuid4
+
+from subsystem_announcement.config import AnnouncementConfig
+
+try:
+    from subsystem_sdk import (  # type: ignore[import-not-found]
+        Ex0Payload,
+        ExPayload,
+        HeartbeatPayload,
+        RegistrationSpec,
+        SubmitResult,
+        SubsystemBaseInterface,
+    )
+except (ImportError, ModuleNotFoundError):
+    from ._sdk_stub import (
+        Ex0Payload,
+        ExPayload,
+        HeartbeatPayload,
+        RegistrationSpec,
+        SubmitResult,
+        SubsystemBaseInterface,
+    )
+
+    SDK_AVAILABLE = False
+else:
+    SDK_AVAILABLE = True
+
+PayloadLike: TypeAlias = ExPayload | dict[str, Any]
+
+
+class AnnouncementSubsystem(SubsystemBaseInterface):
+    """Announcement runtime implementation of the SDK subsystem interface."""
+
+    def __init__(self, config: AnnouncementConfig) -> None:
+        self.config = config
+        self.run_id = str(uuid4())
+        self.last_ex_id: str | None = None
+        self._submit_seq = 0
+
+    def on_register(self) -> RegistrationSpec:
+        """Return this subsystem's registration spec."""
+
+        from .registration import build_registration_spec
+
+        return build_registration_spec(self.config)
+
+    def on_heartbeat(self) -> HeartbeatPayload:
+        """Return this subsystem's current heartbeat payload."""
+
+        from .heartbeat import build_heartbeat
+
+        return build_heartbeat(
+            datetime.now(timezone.utc),
+            self.run_id,
+            interval_seconds=self.config.heartbeat_interval_seconds,
+            last_ex_id=self.last_ex_id,
+            status="ok",
+        )
+
+    def submit(self, candidate: ExPayload) -> SubmitResult:
+        """Submit a candidate through the SDK surface.
+
+        The offline shim returns a deterministic local receipt. When the real
+        SDK is present this override still keeps the subsystem API stable; SDK
+        transport integration remains owned by the imported base interface.
+        """
+
+        ex_type = _payload_ex_type(candidate)
+        self._submit_seq += 1
+        receipt_id = f"{self.run_id}:{self._submit_seq}"
+        self.last_ex_id = receipt_id
+        return SubmitResult(
+            accepted=True,
+            receipt_id=receipt_id,
+            ex_type=ex_type,
+            warnings=(),
+            errors=(),
+        )
+
+
+def _payload_ex_type(candidate: PayloadLike) -> str:
+    if isinstance(candidate, dict):
+        ex_type = candidate.get("ex_type")
+    else:
+        ex_type = getattr(candidate, "ex_type", None)
+        if ex_type is None and hasattr(candidate, "model_dump"):
+            ex_type = candidate.model_dump().get("ex_type")
+
+    if not isinstance(ex_type, str) or not ex_type:
+        raise ValueError("Ex payload must include a non-empty ex_type")
+    return ex_type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+
+@dataclass
+class FakeSDKRecorder:
+    registrations: list[Any] = field(default_factory=list)
+    heartbeats: list[Any] = field(default_factory=list)
+    submissions: list[dict[str, Any]] = field(default_factory=list)
+    submit_results: list[Any] = field(default_factory=list)
+    raise_on_submit: bool = False
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> FakeSDKRecorder:
+    from subsystem_announcement.runtime import lifecycle
+    from subsystem_announcement.runtime.sdk_adapter import AnnouncementSubsystem
+
+    recorder = FakeSDKRecorder()
+
+    class RecordingAnnouncementSubsystem(AnnouncementSubsystem):
+        def on_register(self):  # type: ignore[no-untyped-def]
+            spec = super().on_register()
+            recorder.registrations.append(spec)
+            return spec
+
+        def on_heartbeat(self):  # type: ignore[no-untyped-def]
+            payload = super().on_heartbeat()
+            recorder.heartbeats.append(payload)
+            return payload
+
+        def submit(self, candidate):  # type: ignore[no-untyped-def]
+            payload = (
+                candidate.model_dump()
+                if hasattr(candidate, "model_dump")
+                else dict(candidate)
+            )
+            _validate_ex0_payload(payload)
+            recorder.submissions.append(payload)
+            if recorder.raise_on_submit:
+                raise RuntimeError("fake submit failure")
+            result = super().submit(candidate)
+            recorder.submit_results.append(result)
+            return result
+
+    monkeypatch.setattr(lifecycle, "AnnouncementSubsystem", RecordingAnnouncementSubsystem)
+    return recorder
+
+
+def _validate_ex0_payload(payload: dict[str, Any]) -> None:
+    assert payload["ex_type"] == "Ex-0"
+    assert payload["run_id"]
+    assert payload["reason"]
+    assert payload["emitted_at"]
+    assert "submitted_at" not in payload
+    assert "ingest_seq" not in payload
+    assert "layer_b_receipt_id" not in payload

--- a/tests/test_runtime_sdk.py
+++ b/tests/test_runtime_sdk.py
@@ -7,10 +7,14 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from subsystem_announcement.config import AnnouncementConfig
+import pytest
+from pydantic import ValidationError
+
+from subsystem_announcement.config import AnnouncementConfig, load_config
 from subsystem_announcement.runtime.ex0 import build_ex0_envelope
 from subsystem_announcement.runtime.heartbeat import build_heartbeat
 from subsystem_announcement.runtime.lifecycle import run
+from subsystem_announcement.runtime import sdk_adapter
 from subsystem_announcement.runtime.registration import build_registration_spec
 from subsystem_announcement.runtime.sdk_adapter import (
     AnnouncementSubsystem,
@@ -125,7 +129,31 @@ def test_run_exits_cleanly_when_stop_event_is_set(fake_sdk) -> None:
 def test_submit_exception_is_logged_and_does_not_crash_run(fake_sdk) -> None:
     fake_sdk.raise_on_submit = True
 
-    asyncio.run(run(AnnouncementConfig(heartbeat_interval_seconds=1), once=True))
+    async def scenario() -> None:
+        stop_event = asyncio.Event()
+
+        async def stop_soon() -> None:
+            await asyncio.sleep(0.05)
+            stop_event.set()
+
+        await asyncio.gather(
+            run(AnnouncementConfig(heartbeat_interval_seconds=1), stop_event=stop_event),
+            stop_soon(),
+        )
+
+    asyncio.run(scenario())
+
+    assert len(fake_sdk.heartbeats) >= 2
+    assert fake_sdk.heartbeats[-1].status == "degraded"
+    assert len(fake_sdk.submissions) == 1
+    assert fake_sdk.submit_results == []
+
+
+def test_once_submit_exception_raises_for_health_check(fake_sdk) -> None:
+    fake_sdk.raise_on_submit = True
+
+    with pytest.raises(RuntimeError, match="fake submit failure"):
+        asyncio.run(run(AnnouncementConfig(heartbeat_interval_seconds=1), once=True))
 
     assert len(fake_sdk.submissions) == 1
     assert fake_sdk.submit_results == []
@@ -146,6 +174,74 @@ def test_concurrent_heartbeats_keep_same_run_id() -> None:
 
 def test_sdk_missing_uses_local_stub() -> None:
     assert SDK_AVAILABLE is False
+
+
+def test_broken_sdk_import_is_not_downgraded_to_stub(tmp_path: Path) -> None:
+    sdk_dir = tmp_path / "subsystem_sdk"
+    sdk_dir.mkdir()
+    (sdk_dir / "__init__.py").write_text(
+        "import definitely_missing_subsystem_dep\n",
+        encoding="utf-8",
+    )
+    env = _cli_env()
+    env["PYTHONPATH"] = os.pathsep.join([str(tmp_path), env["PYTHONPATH"]])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import subsystem_announcement.runtime.sdk_adapter",
+        ],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "definitely_missing_subsystem_dep" in result.stderr
+
+
+def test_real_sdk_mode_delegates_submit_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def fake_sdk_hook(module_names, hook_names, payload, hook_kind):  # type: ignore[no-untyped-def]
+        calls.append((module_names, hook_names, payload, hook_kind))
+        return {"accepted": True, "receipt_id": "sdk-receipt", "ex_type": "Ex-0"}
+
+    monkeypatch.setattr(sdk_adapter, "SDK_AVAILABLE", True)
+    monkeypatch.setattr(sdk_adapter, "_call_sdk_hook", fake_sdk_hook)
+    subsystem = AnnouncementSubsystem(AnnouncementConfig())
+
+    result = subsystem.submit(build_ex0_envelope(subsystem.run_id, "test"))
+
+    assert result.accepted is True
+    assert result.receipt_id == "sdk-receipt"
+    assert subsystem.last_ex_id == "sdk-receipt"
+    assert calls[0][3] == "submit"
+    assert calls[0][2]["ex_type"] == "Ex-0"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("heartbeat_interval_seconds", 0),
+        ("heartbeat_interval_seconds", -1),
+        ("registration_ttl_seconds", 0),
+        ("registration_ttl_seconds", -1),
+    ],
+)
+def test_load_config_rejects_non_positive_runtime_intervals(
+    tmp_path: Path,
+    field: str,
+    value: int,
+) -> None:
+    config_path = tmp_path / "announcement.toml"
+    config_path.write_text(f"{field} = {value}\n", encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        load_config(config_path)
 
 
 def test_cli_ping_returns_zero_in_offline_stub_mode() -> None:

--- a/tests/test_runtime_sdk.py
+++ b/tests/test_runtime_sdk.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.runtime.ex0 import build_ex0_envelope
+from subsystem_announcement.runtime.heartbeat import build_heartbeat
+from subsystem_announcement.runtime.lifecycle import run
+from subsystem_announcement.runtime.registration import build_registration_spec
+from subsystem_announcement.runtime.sdk_adapter import (
+    AnnouncementSubsystem,
+    SDK_AVAILABLE,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+
+def _cli_env() -> dict[str, str]:
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(SRC)
+        if not existing_pythonpath
+        else os.pathsep.join([str(SRC), existing_pythonpath])
+    )
+    return env
+
+
+def test_registration_spec_contains_module_ex_types_and_parser_version() -> None:
+    config = AnnouncementConfig(
+        docling_version="docling==1.2.3",
+        sdk_endpoint="http://sdk.local",
+        registration_ttl_seconds=321,
+    )
+
+    spec = build_registration_spec(config)
+
+    assert spec.module_id == "subsystem-announcement"
+    assert spec.owned_ex_types == ("Ex-0", "Ex-1", "Ex-2", "Ex-3")
+    assert spec.parser_version == "docling==1.2.3"
+    assert spec.registration_ttl_seconds == 321
+    assert spec.sdk_endpoint == "http://sdk.local"
+
+
+def test_heartbeat_payload_contains_required_fields_and_interval() -> None:
+    now = datetime(2026, 4, 18, 1, 2, 3, tzinfo=timezone.utc)
+
+    heartbeat = build_heartbeat(
+        now,
+        "run-1",
+        interval_seconds=7,
+        last_ex_id="ex-1",
+    )
+
+    assert heartbeat.run_id == "run-1"
+    assert heartbeat.timestamp == now
+    assert heartbeat.last_ex_id == "ex-1"
+    assert heartbeat.status == "ok"
+    assert heartbeat.interval_seconds == 7
+
+
+def test_ex0_payload_has_stage0_placeholder_fields() -> None:
+    payload = build_ex0_envelope("run-2", "stage0")
+
+    assert payload.ex_type == "Ex-0"
+    assert payload.run_id == "run-2"
+    assert payload.reason == "stage0"
+    assert payload.emitted_at.tzinfo is not None
+
+
+def test_announcement_subsystem_overrides_sdk_methods() -> None:
+    subsystem = AnnouncementSubsystem(AnnouncementConfig(heartbeat_interval_seconds=5))
+
+    registration = subsystem.on_register()
+    heartbeat = subsystem.on_heartbeat()
+    result = subsystem.submit(build_ex0_envelope(subsystem.run_id, "test"))
+
+    assert registration.module_id == "subsystem-announcement"
+    assert heartbeat.run_id == subsystem.run_id
+    assert heartbeat.interval_seconds == 5
+    assert result.accepted is True
+    assert result.ex_type == "Ex-0"
+    assert subsystem.last_ex_id == result.receipt_id
+
+
+def test_lifecycle_ping_path_registers_heartbeats_and_submits_ex0(fake_sdk) -> None:
+    asyncio.run(run(AnnouncementConfig(heartbeat_interval_seconds=1), once=True))
+
+    assert len(fake_sdk.registrations) == 1
+    assert len(fake_sdk.heartbeats) == 1
+    assert len(fake_sdk.submissions) == 1
+    assert fake_sdk.submissions[0]["ex_type"] == "Ex-0"
+
+
+def test_run_exits_cleanly_when_stop_event_is_set(fake_sdk) -> None:
+    async def scenario() -> None:
+        stop_event = asyncio.Event()
+
+        async def stop_soon() -> None:
+            await asyncio.sleep(0.05)
+            stop_event.set()
+
+        await asyncio.gather(
+            asyncio.wait_for(
+                run(
+                    AnnouncementConfig(heartbeat_interval_seconds=60),
+                    stop_event=stop_event,
+                ),
+                timeout=2,
+            ),
+            stop_soon(),
+        )
+
+    asyncio.run(scenario())
+
+    assert fake_sdk.submissions
+
+
+def test_submit_exception_is_logged_and_does_not_crash_run(fake_sdk) -> None:
+    fake_sdk.raise_on_submit = True
+
+    asyncio.run(run(AnnouncementConfig(heartbeat_interval_seconds=1), once=True))
+
+    assert len(fake_sdk.submissions) == 1
+    assert fake_sdk.submit_results == []
+
+
+def test_concurrent_heartbeats_keep_same_run_id() -> None:
+    subsystem = AnnouncementSubsystem(AnnouncementConfig())
+
+    async def gather_heartbeats():
+        return await asyncio.gather(
+            *(asyncio.to_thread(subsystem.on_heartbeat) for _ in range(8))
+        )
+
+    heartbeats = asyncio.run(gather_heartbeats())
+
+    assert {heartbeat.run_id for heartbeat in heartbeats} == {subsystem.run_id}
+
+
+def test_sdk_missing_uses_local_stub() -> None:
+    assert SDK_AVAILABLE is False
+
+
+def test_cli_ping_returns_zero_in_offline_stub_mode() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "subsystem_announcement", "ping"],
+        cwd=ROOT,
+        env=_cli_env(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "ok"
+    assert "subsystem-sdk unavailable; using local SDK stub" in result.stderr
+
+
+def test_cli_run_once_returns_zero() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "subsystem_announcement", "run", "--once"],
+        cwd=ROOT,
+        env=_cli_env(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "ok"


### PR DESCRIPTION
Closes #3

Implemented by Codex.

---
## 背景与目标
本 issue 对应项目文档 §21 阶段 0 退出条件"公告子系统可作为参考子系统启动并发送 Ex-0"。依据 §5.2 与 §16.2，子系统必须通过 `subsystem-sdk` 提供的 `SubsystemBaseInterface` 完成注册、心跳、submit 三个动作，不允许直连 Layer B 队列或自建 adapter。本 issue 在 #2 的骨架上接入 SDK，实现最小可运行的参考子系统：启动 -> 注册 -> 周期心跳 -> 发送一条 Ex-0 占位 payload。它不做任何公告解析；目的是让后续阶段 1 的真实候选对象有一条可复用的提交通道。

## 所属模块
- primary writable paths：
  - `src/subsystem_announcement/runtime/__init__.py`
  - `src/subsystem_announcement/runtime/sdk_adapter.py`
  - `src/subsystem_announcement/runtime/lifecycle.py`
  - `src/subsystem_announcement/runtime/registration.py`
  - `src/subsystem_announcement/runtime/heartbeat.py`
  - `src/subsystem_announcement/runtime/ex0.py`
  - `src/subsystem_announcement/__main__.py`（新增 `run` / `ping` 子命令）
  - `src/subsystem_announcement/config.py`（新增 SDK 相关字段）
  - `tests/test_runtime_sdk.py`
  - `tests/conftest.py`（引入 SDK fake / fixture）
- adjacent read-only 路径：`subsystem-sdk` 源码（若本地可见，只读参考其接口）
- off-limits：
  - 不得直接写 `data-platform` / Layer B 的任何存储或 adapter
  - 不得实现 Ex-1/Ex-2/Ex-3，仅允许 Ex-0
  - 不得在此 issue 启动 Docling / LlamaIndex

## 实现范围
- SDK 适配层：
  - `runtime/sdk_adapter.py`：`class AnnouncementSubsystem(SubsystemBaseInterface)`，构造参数 `config: AnnouncementConfig`；实现 `on_register() -> RegistrationSpec`、`on_heartbeat() -> HeartbeatPayload`、`submit(candidate: ExPayload) -> SubmitResult`
  - 若 `subsystem-sdk` 不可 import，引入 `runtime/sdk_adapter.py` 顶部的 `SDK_AVAILABLE: bool` 守卫，并在缺失时使用 `runtime/_sdk_stub.py` 提供协议兼容 shim（只包含类型占位，不做 IO）
- 生命周期层：
  - `runtime/lifecycle.py`：`async def run(config: AnnouncementConfig, *, stop_event: asyncio.Event | None = None) -> None`，负责启动注册、心跳、Ex-0 首发
  - `runtime/registration.py`：`build_registration_spec(config: AnnouncementConfig) -> RegistrationSpec`，注入 `module_id="subsystem-announcement"`、`owned_ex_types=["Ex-0","Ex-1","Ex-2","Ex-3"]`、`parser_version=config.docling_version`
  - `runtime/heartbeat.py`：`build_heartbeat(now: datetime, last_run_id: str | None) -> HeartbeatPayload`，周期间隔从 `config.heartbeat_interval_seconds` 读取
  - `ru