### PR TITLE
feat(#14): [milestone-0 review] P0: subsystem-sdk integration is optional and stubbed by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "typer>=0.12",
     "structlog>=24.1",
     "httpx>=0.27",
+    "subsystem-sdk==0.1.0",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
 ]

--- a/src/subsystem_announcement/__main__.py
+++ b/src/subsystem_announcement/__main__.py
@@ -58,10 +58,6 @@ if typer is not None:
             configure_logging()
             runtime_config = load_config(config)
             from .runtime.lifecycle import ping
-            from .runtime.sdk_adapter import SDK_AVAILABLE
-
-            if not SDK_AVAILABLE:
-                typer.echo("subsystem-sdk unavailable; using local SDK stub", err=True)
             asyncio.run(ping(runtime_config))
         except Exception as exc:
             typer.echo(f"ping failed: {exc}", err=True)
@@ -88,10 +84,6 @@ if typer is not None:
             configure_logging()
             runtime_config = load_config(config)
             from .runtime.lifecycle import run
-            from .runtime.sdk_adapter import SDK_AVAILABLE
-
-            if not SDK_AVAILABLE:
-                typer.echo("subsystem-sdk unavailable; using local SDK stub", err=True)
             asyncio.run(run(runtime_config, once=once))
         except KeyboardInterrupt:
             raise typer.Exit(code=130) from None
@@ -134,13 +126,6 @@ def _fallback_main(argv: list[str]) -> int:
             configure_logging()
             runtime_config = load_config(config_path)
             from .runtime.lifecycle import ping, run
-            from .runtime.sdk_adapter import SDK_AVAILABLE
-
-            if not SDK_AVAILABLE:
-                print(
-                    "subsystem-sdk unavailable; using local SDK stub",
-                    file=sys.stderr,
-                )
             if command == "ping":
                 asyncio.run(ping(runtime_config))
             else:

--- a/src/subsystem_announcement/runtime/lifecycle.py
+++ b/src/subsystem_announcement/runtime/lifecycle.py
@@ -32,7 +32,7 @@ async def run(
     subsystem.on_register()
     subsystem.on_heartbeat()
     if not SDK_AVAILABLE:
-        _log_info("subsystem_sdk_degraded", sdk_available=False)
+        _log_info("subsystem_sdk_test_stub", sdk_available=False)
 
     submit_ok = await _submit_ex0_once(subsystem, raise_on_error=once)
     if not submit_ok:
@@ -71,12 +71,19 @@ async def _submit_ex0_once(
 ) -> bool:
     payload = build_ex0_envelope(subsystem.run_id, reason="stage0-placeholder")
     try:
-        subsystem.submit(payload)
+        result = subsystem.submit(payload)
     except Exception as exc:
         subsystem.last_submit_failed = True
         _log_error("ex0_submit_failed", exc, run_id=subsystem.run_id)
         if raise_on_error:
             raise
+        return False
+    if not getattr(result, "accepted", False):
+        subsystem.last_submit_failed = True
+        exc = RuntimeError("subsystem-sdk submit rejected Ex-0 payload")
+        _log_error("ex0_submit_rejected", exc, run_id=subsystem.run_id)
+        if raise_on_error:
+            raise exc
         return False
     subsystem.last_submit_failed = False
     return True

--- a/src/subsystem_announcement/runtime/sdk_adapter.py
+++ b/src/subsystem_announcement/runtime/sdk_adapter.py
@@ -3,47 +3,121 @@
 from __future__ import annotations
 
 import importlib
-from collections.abc import Callable, Mapping
+import importlib.util
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, TypeAlias
+from typing import Any, Final, TypeAlias
 from uuid import uuid4
 
+from subsystem_announcement import PACKAGE_NAME, __version__
 from subsystem_announcement.config import AnnouncementConfig
 
-try:
-    from subsystem_sdk import (  # type: ignore[import-not-found]
-        Ex0Payload,
-        ExPayload,
-        HeartbeatPayload,
-        RegistrationSpec,
-        SubmitResult,
-        SubsystemBaseInterface,
-    )
-except ModuleNotFoundError as exc:
-    if exc.name != "subsystem_sdk":
-        raise
+from ._sdk_stub import (
+    Ex0Payload,
+    ExPayload,
+    HeartbeatPayload,
+    RegistrationSpec,
+    SubmitResult as StubSubmitResult,
+    SubsystemBaseInterface as StubSubsystemBaseInterface,
+)
 
-    from ._sdk_stub import (
-        Ex0Payload,
-        ExPayload,
-        HeartbeatPayload,
-        RegistrationSpec,
-        SubmitResult,
-        SubsystemBaseInterface,
-    )
-
-    SDK_AVAILABLE = False
-else:
-    SDK_AVAILABLE = True
+TEST_STUB_ENV: Final[str] = "SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB"
+_SDK_PACKAGE: Final[str] = "subsystem_sdk"
 
 PayloadLike: TypeAlias = ExPayload | dict[str, Any]
-SdkHook: TypeAlias = Callable[[Any], Any]
+
+
+class SubsystemSdkUnavailableError(RuntimeError):
+    """Raised when runtime code starts without the required subsystem-sdk."""
+
+
+class UnsupportedSubsystemSdkError(RuntimeError):
+    """Raised when subsystem-sdk is installed but lacks the pinned API."""
+
+
+@dataclass(frozen=True)
+class _SdkApi:
+    subsystem_base_interface: type[Any]
+    registration_spec: type[Any]
+    submit_receipt: type[Any]
+    register_subsystem: Any
+    send_heartbeat: Any
+    submit: Any
+    assert_producer_only: Any
+
+
+def _load_official_sdk_api() -> _SdkApi | None:
+    if importlib.util.find_spec(_SDK_PACKAGE) is None:
+        return None
+
+    try:
+        base_module = importlib.import_module("subsystem_sdk.base")
+        submit_module = importlib.import_module("subsystem_sdk.submit")
+        heartbeat_module = importlib.import_module("subsystem_sdk.heartbeat")
+        validate_module = importlib.import_module("subsystem_sdk.validate")
+        return _SdkApi(
+            subsystem_base_interface=_required_symbol(
+                base_module,
+                "SubsystemBaseInterface",
+            ),
+            registration_spec=_required_symbol(
+                base_module,
+                "SubsystemRegistrationSpec",
+            ),
+            submit_receipt=_required_symbol(submit_module, "SubmitReceipt"),
+            register_subsystem=_required_symbol(base_module, "register_subsystem"),
+            send_heartbeat=_required_symbol(heartbeat_module, "send_heartbeat"),
+            submit=_required_symbol(submit_module, "submit"),
+            assert_producer_only=_required_symbol(
+                validate_module,
+                "assert_producer_only",
+            ),
+        )
+    except Exception as exc:
+        raise UnsupportedSubsystemSdkError(
+            "Unsupported subsystem-sdk version: expected pinned public API "
+            "subsystem_sdk.base.{SubsystemBaseInterface,"
+            "SubsystemRegistrationSpec,register_subsystem}, "
+            "subsystem_sdk.submit.{SubmitReceipt,submit}, "
+            "subsystem_sdk.heartbeat.send_heartbeat, and "
+            "subsystem_sdk.validate.assert_producer_only."
+        ) from exc
+
+
+def _required_symbol(module: Any, name: str) -> Any:
+    symbol = getattr(module, name, None)
+    if symbol is None:
+        raise AttributeError(f"{module.__name__}.{name} is required")
+    return symbol
+
+
+_SDK_API = _load_official_sdk_api()
+SDK_AVAILABLE = _SDK_API is not None
+SubsystemBaseInterface = (
+    _SDK_API.subsystem_base_interface
+    if _SDK_API is not None
+    else StubSubsystemBaseInterface
+)
+SubmitResult = _SDK_API.submit_receipt if _SDK_API is not None else StubSubmitResult
 
 
 class AnnouncementSubsystem(SubsystemBaseInterface):
     """Announcement runtime implementation of the SDK subsystem interface."""
 
-    def __init__(self, config: AnnouncementConfig) -> None:
+    def __init__(
+        self,
+        config: AnnouncementConfig,
+        *,
+        allow_sdk_stub: bool = False,
+    ) -> None:
+        if not SDK_AVAILABLE and not _stub_explicitly_allowed(allow_sdk_stub):
+            raise SubsystemSdkUnavailableError(
+                "subsystem-sdk is required for announcement runtime startup. "
+                f"Install the pinned dependency or set {TEST_STUB_ENV}=1 only "
+                "inside tests that intentionally use the local SDK stub."
+            )
         self.config = config
         self.run_id = str(uuid4())
         self.last_ex_id: str | None = None
@@ -57,11 +131,8 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
 
         spec = build_registration_spec(self.config)
         if SDK_AVAILABLE:
-            _call_sdk_hook(
-                ("subsystem_sdk", "subsystem_sdk.base.registration"),
-                ("register_subsystem",),
-                spec,
-                "registration",
+            _require_sdk_api().register_subsystem(
+                _to_sdk_registration_spec(spec, self.config),
             )
         return spec
 
@@ -78,14 +149,10 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
             status="degraded" if self.last_submit_failed else "ok",
         )
         if SDK_AVAILABLE:
-            _call_sdk_hook(
-                (
-                    "subsystem_sdk.heartbeat",
-                    "subsystem_sdk.heartbeat.client",
-                    "subsystem_sdk",
-                ),
-                ("send_heartbeat", "heartbeat"),
-                _payload_to_mapping(payload),
+            sdk_payload = _to_sdk_heartbeat_payload(payload)
+            _validate_sdk_payload("Ex-0", sdk_payload)
+            _ensure_accepted(
+                _require_sdk_api().send_heartbeat(sdk_payload),
                 "heartbeat",
             )
         return payload
@@ -95,17 +162,10 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
 
         ex_type = _payload_ex_type(candidate)
         if SDK_AVAILABLE:
+            sdk_payload = _to_sdk_submit_payload(candidate)
+            _validate_sdk_payload(ex_type, sdk_payload)
             result = _coerce_submit_result(
-                _call_sdk_hook(
-                    (
-                        "subsystem_sdk.submit",
-                        "subsystem_sdk.submit.client",
-                        "subsystem_sdk",
-                    ),
-                    ("submit",),
-                    _payload_to_mapping(candidate),
-                    "submit",
-                ),
+                _require_sdk_api().submit(sdk_payload),
                 ex_type,
             )
             if getattr(result, "accepted", False):
@@ -122,6 +182,16 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
             warnings=(),
             errors=(),
         )
+
+
+def _stub_explicitly_allowed(allow_sdk_stub: bool) -> bool:
+    return allow_sdk_stub or os.environ.get(TEST_STUB_ENV) == "1"
+
+
+def _require_sdk_api() -> _SdkApi:
+    if _SDK_API is None:
+        raise SubsystemSdkUnavailableError("subsystem-sdk API is unavailable")
+    return _SDK_API
 
 
 def _payload_ex_type(candidate: PayloadLike) -> str:
@@ -152,41 +222,78 @@ def _payload_to_mapping(candidate: PayloadLike) -> dict[str, Any]:
     return payload
 
 
-def _call_sdk_hook(
-    module_names: tuple[str, ...],
-    hook_names: tuple[str, ...],
-    payload: Any,
-    hook_kind: str,
+def _to_sdk_registration_spec(
+    spec: RegistrationSpec,
+    config: AnnouncementConfig,
 ) -> Any:
-    hook = _load_sdk_hook(module_names, hook_names)
-    if hook is None:
-        raise RuntimeError(f"subsystem-sdk {hook_kind} transport is unavailable")
-    return hook(payload)
+    sdk_api = _require_sdk_api()
+    return sdk_api.registration_spec(
+        subsystem_id=spec.module_id,
+        version=__version__,
+        domain="announcement",
+        supported_ex_types=spec.owned_ex_types,
+        owner=PACKAGE_NAME,
+        heartbeat_policy_ref=f"interval:{config.heartbeat_interval_seconds}s",
+        capabilities={
+            "parser_version": spec.parser_version,
+            "registration_ttl_seconds": spec.registration_ttl_seconds,
+            "sdk_endpoint": spec.sdk_endpoint,
+        },
+    )
 
 
-def _load_sdk_hook(
-    module_names: tuple[str, ...],
-    hook_names: tuple[str, ...],
-) -> SdkHook | None:
-    for module_name in module_names:
-        try:
-            module = importlib.import_module(module_name)
-        except ModuleNotFoundError as exc:
-            if exc.name is not None and (
-                exc.name == module_name or module_name.startswith(f"{exc.name}.")
-            ):
-                continue
-            raise
+def _to_sdk_heartbeat_payload(payload: HeartbeatPayload) -> dict[str, Any]:
+    return {
+        "subsystem_id": PACKAGE_NAME,
+        "version": __version__,
+        "heartbeat_at": payload.timestamp,
+        "status": payload.status,
+        "last_output_at": None,
+        "pending_count": 0,
+    }
 
-        for hook_name in hook_names:
-            hook = getattr(module, hook_name, None)
-            if callable(hook):
-                return hook
-    return None
+
+def _to_sdk_submit_payload(candidate: PayloadLike) -> dict[str, Any]:
+    payload = _payload_to_mapping(candidate)
+    if payload.get("ex_type") != "Ex-0":
+        return payload
+
+    heartbeat_at = payload.get("emitted_at")
+    if not isinstance(heartbeat_at, datetime):
+        heartbeat_at = datetime.now(timezone.utc)
+    return {
+        "ex_type": "Ex-0",
+        "subsystem_id": PACKAGE_NAME,
+        "version": __version__,
+        "heartbeat_at": heartbeat_at,
+        "status": "ok",
+        "last_output_at": heartbeat_at,
+        "pending_count": 0,
+    }
+
+
+def _validate_sdk_payload(ex_type: str, payload: Mapping[str, Any]) -> None:
+    _require_sdk_api().assert_producer_only(ex_type, payload)
+
+
+def _ensure_accepted(raw_result: Any, operation: str) -> None:
+    if raw_result is None:
+        return
+    accepted = (
+        raw_result.get("accepted")
+        if isinstance(raw_result, Mapping)
+        else getattr(raw_result, "accepted", None)
+    )
+    if accepted is None:
+        return
+    if bool(accepted):
+        return
+    raise RuntimeError(_rejection_message(raw_result, operation))
 
 
 def _coerce_submit_result(raw_result: Any, ex_type: str) -> SubmitResult:
-    if isinstance(raw_result, SubmitResult):
+    result_model = _submit_result_model()
+    if isinstance(raw_result, result_model):
         return raw_result
 
     if isinstance(raw_result, Mapping):
@@ -196,11 +303,56 @@ def _coerce_submit_result(raw_result: Any, ex_type: str) -> SubmitResult:
     else:
         result_data = {
             field: getattr(raw_result, field)
-            for field in ("accepted", "receipt_id", "warnings", "errors")
+            for field in (
+                "accepted",
+                "receipt_id",
+                "backend_kind",
+                "transport_ref",
+                "validator_version",
+                "warnings",
+                "errors",
+            )
             if hasattr(raw_result, field)
         }
 
-    result_data.setdefault("ex_type", ex_type)
     result_data.setdefault("warnings", ())
     result_data.setdefault("errors", ())
-    return SubmitResult(**result_data)
+    if not SDK_AVAILABLE:
+        result_data.setdefault("ex_type", ex_type)
+    return result_model(**result_data)
+
+
+def _submit_result_model() -> type[Any]:
+    if SDK_AVAILABLE and _SDK_API is not None:
+        return _SDK_API.submit_receipt
+    return StubSubmitResult
+
+
+def _rejection_message(result: Any, operation: str) -> str:
+    if isinstance(result, Mapping):
+        errors = _string_sequence(result.get("errors", ()))
+        warnings = _string_sequence(result.get("warnings", ()))
+    else:
+        errors = _string_sequence(getattr(result, "errors", ()))
+        warnings = _string_sequence(getattr(result, "warnings", ()))
+    detail = ", ".join(
+        part
+        for part in (
+            f"errors={errors}" if errors else "",
+            f"warnings={warnings}" if warnings else "",
+        )
+        if part
+    )
+    return f"subsystem-sdk {operation} rejected payload" + (
+        f": {detail}" if detail else ""
+    )
+
+
+def _string_sequence(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence):
+        return tuple(str(item) for item in value)
+    return (str(value),)

--- a/src/subsystem_announcement/runtime/sdk_adapter.py
+++ b/src/subsystem_announcement/runtime/sdk_adapter.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
-import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -23,7 +22,6 @@ from ._sdk_stub import (
     SubsystemBaseInterface as StubSubsystemBaseInterface,
 )
 
-TEST_STUB_ENV: Final[str] = "SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB"
 _SDK_PACKAGE: Final[str] = "subsystem_sdk"
 
 PayloadLike: TypeAlias = ExPayload | dict[str, Any]
@@ -115,8 +113,8 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
         if not SDK_AVAILABLE and not _stub_explicitly_allowed(allow_sdk_stub):
             raise SubsystemSdkUnavailableError(
                 "subsystem-sdk is required for announcement runtime startup. "
-                f"Install the pinned dependency or set {TEST_STUB_ENV}=1 only "
-                "inside tests that intentionally use the local SDK stub."
+                "Install the pinned dependency or inject the local SDK stub "
+                "from test-only code."
             )
         self.config = config
         self.run_id = str(uuid4())
@@ -185,7 +183,7 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
 
 
 def _stub_explicitly_allowed(allow_sdk_stub: bool) -> bool:
-    return allow_sdk_stub or os.environ.get(TEST_STUB_ENV) == "1"
+    return allow_sdk_stub
 
 
 def _require_sdk_api() -> _SdkApi:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ class FakeSDKRecorder:
     submissions: list[dict[str, Any]] = field(default_factory=list)
     submit_results: list[Any] = field(default_factory=list)
     raise_on_submit: bool = False
+    reject_submit: bool = False
 
 
 @pytest.fixture
@@ -20,6 +21,7 @@ def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> FakeSDKRecorder:
     from subsystem_announcement.runtime import lifecycle
     from subsystem_announcement.runtime.sdk_adapter import AnnouncementSubsystem
 
+    monkeypatch.setenv("SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB", "1")
     recorder = FakeSDKRecorder()
 
     class RecordingAnnouncementSubsystem(AnnouncementSubsystem):
@@ -43,6 +45,18 @@ def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> FakeSDKRecorder:
             recorder.submissions.append(payload)
             if recorder.raise_on_submit:
                 raise RuntimeError("fake submit failure")
+            if recorder.reject_submit:
+                from subsystem_announcement.runtime.sdk_adapter import SubmitResult
+
+                result = SubmitResult(
+                    accepted=False,
+                    receipt_id="fake-rejected",
+                    ex_type=payload["ex_type"],
+                    warnings=(),
+                    errors=("fake rejected",),
+                )
+                recorder.submit_results.append(result)
+                return result
             result = super().submit(candidate)
             recorder.submit_results.append(result)
             return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,10 +21,12 @@ def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> FakeSDKRecorder:
     from subsystem_announcement.runtime import lifecycle
     from subsystem_announcement.runtime.sdk_adapter import AnnouncementSubsystem
 
-    monkeypatch.setenv("SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB", "1")
     recorder = FakeSDKRecorder()
 
     class RecordingAnnouncementSubsystem(AnnouncementSubsystem):
+        def __init__(self, config):  # type: ignore[no-untyped-def]
+            super().__init__(config, allow_sdk_stub=True)
+
         def on_register(self):  # type: ignore[no-untyped-def]
             spec = super().on_register()
             recorder.registrations.append(spec)

--- a/tests/test_runtime_sdk.py
+++ b/tests/test_runtime_sdk.py
@@ -192,6 +192,16 @@ def test_sdk_missing_fails_without_explicit_test_stub() -> None:
         AnnouncementSubsystem(AnnouncementConfig())
 
 
+def test_sdk_missing_fails_even_with_legacy_test_stub_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert SDK_AVAILABLE is False
+    monkeypatch.setenv("SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB", "1")
+
+    with pytest.raises(SubsystemSdkUnavailableError, match="subsystem-sdk is required"):
+        AnnouncementSubsystem(AnnouncementConfig())
+
+
 def test_broken_sdk_import_is_not_downgraded_to_stub(tmp_path: Path) -> None:
     sdk_dir = tmp_path / "subsystem_sdk"
     sdk_dir.mkdir()
@@ -357,6 +367,24 @@ def test_cli_ping_fails_when_sdk_is_unavailable() -> None:
         [sys.executable, "-m", "subsystem_announcement", "ping"],
         cwd=ROOT,
         env=_cli_env(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout.strip() == ""
+    assert "subsystem-sdk is required" in result.stderr
+
+
+def test_cli_ping_fails_when_legacy_test_stub_env_is_set() -> None:
+    env = _cli_env()
+    env["SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB"] = "1"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "subsystem_announcement", "ping"],
+        cwd=ROOT,
+        env=env,
         check=False,
         capture_output=True,
         text=True,

--- a/tests/test_runtime_sdk.py
+++ b/tests/test_runtime_sdk.py
@@ -19,6 +19,7 @@ from subsystem_announcement.runtime.registration import build_registration_spec
 from subsystem_announcement.runtime.sdk_adapter import (
     AnnouncementSubsystem,
     SDK_AVAILABLE,
+    SubsystemSdkUnavailableError,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -79,7 +80,10 @@ def test_ex0_payload_has_stage0_placeholder_fields() -> None:
 
 
 def test_announcement_subsystem_overrides_sdk_methods() -> None:
-    subsystem = AnnouncementSubsystem(AnnouncementConfig(heartbeat_interval_seconds=5))
+    subsystem = AnnouncementSubsystem(
+        AnnouncementConfig(heartbeat_interval_seconds=5),
+        allow_sdk_stub=True,
+    )
 
     registration = subsystem.on_register()
     heartbeat = subsystem.on_heartbeat()
@@ -159,8 +163,18 @@ def test_once_submit_exception_raises_for_health_check(fake_sdk) -> None:
     assert fake_sdk.submit_results == []
 
 
+def test_once_rejected_submit_raises_for_health_check(fake_sdk) -> None:
+    fake_sdk.reject_submit = True
+
+    with pytest.raises(RuntimeError, match="submit rejected Ex-0 payload"):
+        asyncio.run(run(AnnouncementConfig(heartbeat_interval_seconds=1), once=True))
+
+    assert len(fake_sdk.submissions) == 1
+    assert fake_sdk.submit_results[0].accepted is False
+
+
 def test_concurrent_heartbeats_keep_same_run_id() -> None:
-    subsystem = AnnouncementSubsystem(AnnouncementConfig())
+    subsystem = AnnouncementSubsystem(AnnouncementConfig(), allow_sdk_stub=True)
 
     async def gather_heartbeats():
         return await asyncio.gather(
@@ -172,8 +186,10 @@ def test_concurrent_heartbeats_keep_same_run_id() -> None:
     assert {heartbeat.run_id for heartbeat in heartbeats} == {subsystem.run_id}
 
 
-def test_sdk_missing_uses_local_stub() -> None:
+def test_sdk_missing_fails_without_explicit_test_stub() -> None:
     assert SDK_AVAILABLE is False
+    with pytest.raises(SubsystemSdkUnavailableError, match="subsystem-sdk is required"):
+        AnnouncementSubsystem(AnnouncementConfig())
 
 
 def test_broken_sdk_import_is_not_downgraded_to_stub(tmp_path: Path) -> None:
@@ -203,24 +219,116 @@ def test_broken_sdk_import_is_not_downgraded_to_stub(tmp_path: Path) -> None:
     assert "definitely_missing_subsystem_dep" in result.stderr
 
 
-def test_real_sdk_mode_delegates_submit_transport(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = []
+def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, object]] = []
 
-    def fake_sdk_hook(module_names, hook_names, payload, hook_kind):  # type: ignore[no-untyped-def]
-        calls.append((module_names, hook_names, payload, hook_kind))
-        return {"accepted": True, "receipt_id": "sdk-receipt", "ex_type": "Ex-0"}
+    class FakeBase:
+        pass
 
+    class FakeRegistrationSpec:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.kwargs = kwargs
+
+    class FakeSubmitReceipt:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.accepted = kwargs["accepted"]
+            self.receipt_id = kwargs["receipt_id"]
+            self.backend_kind = kwargs["backend_kind"]
+            self.transport_ref = kwargs["transport_ref"]
+            self.validator_version = kwargs["validator_version"]
+            self.warnings = tuple(kwargs.get("warnings", ()))
+            self.errors = tuple(kwargs.get("errors", ()))
+
+    def register_subsystem(spec):  # type: ignore[no-untyped-def]
+        calls.append(("register", spec.kwargs))
+
+    def send_heartbeat(payload):  # type: ignore[no-untyped-def]
+        calls.append(("heartbeat", payload))
+        return FakeSubmitReceipt(
+            accepted=True,
+            receipt_id="heartbeat-receipt",
+            backend_kind="mock",
+            transport_ref=None,
+            validator_version="validator-v1",
+        )
+
+    def submit(payload):  # type: ignore[no-untyped-def]
+        calls.append(("submit", payload))
+        return FakeSubmitReceipt(
+            accepted=True,
+            receipt_id="sdk-receipt",
+            backend_kind="mock",
+            transport_ref=None,
+            validator_version="validator-v1",
+        )
+
+    def assert_producer_only(ex_type, payload):  # type: ignore[no-untyped-def]
+        calls.append(("validate", (ex_type, payload)))
+        assert "submitted_at" not in payload
+        assert "ingest_seq" not in payload
+        assert "layer_b_receipt_id" not in payload
+
+    fake_api = sdk_adapter._SdkApi(
+        subsystem_base_interface=FakeBase,
+        registration_spec=FakeRegistrationSpec,
+        submit_receipt=FakeSubmitReceipt,
+        register_subsystem=register_subsystem,
+        send_heartbeat=send_heartbeat,
+        submit=submit,
+        assert_producer_only=assert_producer_only,
+    )
     monkeypatch.setattr(sdk_adapter, "SDK_AVAILABLE", True)
-    monkeypatch.setattr(sdk_adapter, "_call_sdk_hook", fake_sdk_hook)
+    monkeypatch.setattr(sdk_adapter, "_SDK_API", fake_api)
     subsystem = AnnouncementSubsystem(AnnouncementConfig())
 
+    registration = subsystem.on_register()
+    heartbeat = subsystem.on_heartbeat()
     result = subsystem.submit(build_ex0_envelope(subsystem.run_id, "test"))
 
     assert result.accepted is True
     assert result.receipt_id == "sdk-receipt"
     assert subsystem.last_ex_id == "sdk-receipt"
-    assert calls[0][3] == "submit"
-    assert calls[0][2]["ex_type"] == "Ex-0"
+    assert registration.module_id == "subsystem-announcement"
+    assert heartbeat.run_id == subsystem.run_id
+    assert calls[0] == (
+        "register",
+        {
+            "subsystem_id": "subsystem-announcement",
+            "version": "0.1.0",
+            "domain": "announcement",
+            "supported_ex_types": ("Ex-0", "Ex-1", "Ex-2", "Ex-3"),
+            "owner": "subsystem-announcement",
+            "heartbeat_policy_ref": "interval:60s",
+            "capabilities": {
+                "parser_version": "not-configured",
+                "registration_ttl_seconds": 900,
+                "sdk_endpoint": None,
+            },
+        },
+    )
+    assert (
+        "heartbeat",
+        {
+            "subsystem_id": "subsystem-announcement",
+            "version": "0.1.0",
+            "heartbeat_at": heartbeat.timestamp,
+            "status": "ok",
+            "last_output_at": None,
+            "pending_count": 0,
+        },
+    ) in calls
+    submit_calls = [call for call in calls if call[0] == "submit"]
+    assert len(submit_calls) == 1
+    submit_payload = submit_calls[0][1]
+    assert submit_payload["ex_type"] == "Ex-0"
+    assert submit_payload["subsystem_id"] == "subsystem-announcement"
+    assert submit_payload["version"] == "0.1.0"
+    assert submit_payload["status"] == "ok"
+    assert submit_payload["pending_count"] == 0
+    assert "run_id" not in submit_payload
+    assert "reason" not in submit_payload
 
 
 @pytest.mark.parametrize(
@@ -244,7 +352,7 @@ def test_load_config_rejects_non_positive_runtime_intervals(
         load_config(config_path)
 
 
-def test_cli_ping_returns_zero_in_offline_stub_mode() -> None:
+def test_cli_ping_fails_when_sdk_is_unavailable() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "subsystem_announcement", "ping"],
         cwd=ROOT,
@@ -254,12 +362,12 @@ def test_cli_ping_returns_zero_in_offline_stub_mode() -> None:
         text=True,
     )
 
-    assert result.returncode == 0
-    assert result.stdout.strip() == "ok"
-    assert "subsystem-sdk unavailable; using local SDK stub" in result.stderr
+    assert result.returncode == 1
+    assert result.stdout.strip() == ""
+    assert "subsystem-sdk is required" in result.stderr
 
 
-def test_cli_run_once_returns_zero() -> None:
+def test_cli_run_once_fails_when_sdk_is_unavailable() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "subsystem_announcement", "run", "--once"],
         cwd=ROOT,
@@ -269,5 +377,6 @@ def test_cli_run_once_returns_zero() -> None:
         text=True,
     )
 
-    assert result.returncode == 0
-    assert result.stdout.strip() == "ok"
+    assert result.returncode == 1
+    assert result.stdout.strip() == ""
+    assert "subsystem-sdk is required" in result.stderr


### PR DESCRIPTION
Closes #14

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/subsystem_announcement/config.py`, `src/subsystem_announcement/runtime/lifecycle.py`, `src/subsystem_announcement/runtime/sdk_adapter.py`, `tests/test_runtime_sdk.py`


---
## 背景与目标
Milestone review for milestone-0 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
Issue #3 requires the subsystem to use subsystem-sdk for registration, heartbeat, and submit, but pyproject.toml does not declare subsystem-sdk and sdk_adapter.py silently falls back to local protocol-compatible models when the import is missing. The CLI even treats this as a normal degraded path, and the tests assert SDK_AVAILABLE is False. This means milestone-0 can pass without exercising the real SDK contract or transport, so the stated goal is not satisfied.

## 实现范围
- 修改文件: `src/subsystem_announcement/runtime/sdk_adapter.py`
- Add a pinned subsystem-sdk dependency, wire AnnouncementSubsystem to the official SDK API/fixtures instead of guessed dynamic hooks, and make ping/run fail fast when the SDK is unavailable outside explicit test-only stubs.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/subsystem-announcement/.venv/bin/python -m pytest
```
