### PR TITLE
feat(#4): 公告发现与官方正文获取子链

### DIFF
--- a/src/subsystem_announcement/discovery/__init__.py
+++ b/src/subsystem_announcement/discovery/__init__.py
@@ -36,14 +36,10 @@ async def consume_announcement_ref(
 
     content = await fetch_official_document(envelope, client=client)
     content_hash = compute_content_hash(content)
-    existing_by_hash = dedupe_store.find_by_content_hash(content_hash)
-    if existing_by_hash is not None:
-        dedupe_store.record(existing_by_hash, announcement_id=envelope.announcement_id)
-        return AnnouncementDiscoveryResult(
-            status="duplicate",
-            document=existing_by_hash,
-        )
-
-    artifact = AnnouncementDocumentCache(config).put(envelope, content)
-    dedupe_store.record(artifact)
-    return AnnouncementDiscoveryResult(status="fetched", document=artifact)
+    cache = AnnouncementDocumentCache(config)
+    status, artifact = dedupe_store.resolve_or_record(
+        announcement_id=envelope.announcement_id,
+        content_hash=content_hash,
+        create_artifact=lambda: cache.put(envelope, content),
+    )
+    return AnnouncementDiscoveryResult(status=status, document=artifact)

--- a/src/subsystem_announcement/discovery/__init__.py
+++ b/src/subsystem_announcement/discovery/__init__.py
@@ -1,1 +1,49 @@
-__all__: list[str] = []
+"""Official announcement discovery entrypoint."""
+
+from __future__ import annotations
+
+import httpx
+
+from subsystem_announcement.config import AnnouncementConfig
+
+from .cache import AnnouncementDocumentCache
+from .dedupe import AnnouncementDedupeStore, compute_content_hash
+from .document import AnnouncementDiscoveryResult, AnnouncementDocumentArtifact
+from .envelope import AnnouncementEnvelope
+from .fetcher import fetch_official_document, validate_official_url
+
+__all__: list[str] = [
+    "AnnouncementDiscoveryResult",
+    "AnnouncementDocumentArtifact",
+    "AnnouncementEnvelope",
+    "consume_announcement_ref",
+]
+
+
+async def consume_announcement_ref(
+    envelope: AnnouncementEnvelope,
+    config: AnnouncementConfig,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> AnnouncementDiscoveryResult:
+    """Convert one official announcement reference into a cached artifact."""
+
+    validate_official_url(envelope)
+    dedupe_store = AnnouncementDedupeStore(config.artifact_root)
+    existing_by_id = dedupe_store.find_by_announcement_id(envelope.announcement_id)
+    if existing_by_id is not None:
+        return AnnouncementDiscoveryResult(status="duplicate", document=existing_by_id)
+
+    content = await fetch_official_document(envelope, client=client)
+    content_hash = compute_content_hash(content)
+    existing_by_hash = dedupe_store.find_by_content_hash(content_hash)
+    if existing_by_hash is not None:
+        dedupe_store.record(existing_by_hash, announcement_id=envelope.announcement_id)
+        return AnnouncementDiscoveryResult(
+            status="duplicate",
+            document=existing_by_hash,
+        )
+
+    artifact = AnnouncementDocumentCache(config).put(envelope, content)
+    dedupe_store.record(artifact)
+    return AnnouncementDiscoveryResult(status="fetched", document=artifact)

--- a/src/subsystem_announcement/discovery/cache.py
+++ b/src/subsystem_announcement/discovery/cache.py
@@ -1,0 +1,129 @@
+"""Local document cache for official announcement bytes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from subsystem_announcement.config import AnnouncementConfig
+
+from .dedupe import compute_content_hash
+from .document import AnnouncementDocumentArtifact
+from .envelope import AnnouncementEnvelope
+from .errors import DocumentCacheError
+
+
+class AnnouncementDocumentCache:
+    """Write and load official document bytes and sidecar metadata."""
+
+    def __init__(self, config: AnnouncementConfig) -> None:
+        self.artifact_root = Path(config.artifact_root)
+
+    def put(
+        self,
+        envelope: AnnouncementEnvelope,
+        content: bytes,
+        content_type: str | None = None,
+    ) -> AnnouncementDocumentArtifact:
+        """Cache document bytes and return replayable artifact metadata."""
+
+        content_hash = compute_content_hash(content)
+        document_path = self._document_path(envelope, content_hash)
+        metadata_path = _metadata_path_for_document(document_path)
+        artifact = AnnouncementDocumentArtifact(
+            announcement_id=envelope.announcement_id,
+            content_hash=content_hash,
+            official_url=envelope.official_url,
+            source_exchange=envelope.source_exchange,
+            attachment_type=envelope.attachment_type,
+            local_path=document_path,
+            content_type=content_type or _default_content_type(envelope),
+            byte_size=len(content),
+            fetched_at=datetime.now(timezone.utc),
+        )
+        self._ensure_under_artifact_root(document_path, envelope.announcement_id)
+
+        try:
+            document_path.parent.mkdir(parents=True, exist_ok=True)
+            if not document_path.exists():
+                document_path.write_bytes(content)
+            metadata_path.write_text(
+                artifact.model_dump_json(indent=2),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            raise DocumentCacheError(
+                "Unable to cache announcement document: "
+                f"announcement_id={envelope.announcement_id} path={document_path}"
+            ) from exc
+        return artifact
+
+    def load(self, path: Path) -> AnnouncementDocumentArtifact:
+        """Load artifact metadata from a JSON path or document path."""
+
+        return load_document_artifact(path)
+
+    def _document_path(
+        self,
+        envelope: AnnouncementEnvelope,
+        content_hash: str,
+    ) -> Path:
+        suffix = _suffix_for_attachment(envelope)
+        return (
+            self.artifact_root
+            / "documents"
+            / envelope.source_exchange
+            / envelope.announcement_id
+            / f"{content_hash}.{suffix}"
+        )
+
+    def _ensure_under_artifact_root(
+        self,
+        document_path: Path,
+        announcement_id: str,
+    ) -> None:
+        try:
+            document_path.resolve().relative_to(self.artifact_root.resolve())
+        except ValueError as exc:
+            raise DocumentCacheError(
+                "Document cache path escaped artifact_root: "
+                f"announcement_id={announcement_id} path={document_path} "
+                f"artifact_root={self.artifact_root}"
+            ) from exc
+
+
+def load_document_artifact(path: Path) -> AnnouncementDocumentArtifact:
+    """Load a cached document artifact for parse/replay reuse."""
+
+    metadata_path = path if path.suffix == ".json" else _metadata_path_for_document(path)
+    try:
+        return AnnouncementDocumentArtifact.model_validate_json(
+            metadata_path.read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError) as exc:
+        raise DocumentCacheError(
+            "Unable to load announcement document metadata: "
+            f"announcement_id=unknown path={metadata_path}"
+        ) from exc
+
+
+def _metadata_path_for_document(local_path: Path) -> Path:
+    return local_path.with_name(f"{local_path.stem}.metadata.json")
+
+
+def _suffix_for_attachment(envelope: AnnouncementEnvelope) -> str:
+    if envelope.attachment_type in {"pdf", "html"}:
+        return envelope.attachment_type
+    url_path = urlsplit(str(envelope.official_url)).path.lower()
+    if url_path.endswith(".doc"):
+        return "doc"
+    return "docx"
+
+
+def _default_content_type(envelope: AnnouncementEnvelope) -> str:
+    if envelope.attachment_type == "pdf":
+        return "application/pdf"
+    if envelope.attachment_type == "html":
+        return "text/html"
+    return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"

--- a/src/subsystem_announcement/discovery/dedupe.py
+++ b/src/subsystem_announcement/discovery/dedupe.py
@@ -6,10 +6,11 @@ import hashlib
 import json
 import os
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from fcntl import LOCK_EX, LOCK_UN, flock
 from pathlib import Path
+from typing import Literal
 
 from .document import AnnouncementDocumentArtifact
 from .errors import DocumentCacheError
@@ -67,15 +68,23 @@ class AnnouncementDedupeStore:
             index = self._read_index()
             existing_for_id = index["announcement_id"].get(target_announcement_id)
             if existing_for_id is not None:
-                if artifact.content_hash in index["content_hash"]:
-                    return
                 existing_artifact = self._load_artifact(
                     self._metadata_path_from_index(existing_for_id)
                 )
                 if existing_artifact.content_hash == artifact.content_hash:
-                    index["content_hash"][artifact.content_hash] = existing_for_id
-                    self._write_index(index)
-                return
+                    indexed_hash_path = index["content_hash"].get(
+                        artifact.content_hash
+                    )
+                    if indexed_hash_path != existing_for_id:
+                        index["content_hash"][artifact.content_hash] = existing_for_id
+                        self._write_index(index)
+                    return
+                raise DocumentCacheError(
+                    "Conflicting announcement document content: "
+                    f"announcement_id={target_announcement_id} "
+                    f"existing_hash={existing_artifact.content_hash} "
+                    f"new_hash={artifact.content_hash}"
+                )
 
             canonical_metadata_path = index["content_hash"].setdefault(
                 artifact.content_hash,
@@ -83,6 +92,64 @@ class AnnouncementDedupeStore:
             )
             index["announcement_id"][target_announcement_id] = canonical_metadata_path
             self._write_index(index)
+
+    def resolve_or_record(
+        self,
+        *,
+        announcement_id: str,
+        content_hash: str,
+        create_artifact: Callable[[], AnnouncementDocumentArtifact],
+    ) -> tuple[Literal["fetched", "duplicate"], AnnouncementDocumentArtifact]:
+        """Atomically resolve duplicate state or create and index a new artifact."""
+
+        with self._exclusive_lock():
+            index = self._read_index()
+            existing_for_id = index["announcement_id"].get(announcement_id)
+            if existing_for_id is not None:
+                existing_artifact = self._load_artifact(
+                    self._metadata_path_from_index(existing_for_id)
+                )
+                if existing_artifact.content_hash != content_hash:
+                    raise DocumentCacheError(
+                        "Conflicting announcement document content: "
+                        f"announcement_id={announcement_id} "
+                        f"existing_hash={existing_artifact.content_hash} "
+                        f"new_hash={content_hash}"
+                    )
+                if index["content_hash"].get(content_hash) != existing_for_id:
+                    index["content_hash"][content_hash] = existing_for_id
+                    self._write_index(index)
+                return "duplicate", existing_artifact
+
+            existing_for_hash = index["content_hash"].get(content_hash)
+            if existing_for_hash is not None:
+                existing_artifact = self._load_artifact(
+                    self._metadata_path_from_index(existing_for_hash)
+                )
+                index["announcement_id"][announcement_id] = existing_for_hash
+                self._write_index(index)
+                return "duplicate", existing_artifact
+
+            artifact = create_artifact()
+            if artifact.announcement_id != announcement_id:
+                raise DocumentCacheError(
+                    "Cached artifact announcement_id mismatch: "
+                    f"announcement_id={announcement_id} "
+                    f"artifact_announcement_id={artifact.announcement_id}"
+                )
+            if artifact.content_hash != content_hash:
+                raise DocumentCacheError(
+                    "Cached artifact content_hash mismatch: "
+                    f"announcement_id={announcement_id} "
+                    f"expected_hash={content_hash} actual_hash={artifact.content_hash}"
+                )
+            metadata_path_text = self._metadata_path_to_index(
+                _metadata_path_for_document(artifact.local_path)
+            )
+            index["content_hash"][content_hash] = metadata_path_text
+            index["announcement_id"][announcement_id] = metadata_path_text
+            self._write_index(index)
+            return "fetched", artifact
 
     def _read_index(self) -> dict[str, dict[str, str]]:
         if not self.index_path.exists():

--- a/src/subsystem_announcement/discovery/dedupe.py
+++ b/src/subsystem_announcement/discovery/dedupe.py
@@ -1,0 +1,108 @@
+"""Content hashing and file-backed dedupe state for discovery."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from .document import AnnouncementDocumentArtifact
+from .errors import DocumentCacheError
+
+
+def compute_content_hash(content: bytes) -> str:
+    """Return a stable sha256 hex digest for document bytes."""
+
+    return hashlib.sha256(content).hexdigest()
+
+
+class AnnouncementDedupeStore:
+    """Small JSON index keyed by announcement id and content hash."""
+
+    def __init__(self, artifact_root: Path) -> None:
+        self.artifact_root = Path(artifact_root)
+        self.index_path = self.artifact_root / "documents" / ".dedupe_index.json"
+
+    def find_by_announcement_id(
+        self,
+        announcement_id: str,
+    ) -> AnnouncementDocumentArtifact | None:
+        """Return a previously recorded artifact for an announcement id."""
+
+        metadata_path = self._read_index()["announcement_id"].get(announcement_id)
+        if metadata_path is None:
+            return None
+        return self._load_artifact(Path(metadata_path))
+
+    def find_by_content_hash(
+        self,
+        content_hash: str,
+    ) -> AnnouncementDocumentArtifact | None:
+        """Return a previously recorded artifact for identical bytes."""
+
+        metadata_path = self._read_index()["content_hash"].get(content_hash)
+        if metadata_path is None:
+            return None
+        return self._load_artifact(Path(metadata_path))
+
+    def record(
+        self,
+        artifact: AnnouncementDocumentArtifact,
+        *,
+        announcement_id: str | None = None,
+    ) -> None:
+        """Record an artifact under its hash and an announcement id."""
+
+        index = self._read_index()
+        metadata_path = _metadata_path_for_document(artifact.local_path)
+        metadata_path_text = str(metadata_path)
+        index["announcement_id"][announcement_id or artifact.announcement_id] = (
+            metadata_path_text
+        )
+        index["content_hash"].setdefault(artifact.content_hash, metadata_path_text)
+        self._write_index(index)
+
+    def _read_index(self) -> dict[str, dict[str, str]]:
+        if not self.index_path.exists():
+            return {"announcement_id": {}, "content_hash": {}}
+        try:
+            raw_index = json.loads(self.index_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise DocumentCacheError(
+                "Unable to read discovery dedupe index: "
+                f"announcement_id=unknown path={self.index_path}"
+            ) from exc
+        return {
+            "announcement_id": dict(raw_index.get("announcement_id", {})),
+            "content_hash": dict(raw_index.get("content_hash", {})),
+        }
+
+    def _write_index(self, index: dict[str, dict[str, str]]) -> None:
+        try:
+            self.index_path.parent.mkdir(parents=True, exist_ok=True)
+            temp_path = self.index_path.with_suffix(".tmp")
+            temp_path.write_text(
+                json.dumps(index, ensure_ascii=False, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            temp_path.replace(self.index_path)
+        except OSError as exc:
+            raise DocumentCacheError(
+                "Unable to write discovery dedupe index: "
+                f"announcement_id=unknown path={self.index_path}"
+            ) from exc
+
+    def _load_artifact(self, metadata_path: Path) -> AnnouncementDocumentArtifact:
+        try:
+            return AnnouncementDocumentArtifact.model_validate_json(
+                metadata_path.read_text(encoding="utf-8")
+            )
+        except (OSError, ValueError) as exc:
+            raise DocumentCacheError(
+                "Unable to load dedupe artifact metadata: "
+                f"announcement_id=unknown path={metadata_path}"
+            ) from exc
+
+
+def _metadata_path_for_document(local_path: Path) -> Path:
+    return local_path.with_name(f"{local_path.stem}.metadata.json")

--- a/src/subsystem_announcement/discovery/dedupe.py
+++ b/src/subsystem_announcement/discovery/dedupe.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from fcntl import LOCK_EX, LOCK_UN, flock
 from pathlib import Path
 
 from .document import AnnouncementDocumentArtifact
@@ -22,6 +27,7 @@ class AnnouncementDedupeStore:
     def __init__(self, artifact_root: Path) -> None:
         self.artifact_root = Path(artifact_root)
         self.index_path = self.artifact_root / "documents" / ".dedupe_index.json"
+        self.lock_path = self.artifact_root / "documents" / ".dedupe_index.lock"
 
     def find_by_announcement_id(
         self,
@@ -29,10 +35,10 @@ class AnnouncementDedupeStore:
     ) -> AnnouncementDocumentArtifact | None:
         """Return a previously recorded artifact for an announcement id."""
 
-        metadata_path = self._read_index()["announcement_id"].get(announcement_id)
-        if metadata_path is None:
+        metadata_path_text = self._read_index()["announcement_id"].get(announcement_id)
+        if metadata_path_text is None:
             return None
-        return self._load_artifact(Path(metadata_path))
+        return self._load_artifact(self._metadata_path_from_index(metadata_path_text))
 
     def find_by_content_hash(
         self,
@@ -40,10 +46,10 @@ class AnnouncementDedupeStore:
     ) -> AnnouncementDocumentArtifact | None:
         """Return a previously recorded artifact for identical bytes."""
 
-        metadata_path = self._read_index()["content_hash"].get(content_hash)
-        if metadata_path is None:
+        metadata_path_text = self._read_index()["content_hash"].get(content_hash)
+        if metadata_path_text is None:
             return None
-        return self._load_artifact(Path(metadata_path))
+        return self._load_artifact(self._metadata_path_from_index(metadata_path_text))
 
     def record(
         self,
@@ -53,14 +59,30 @@ class AnnouncementDedupeStore:
     ) -> None:
         """Record an artifact under its hash and an announcement id."""
 
-        index = self._read_index()
+        target_announcement_id = announcement_id or artifact.announcement_id
         metadata_path = _metadata_path_for_document(artifact.local_path)
-        metadata_path_text = str(metadata_path)
-        index["announcement_id"][announcement_id or artifact.announcement_id] = (
-            metadata_path_text
-        )
-        index["content_hash"].setdefault(artifact.content_hash, metadata_path_text)
-        self._write_index(index)
+        metadata_path_text = self._metadata_path_to_index(metadata_path)
+
+        with self._exclusive_lock():
+            index = self._read_index()
+            existing_for_id = index["announcement_id"].get(target_announcement_id)
+            if existing_for_id is not None:
+                if artifact.content_hash in index["content_hash"]:
+                    return
+                existing_artifact = self._load_artifact(
+                    self._metadata_path_from_index(existing_for_id)
+                )
+                if existing_artifact.content_hash == artifact.content_hash:
+                    index["content_hash"][artifact.content_hash] = existing_for_id
+                    self._write_index(index)
+                return
+
+            canonical_metadata_path = index["content_hash"].setdefault(
+                artifact.content_hash,
+                metadata_path_text,
+            )
+            index["announcement_id"][target_announcement_id] = canonical_metadata_path
+            self._write_index(index)
 
     def _read_index(self) -> dict[str, dict[str, str]]:
         if not self.index_path.exists():
@@ -78,15 +100,22 @@ class AnnouncementDedupeStore:
         }
 
     def _write_index(self, index: dict[str, dict[str, str]]) -> None:
+        temp_path: Path | None = None
         try:
             self.index_path.parent.mkdir(parents=True, exist_ok=True)
-            temp_path = self.index_path.with_suffix(".tmp")
-            temp_path.write_text(
-                json.dumps(index, ensure_ascii=False, indent=2, sort_keys=True),
-                encoding="utf-8",
+            fd, temp_path_text = tempfile.mkstemp(
+                prefix=f"{self.index_path.name}.",
+                suffix=".tmp",
+                dir=self.index_path.parent,
             )
+            temp_path = Path(temp_path_text)
+            with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+                json.dump(index, temp_file, ensure_ascii=False, indent=2, sort_keys=True)
+                temp_file.write("\n")
             temp_path.replace(self.index_path)
         except OSError as exc:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
             raise DocumentCacheError(
                 "Unable to write discovery dedupe index: "
                 f"announcement_id=unknown path={self.index_path}"
@@ -94,7 +123,7 @@ class AnnouncementDedupeStore:
 
     def _load_artifact(self, metadata_path: Path) -> AnnouncementDocumentArtifact:
         try:
-            return AnnouncementDocumentArtifact.model_validate_json(
+            artifact = AnnouncementDocumentArtifact.model_validate_json(
                 metadata_path.read_text(encoding="utf-8")
             )
         except (OSError, ValueError) as exc:
@@ -102,7 +131,54 @@ class AnnouncementDedupeStore:
                 "Unable to load dedupe artifact metadata: "
                 f"announcement_id=unknown path={metadata_path}"
             ) from exc
+        document_path = _document_path_for_metadata(metadata_path, artifact)
+        if document_path != artifact.local_path:
+            return artifact.model_copy(update={"local_path": document_path})
+        return artifact
+
+    def _metadata_path_to_index(self, metadata_path: Path) -> str:
+        try:
+            return str(metadata_path.resolve().relative_to(self.artifact_root.resolve()))
+        except ValueError as exc:
+            raise DocumentCacheError(
+                "Dedupe metadata path escaped artifact_root: "
+                f"announcement_id=unknown path={metadata_path} "
+                f"artifact_root={self.artifact_root}"
+            ) from exc
+
+    def _metadata_path_from_index(self, metadata_path_text: str) -> Path:
+        metadata_path = Path(metadata_path_text)
+        if metadata_path.is_absolute():
+            return metadata_path
+        return self.artifact_root / metadata_path
+
+    @contextmanager
+    def _exclusive_lock(self) -> Iterator[None]:
+        try:
+            self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+            with self.lock_path.open("a+") as lock_file:
+                flock(lock_file.fileno(), LOCK_EX)
+                try:
+                    yield
+                finally:
+                    flock(lock_file.fileno(), LOCK_UN)
+        except OSError as exc:
+            raise DocumentCacheError(
+                "Unable to lock discovery dedupe index: "
+                f"announcement_id=unknown path={self.lock_path}"
+            ) from exc
 
 
 def _metadata_path_for_document(local_path: Path) -> Path:
     return local_path.with_name(f"{local_path.stem}.metadata.json")
+
+
+def _document_path_for_metadata(
+    metadata_path: Path,
+    artifact: AnnouncementDocumentArtifact,
+) -> Path:
+    metadata_suffix = ".metadata.json"
+    if not metadata_path.name.endswith(metadata_suffix):
+        return artifact.local_path
+    content_stem = metadata_path.name[: -len(metadata_suffix)]
+    return metadata_path.with_name(f"{content_stem}{artifact.local_path.suffix}")

--- a/src/subsystem_announcement/discovery/document.py
+++ b/src/subsystem_announcement/discovery/document.py
@@ -1,0 +1,34 @@
+"""Discovery artifacts produced from official announcement documents."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field
+
+
+class AnnouncementDocumentArtifact(BaseModel):
+    """Replayable local reference to official announcement document bytes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    announcement_id: str = Field(min_length=1)
+    content_hash: str = Field(min_length=64, max_length=64)
+    official_url: AnyUrl
+    source_exchange: str = Field(min_length=1)
+    attachment_type: Literal["pdf", "html", "word"]
+    local_path: Path
+    content_type: str = Field(min_length=1)
+    byte_size: int = Field(ge=0)
+    fetched_at: datetime
+
+
+class AnnouncementDiscoveryResult(BaseModel):
+    """Result of consuming one announcement reference."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["fetched", "duplicate"]
+    document: AnnouncementDocumentArtifact

--- a/src/subsystem_announcement/discovery/envelope.py
+++ b/src/subsystem_announcement/discovery/envelope.py
@@ -1,0 +1,34 @@
+"""Announcement metadata references accepted by discovery."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, field_validator
+from pydantic.types import StringConstraints
+
+NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class AnnouncementEnvelope(BaseModel):
+    """Upstream announcement metadata needed to fetch an official document."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    announcement_id: NonEmptyStr
+    ts_code: NonEmptyStr
+    title: NonEmptyStr
+    publish_time: datetime
+    official_url: AnyUrl
+    source_exchange: NonEmptyStr
+    attachment_type: Literal["pdf", "html", "word"] = Field(...)
+
+    @field_validator("publish_time")
+    @classmethod
+    def require_timezone(cls, value: datetime) -> datetime:
+        """Reject naive datetimes so replay ordering is unambiguous."""
+
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("publish_time must include timezone information")
+        return value

--- a/src/subsystem_announcement/discovery/errors.py
+++ b/src/subsystem_announcement/discovery/errors.py
@@ -1,0 +1,23 @@
+"""Discovery-stage errors with traceable identifiers."""
+
+from __future__ import annotations
+
+
+class DiscoveryError(RuntimeError):
+    """Base error for announcement discovery failures."""
+
+
+class InvalidAnnouncementEnvelopeError(DiscoveryError):
+    """Raised when an upstream announcement envelope cannot be consumed."""
+
+
+class NonOfficialSourceError(DiscoveryError):
+    """Raised before fetching when an announcement URL is not official."""
+
+
+class DocumentFetchError(DiscoveryError):
+    """Raised when official document bytes cannot be fetched."""
+
+
+class DocumentCacheError(DiscoveryError):
+    """Raised when document bytes or metadata cannot be cached."""

--- a/src/subsystem_announcement/discovery/fetcher.py
+++ b/src/subsystem_announcement/discovery/fetcher.py
@@ -1,0 +1,137 @@
+"""Official source validation and byte fetching for announcements."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from urllib.parse import urlsplit
+
+import httpx
+
+from .envelope import AnnouncementEnvelope
+from .errors import DocumentFetchError, NonOfficialSourceError
+
+_OFFICIAL_DISCLOSURE_DOMAINS: frozenset[str] = frozenset(
+    {
+        "bse.cn",
+        "cninfo.com.cn",
+        "neeq.com.cn",
+        "sse.com.cn",
+        "szse.cn",
+    }
+)
+
+
+def validate_official_url(envelope: AnnouncementEnvelope) -> None:
+    """Reject non-official disclosure URLs before any network request."""
+
+    url = str(envelope.official_url)
+    parsed = urlsplit(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"} or not _is_official_host(host):
+        raise NonOfficialSourceError(
+            "Non-official announcement URL rejected before fetch: "
+            f"announcement_id={envelope.announcement_id} url={url}"
+        )
+
+
+async def fetch_official_document(
+    envelope: AnnouncementEnvelope,
+    *,
+    client: httpx.AsyncClient | None = None,
+    timeout_seconds: float = 30.0,
+    max_attempts: int = 3,
+) -> bytes:
+    """Fetch official announcement document bytes using httpx only."""
+
+    validate_official_url(envelope)
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+
+    if client is not None:
+        return await _fetch_with_client(
+            envelope,
+            client=client,
+            timeout_seconds=timeout_seconds,
+            max_attempts=max_attempts,
+        )
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as managed_client:
+        return await _fetch_with_client(
+            envelope,
+            client=managed_client,
+            timeout_seconds=timeout_seconds,
+            max_attempts=max_attempts,
+        )
+
+
+def _is_official_host(host: str) -> bool:
+    return any(_host_matches(host, domain) for domain in _OFFICIAL_DISCLOSURE_DOMAINS)
+
+
+def _host_matches(host: str, domain: str) -> bool:
+    return host == domain or host.endswith(f".{domain}")
+
+
+async def _fetch_with_client(
+    envelope: AnnouncementEnvelope,
+    *,
+    client: httpx.AsyncClient,
+    timeout_seconds: float,
+    max_attempts: int,
+) -> bytes:
+    url = str(envelope.official_url)
+    retry_statuses = {429, *range(500, 600)}
+    last_error: Exception | None = None
+    last_status: int | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = await client.get(
+                url,
+                follow_redirects=True,
+                timeout=timeout_seconds,
+            )
+        except httpx.TimeoutException as exc:
+            last_error = exc
+            if attempt == max_attempts:
+                break
+            await asyncio.sleep(0)
+            continue
+        except httpx.RequestError as exc:
+            raise DocumentFetchError(
+                "Failed to fetch official announcement document: "
+                f"announcement_id={envelope.announcement_id} url={url} error={exc}"
+            ) from exc
+
+        last_status = response.status_code
+        if response.status_code < 400:
+            return response.content
+        if response.status_code not in retry_statuses:
+            raise DocumentFetchError(
+                "Failed to fetch official announcement document: "
+                f"announcement_id={envelope.announcement_id} url={url} "
+                f"status_code={response.status_code}"
+            )
+        if attempt < max_attempts:
+            await asyncio.sleep(0)
+
+    detail = (
+        f"error={last_error}"
+        if last_error is not None
+        else f"status_code={last_status}"
+    )
+    raise DocumentFetchError(
+        "Failed to fetch official announcement document after bounded retries: "
+        f"announcement_id={envelope.announcement_id} url={url} attempts={max_attempts} "
+        f"{detail}"
+    )
+
+
+def official_disclosure_domains() -> Iterable[str]:
+    """Return configured official disclosure domain suffixes for diagnostics."""
+
+    return tuple(sorted(_OFFICIAL_DISCLOSURE_DOMAINS))

--- a/src/subsystem_announcement/discovery/fetcher.py
+++ b/src/subsystem_announcement/discovery/fetcher.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterable
-from urllib.parse import urlsplit
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from urllib.parse import urljoin, urlsplit
 
 import httpx
 
@@ -20,19 +22,29 @@ _OFFICIAL_DISCLOSURE_DOMAINS: frozenset[str] = frozenset(
         "szse.cn",
     }
 )
+_REDIRECT_STATUSES: frozenset[int] = frozenset({301, 302, 303, 307, 308})
+_RETRY_STATUSES: frozenset[int] = frozenset({429, *range(500, 600)})
+_RETRY_BASE_DELAY_SECONDS = 0.5
+_MAX_REDIRECTS = 10
 
 
 def validate_official_url(envelope: AnnouncementEnvelope) -> None:
     """Reject non-official disclosure URLs before any network request."""
 
-    url = str(envelope.official_url)
+    _validate_official_url_text(
+        str(envelope.official_url),
+        announcement_id=envelope.announcement_id,
+    )
+
+
+def _validate_official_url_text(url: str, *, announcement_id: str) -> None:
     parsed = urlsplit(url)
     host = (parsed.hostname or "").lower().rstrip(".")
     scheme = parsed.scheme.lower()
     if scheme not in {"http", "https"} or not _is_official_host(host):
         raise NonOfficialSourceError(
             "Non-official announcement URL rejected before fetch: "
-            f"announcement_id={envelope.announcement_id} url={url}"
+            f"announcement_id={announcement_id} url={url}"
         )
 
 
@@ -84,22 +96,22 @@ async def _fetch_with_client(
     max_attempts: int,
 ) -> bytes:
     url = str(envelope.official_url)
-    retry_statuses = {429, *range(500, 600)}
     last_error: Exception | None = None
     last_status: int | None = None
 
     for attempt in range(1, max_attempts + 1):
         try:
-            response = await client.get(
-                url,
-                follow_redirects=True,
-                timeout=timeout_seconds,
+            response = await _get_with_official_redirects(
+                envelope,
+                client=client,
+                url=url,
+                timeout_seconds=timeout_seconds,
             )
         except httpx.TimeoutException as exc:
             last_error = exc
             if attempt == max_attempts:
                 break
-            await asyncio.sleep(0)
+            await _sleep_before_retry(attempt=attempt)
             continue
         except httpx.RequestError as exc:
             raise DocumentFetchError(
@@ -108,16 +120,16 @@ async def _fetch_with_client(
             ) from exc
 
         last_status = response.status_code
-        if response.status_code < 400:
+        if 200 <= response.status_code < 300:
             return response.content
-        if response.status_code not in retry_statuses:
+        if response.status_code not in _RETRY_STATUSES:
             raise DocumentFetchError(
                 "Failed to fetch official announcement document: "
                 f"announcement_id={envelope.announcement_id} url={url} "
                 f"status_code={response.status_code}"
             )
         if attempt < max_attempts:
-            await asyncio.sleep(0)
+            await _sleep_before_retry(attempt=attempt, response=response)
 
     detail = (
         f"error={last_error}"
@@ -135,3 +147,83 @@ def official_disclosure_domains() -> Iterable[str]:
     """Return configured official disclosure domain suffixes for diagnostics."""
 
     return tuple(sorted(_OFFICIAL_DISCLOSURE_DOMAINS))
+
+
+async def _get_with_official_redirects(
+    envelope: AnnouncementEnvelope,
+    *,
+    client: httpx.AsyncClient,
+    url: str,
+    timeout_seconds: float,
+) -> httpx.Response:
+    current_url = url
+    for _ in range(_MAX_REDIRECTS + 1):
+        _validate_official_url_text(
+            current_url,
+            announcement_id=envelope.announcement_id,
+        )
+        response = await client.get(
+            current_url,
+            follow_redirects=False,
+            timeout=timeout_seconds,
+        )
+        if response.status_code not in _REDIRECT_STATUSES:
+            return response
+
+        location = response.headers.get("location")
+        if not location:
+            raise DocumentFetchError(
+                "Official announcement redirect missing Location header: "
+                f"announcement_id={envelope.announcement_id} url={current_url} "
+                f"status_code={response.status_code}"
+            )
+        current_url = urljoin(current_url, location)
+        _validate_official_url_text(
+            current_url,
+            announcement_id=envelope.announcement_id,
+        )
+
+    raise DocumentFetchError(
+        "Official announcement redirect limit exceeded: "
+        f"announcement_id={envelope.announcement_id} url={url} "
+        f"max_redirects={_MAX_REDIRECTS}"
+    )
+
+
+async def _sleep_before_retry(
+    *,
+    attempt: int,
+    response: httpx.Response | None = None,
+) -> None:
+    await asyncio.sleep(_retry_delay_seconds(attempt=attempt, response=response))
+
+
+def _retry_delay_seconds(
+    *,
+    attempt: int,
+    response: httpx.Response | None = None,
+) -> float:
+    if response is not None and response.status_code == 429:
+        retry_after = _parse_retry_after(response.headers.get("retry-after"))
+        if retry_after is not None:
+            return retry_after
+    return _RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return max(0.0, float(stripped))
+    except ValueError:
+        pass
+    try:
+        retry_at = parsedate_to_datetime(stripped)
+    except (TypeError, ValueError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+    return max(0.0, (retry_at - datetime.now(timezone.utc)).total_seconds())

--- a/tests/test_discovery_cache.py
+++ b/tests/test_discovery_cache.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
+import pytest
 
 from subsystem_announcement.config import AnnouncementConfig
 from subsystem_announcement.discovery import consume_announcement_ref
@@ -19,6 +20,7 @@ from subsystem_announcement.discovery.dedupe import (
     compute_content_hash,
 )
 from subsystem_announcement.discovery.envelope import AnnouncementEnvelope
+from subsystem_announcement.discovery.errors import DocumentCacheError
 
 
 def _envelope(
@@ -94,6 +96,23 @@ def test_dedupe_store_records_concurrent_writers_without_lost_updates(
     for artifact in artifacts:
         assert store.find_by_announcement_id(artifact.announcement_id) == artifact
         assert store.find_by_content_hash(artifact.content_hash) == artifact
+
+
+def test_dedupe_store_rejects_same_announcement_id_with_conflicting_hash(
+    tmp_path: Path,
+) -> None:
+    config = AnnouncementConfig(artifact_root=tmp_path)
+    cache = AnnouncementDocumentCache(config)
+    first = cache.put(_envelope("ann-1"), b"first pdf bytes")
+    second = cache.put(_envelope("ann-1"), b"second pdf bytes")
+    store = AnnouncementDedupeStore(tmp_path)
+
+    store.record(first)
+
+    with pytest.raises(DocumentCacheError, match="announcement_id=ann-1"):
+        store.record(second)
+
+    assert store.find_by_announcement_id("ann-1") == first
 
 
 def test_dedupe_store_uses_relative_paths_after_artifact_root_move(
@@ -204,6 +223,88 @@ def test_consume_announcement_ref_marks_same_content_hash_duplicate(
     assert second.document.local_path == first.document.local_path
     assert third.document.local_path == first.document.local_path
     assert request_count == 2
+    assert len(body_files) == 1
+
+
+def test_consume_announcement_ref_concurrent_same_id_returns_canonical_artifact(
+    tmp_path: Path,
+) -> None:
+    async def scenario():
+        first_seen = asyncio.Event()
+        second_seen = asyncio.Event()
+        request_count = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            request_count += 1
+            if request_count == 1:
+                first_seen.set()
+                await second_seen.wait()
+            else:
+                second_seen.set()
+                await first_seen.wait()
+            return httpx.Response(200, content=b"same concurrent pdf bytes")
+
+        config = AnnouncementConfig(artifact_root=tmp_path)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            results = await asyncio.gather(
+                consume_announcement_ref(_envelope("ann-1"), config, client=client),
+                consume_announcement_ref(_envelope("ann-1"), config, client=client),
+            )
+        return request_count, results
+
+    request_count, results = asyncio.run(scenario())
+    body_files = _document_body_files(tmp_path)
+
+    assert sorted(result.status for result in results) == ["duplicate", "fetched"]
+    assert results[0].document == results[1].document
+    assert request_count == 2
+    assert len(body_files) == 1
+
+
+def test_consume_announcement_ref_concurrent_same_id_conflicting_bytes_fails(
+    tmp_path: Path,
+) -> None:
+    async def scenario():
+        first_seen = asyncio.Event()
+        second_seen = asyncio.Event()
+        request_count = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            request_count += 1
+            content = f"concurrent pdf bytes {request_count}".encode()
+            if request_count == 1:
+                first_seen.set()
+                await second_seen.wait()
+            else:
+                second_seen.set()
+                await first_seen.wait()
+            return httpx.Response(200, content=content)
+
+        config = AnnouncementConfig(artifact_root=tmp_path)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            results = await asyncio.gather(
+                consume_announcement_ref(_envelope("ann-1"), config, client=client),
+                consume_announcement_ref(_envelope("ann-1"), config, client=client),
+                return_exceptions=True,
+            )
+        return request_count, results
+
+    request_count, results = asyncio.run(scenario())
+    successes = [result for result in results if not isinstance(result, BaseException)]
+    errors = [result for result in results if isinstance(result, DocumentCacheError)]
+    body_files = _document_body_files(tmp_path)
+
+    assert request_count == 2
+    assert len(successes) == 1
+    assert successes[0].status == "fetched"
+    assert len(errors) == 1
+    assert "announcement_id=ann-1" in str(errors[0])
     assert len(body_files) == 1
 
 

--- a/tests/test_discovery_cache.py
+++ b/tests/test_discovery_cache.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -70,6 +72,58 @@ def test_dedupe_store_finds_recorded_artifact_by_id_and_hash(
 
     assert store.find_by_announcement_id("ann-1") == artifact
     assert store.find_by_content_hash(artifact.content_hash) == artifact
+
+
+def test_dedupe_store_records_concurrent_writers_without_lost_updates(
+    tmp_path: Path,
+) -> None:
+    config = AnnouncementConfig(artifact_root=tmp_path)
+    cache = AnnouncementDocumentCache(config)
+    artifacts = [
+        cache.put(_envelope(f"ann-{index}"), f"pdf bytes {index}".encode())
+        for index in range(24)
+    ]
+
+    def record_artifact(artifact) -> None:
+        AnnouncementDedupeStore(tmp_path).record(artifact)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(record_artifact, artifacts))
+
+    store = AnnouncementDedupeStore(tmp_path)
+    for artifact in artifacts:
+        assert store.find_by_announcement_id(artifact.announcement_id) == artifact
+        assert store.find_by_content_hash(artifact.content_hash) == artifact
+
+
+def test_dedupe_store_uses_relative_paths_after_artifact_root_move(
+    tmp_path: Path,
+) -> None:
+    original_root = tmp_path / "artifacts"
+    moved_root = tmp_path / "moved-artifacts"
+    config = AnnouncementConfig(artifact_root=original_root)
+    artifact = AnnouncementDocumentCache(config).put(_envelope(), b"pdf bytes")
+    store = AnnouncementDedupeStore(original_root)
+
+    store.record(artifact)
+
+    index = json.loads(
+        (original_root / "documents" / ".dedupe_index.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert not Path(index["announcement_id"]["ann-1"]).is_absolute()
+    assert not Path(index["content_hash"][artifact.content_hash]).is_absolute()
+
+    original_root.rename(moved_root)
+    moved_store = AnnouncementDedupeStore(moved_root)
+    moved_artifact = moved_store.find_by_announcement_id("ann-1")
+
+    assert moved_artifact is not None
+    assert moved_artifact.local_path == moved_root / artifact.local_path.relative_to(
+        original_root
+    )
+    assert moved_artifact.local_path.exists()
 
 
 def test_consume_announcement_ref_dedupes_repeated_announcement_id(

--- a/tests/test_discovery_cache.py
+++ b/tests/test_discovery_cache.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.discovery import consume_announcement_ref
+from subsystem_announcement.discovery.cache import (
+    AnnouncementDocumentCache,
+    load_document_artifact,
+)
+from subsystem_announcement.discovery.dedupe import (
+    AnnouncementDedupeStore,
+    compute_content_hash,
+)
+from subsystem_announcement.discovery.envelope import AnnouncementEnvelope
+
+
+def _envelope(
+    announcement_id: str = "ann-1",
+    url: str | None = None,
+) -> AnnouncementEnvelope:
+    return AnnouncementEnvelope(
+        announcement_id=announcement_id,
+        ts_code="600000.SH",
+        title="重大合同公告",
+        publish_time=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+        official_url=url
+        or f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf",
+        source_exchange="sse",
+        attachment_type="pdf",
+    )
+
+
+def test_compute_content_hash_is_stable_and_content_sensitive() -> None:
+    content = b"official document bytes"
+
+    assert compute_content_hash(content) == compute_content_hash(content)
+    assert compute_content_hash(content) != compute_content_hash(b"other bytes")
+
+
+def test_document_cache_put_writes_bytes_and_round_trips_metadata(
+    tmp_path: Path,
+) -> None:
+    config = AnnouncementConfig(artifact_root=tmp_path)
+    cache = AnnouncementDocumentCache(config)
+
+    artifact = cache.put(_envelope(), b"pdf bytes", content_type="application/pdf")
+    loaded = load_document_artifact(artifact.local_path)
+
+    assert artifact.local_path.read_bytes() == b"pdf bytes"
+    assert artifact.local_path.resolve().is_relative_to(tmp_path.resolve())
+    assert loaded == artifact
+    assert cache.load(artifact.local_path) == artifact
+    assert artifact.byte_size == len(b"pdf bytes")
+    assert artifact.content_type == "application/pdf"
+
+
+def test_dedupe_store_finds_recorded_artifact_by_id_and_hash(
+    tmp_path: Path,
+) -> None:
+    config = AnnouncementConfig(artifact_root=tmp_path)
+    artifact = AnnouncementDocumentCache(config).put(_envelope(), b"pdf bytes")
+    store = AnnouncementDedupeStore(tmp_path)
+
+    store.record(artifact)
+
+    assert store.find_by_announcement_id("ann-1") == artifact
+    assert store.find_by_content_hash(artifact.content_hash) == artifact
+
+
+def test_consume_announcement_ref_dedupes_repeated_announcement_id(
+    tmp_path: Path,
+) -> None:
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        return httpx.Response(200, content=b"pdf bytes")
+
+    async def scenario():
+        config = AnnouncementConfig(artifact_root=tmp_path)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            first = await consume_announcement_ref(
+                _envelope("ann-1"),
+                config,
+                client=client,
+            )
+            second = await consume_announcement_ref(
+                _envelope("ann-1"),
+                config,
+                client=client,
+            )
+            return first, second
+
+    first, second = asyncio.run(scenario())
+    body_files = _document_body_files(tmp_path)
+
+    assert first.status == "fetched"
+    assert second.status == "duplicate"
+    assert second.document == first.document
+    assert request_count == 1
+    assert len(body_files) == 1
+
+
+def test_consume_announcement_ref_marks_same_content_hash_duplicate(
+    tmp_path: Path,
+) -> None:
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        return httpx.Response(200, content=b"same pdf bytes")
+
+    async def scenario():
+        config = AnnouncementConfig(artifact_root=tmp_path)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            first = await consume_announcement_ref(
+                _envelope("ann-1"),
+                config,
+                client=client,
+            )
+            second = await consume_announcement_ref(
+                _envelope("ann-2"),
+                config,
+                client=client,
+            )
+            third = await consume_announcement_ref(
+                _envelope("ann-2"),
+                config,
+                client=client,
+            )
+            return first, second, third
+
+    first, second, third = asyncio.run(scenario())
+    body_files = _document_body_files(tmp_path)
+
+    assert first.status == "fetched"
+    assert second.status == "duplicate"
+    assert third.status == "duplicate"
+    assert second.document.local_path == first.document.local_path
+    assert third.document.local_path == first.document.local_path
+    assert request_count == 2
+    assert len(body_files) == 1
+
+
+def _document_body_files(root: Path) -> list[Path]:
+    return [
+        path
+        for path in (root / "documents").rglob("*")
+        if path.is_file() and path.suffix in {".pdf", ".html", ".doc", ".docx"}
+    ]

--- a/tests/test_discovery_envelope.py
+++ b/tests/test_discovery_envelope.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from subsystem_announcement.discovery.envelope import AnnouncementEnvelope
+
+
+def _envelope_data() -> dict[str, object]:
+    return {
+        "announcement_id": "ann-1",
+        "ts_code": "600000.SH",
+        "title": "重大合同公告",
+        "publish_time": datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+        "official_url": "https://static.sse.com.cn/disclosure/ann-1.pdf",
+        "source_exchange": "sse",
+        "attachment_type": "pdf",
+    }
+
+
+def test_announcement_envelope_accepts_required_fields_and_timezone() -> None:
+    envelope = AnnouncementEnvelope.model_validate(_envelope_data())
+
+    assert envelope.announcement_id == "ann-1"
+    assert envelope.publish_time.tzinfo is not None
+    assert envelope.publish_time.utcoffset() is not None
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("announcement_id", ""),
+        ("title", ""),
+        ("attachment_type", "image"),
+    ],
+)
+def test_announcement_envelope_rejects_invalid_required_fields(
+    field: str,
+    value: object,
+) -> None:
+    data = _envelope_data()
+    data[field] = value
+
+    with pytest.raises(ValidationError):
+        AnnouncementEnvelope.model_validate(data)
+
+
+def test_announcement_envelope_rejects_extra_fields() -> None:
+    data = _envelope_data()
+    data["ingest_metadata"] = {"source": "crawler"}
+
+    with pytest.raises(ValidationError):
+        AnnouncementEnvelope.model_validate(data)
+
+
+def test_announcement_envelope_rejects_naive_publish_time() -> None:
+    data = _envelope_data()
+    data["publish_time"] = datetime(2026, 4, 18, 9, 30)
+
+    with pytest.raises(ValidationError, match="timezone"):
+        AnnouncementEnvelope.model_validate(data)

--- a/tests/test_discovery_fetcher.py
+++ b/tests/test_discovery_fetcher.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import httpx
 import pytest
 
+import subsystem_announcement.discovery.fetcher as fetcher_module
 from subsystem_announcement.discovery.envelope import AnnouncementEnvelope
 from subsystem_announcement.discovery.errors import (
     DocumentFetchError,
@@ -15,6 +16,17 @@ from subsystem_announcement.discovery.fetcher import (
     fetch_official_document,
     validate_official_url,
 )
+
+
+@pytest.fixture
+def retry_delays(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(fetcher_module.asyncio, "sleep", fake_sleep)
+    return delays
 
 
 def _envelope(url: str = "https://static.sse.com.cn/disclosure/ann-1.pdf"):
@@ -71,6 +83,28 @@ def test_fetch_official_document_returns_200_body() -> None:
     assert asyncio.run(scenario()) == b"pdf bytes"
 
 
+def test_fetch_official_document_rejects_non_official_redirect_before_request() -> None:
+    requested_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        return httpx.Response(
+            302,
+            headers={"location": "https://news.example.com/ann-1.pdf"},
+        )
+
+    async def scenario() -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            with pytest.raises(NonOfficialSourceError, match="news.example.com"):
+                await fetch_official_document(_envelope(), client=client)
+
+    asyncio.run(scenario())
+
+    assert requested_urls == ["https://static.sse.com.cn/disclosure/ann-1.pdf"]
+
+
 def test_fetch_official_document_fails_404_without_retry() -> None:
     request_count = 0
 
@@ -91,7 +125,9 @@ def test_fetch_official_document_fails_404_without_retry() -> None:
     assert request_count == 1
 
 
-def test_fetch_official_document_retries_429_then_succeeds() -> None:
+def test_fetch_official_document_retries_429_then_succeeds(
+    retry_delays: list[float],
+) -> None:
     statuses = [429, 429, 200]
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -106,9 +142,12 @@ def test_fetch_official_document_retries_429_then_succeeds() -> None:
 
     assert asyncio.run(scenario()) == b"ok"
     assert statuses == []
+    assert retry_delays == [0.5, 1.0]
 
 
-def test_fetch_official_document_retries_5xx_then_succeeds() -> None:
+def test_fetch_official_document_retries_5xx_then_succeeds(
+    retry_delays: list[float],
+) -> None:
     statuses = [503, 502, 200]
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -123,9 +162,12 @@ def test_fetch_official_document_retries_5xx_then_succeeds() -> None:
 
     assert asyncio.run(scenario()) == b"ok"
     assert statuses == []
+    assert retry_delays == [0.5, 1.0]
 
 
-def test_fetch_official_document_reports_timeout_after_bounded_attempts() -> None:
+def test_fetch_official_document_reports_timeout_after_bounded_attempts(
+    retry_delays: list[float],
+) -> None:
     request_count = 0
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -148,3 +190,4 @@ def test_fetch_official_document_reports_timeout_after_bounded_attempts() -> Non
     asyncio.run(scenario())
 
     assert request_count == 2
+    assert retry_delays == [0.5]

--- a/tests/test_discovery_fetcher.py
+++ b/tests/test_discovery_fetcher.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from subsystem_announcement.discovery.envelope import AnnouncementEnvelope
+from subsystem_announcement.discovery.errors import (
+    DocumentFetchError,
+    NonOfficialSourceError,
+)
+from subsystem_announcement.discovery.fetcher import (
+    fetch_official_document,
+    validate_official_url,
+)
+
+
+def _envelope(url: str = "https://static.sse.com.cn/disclosure/ann-1.pdf"):
+    return AnnouncementEnvelope(
+        announcement_id="ann-1",
+        ts_code="600000.SH",
+        title="重大合同公告",
+        publish_time=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+        official_url=url,
+        source_exchange="sse",
+        attachment_type="pdf",
+    )
+
+
+def test_validate_official_url_rejects_non_official_domain() -> None:
+    envelope = _envelope("https://news.example.com/ann-1.pdf")
+
+    with pytest.raises(NonOfficialSourceError, match="ann-1"):
+        validate_official_url(envelope)
+
+
+def test_fetch_rejects_non_official_domain_before_network_request() -> None:
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        return httpx.Response(200, content=b"unexpected")
+
+    async def scenario() -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            with pytest.raises(NonOfficialSourceError):
+                await fetch_official_document(
+                    _envelope("https://news.example.com/ann-1.pdf"),
+                    client=client,
+                )
+
+    asyncio.run(scenario())
+
+    assert request_count == 0
+
+
+def test_fetch_official_document_returns_200_body() -> None:
+    async def scenario() -> bytes:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(200, content=b"pdf bytes"),
+            ),
+        ) as client:
+            return await fetch_official_document(_envelope(), client=client)
+
+    assert asyncio.run(scenario()) == b"pdf bytes"
+
+
+def test_fetch_official_document_fails_404_without_retry() -> None:
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        return httpx.Response(404, content=b"missing")
+
+    async def scenario() -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            with pytest.raises(DocumentFetchError, match="status_code=404"):
+                await fetch_official_document(_envelope(), client=client)
+
+    asyncio.run(scenario())
+
+    assert request_count == 1
+
+
+def test_fetch_official_document_retries_429_then_succeeds() -> None:
+    statuses = [429, 429, 200]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        status = statuses.pop(0)
+        return httpx.Response(status, content=b"ok" if status == 200 else b"retry")
+
+    async def scenario() -> bytes:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            return await fetch_official_document(_envelope(), client=client)
+
+    assert asyncio.run(scenario()) == b"ok"
+    assert statuses == []
+
+
+def test_fetch_official_document_retries_5xx_then_succeeds() -> None:
+    statuses = [503, 502, 200]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        status = statuses.pop(0)
+        return httpx.Response(status, content=b"ok" if status == 200 else b"retry")
+
+    async def scenario() -> bytes:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            return await fetch_official_document(_envelope(), client=client)
+
+    assert asyncio.run(scenario()) == b"ok"
+    assert statuses == []
+
+
+def test_fetch_official_document_reports_timeout_after_bounded_attempts() -> None:
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        raise httpx.ReadTimeout("slow official source", request=request)
+
+    async def scenario() -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            with pytest.raises(DocumentFetchError, match="attempts=2"):
+                await fetch_official_document(
+                    _envelope(),
+                    client=client,
+                    timeout_seconds=0.1,
+                    max_attempts=2,
+                )
+
+    asyncio.run(scenario())
+
+    assert request_count == 2

--- a/tests/test_package_layout.py
+++ b/tests/test_package_layout.py
@@ -45,7 +45,15 @@ def test_package_exports_version_and_name() -> None:
 @pytest.mark.parametrize("subpackage", SUBPACKAGES)
 def test_subpackages_are_importable(subpackage: str) -> None:
     module = importlib.import_module(f"subsystem_announcement.{subpackage}")
-    assert module.__all__ == []
+    if subpackage == "discovery":
+        assert set(module.__all__) == {
+            "AnnouncementDiscoveryResult",
+            "AnnouncementDocumentArtifact",
+            "AnnouncementEnvelope",
+            "consume_announcement_ref",
+        }
+    else:
+        assert module.__all__ == []
 
 
 def test_config_defaults_are_instantiable() -> None:


### PR DESCRIPTION
Closes #4

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/subsystem_announcement/config.py`, `tests/test_runtime_sdk.py`


---
### 1. 背景与目标
项目文档 §8.1、§11.1 和 §16.1 要求先把公告元数据引用转成可重放的官方正文 artifact，再交给 Docling 解析。当前代码中 `src/subsystem_announcement/discovery/__init__.py` 仍是空 package，已有可复用基础只有 `src/subsystem_announcement/config.py` 的 `AnnouncementConfig.artifact_root`、`httpx` 依赖和阶段 0 的 runtime/CLI 骨架。本 issue 的目标是在不采集元数据、不进入解析的前提下，实现 `AnnouncementEnvelope -> official document bytes -> content_hash -> AnnouncementDocumentArtifact` 的发现子链。

### 2. 所属模块
Primary writable paths:
- `src/subsystem_announcement/discovery/__init__.py`
- `src/subsystem_announcement/discovery/envelope.py`
- `src/subsystem_announcement/discovery/document.py`
- `src/subsystem_announcement/discovery/fetcher.py`
- `src/subsystem_announcement/discovery/dedupe.py`
- `src/subsystem_announcement/discovery/cache.py`
- `src/subsystem_announcement/discovery/errors.py`
- `tests/test_discovery_envelope.py`
- `tests/test_discovery_fetcher.py`
- `tests/test_discovery_cache.py`

Adjacent read-only / integration paths:
- `src/subsystem_announcement/config.py`，只读取 `AnnouncementConfig.artifact_root`
- `src/subsystem_announcement/runtime/*`，不改 runtime 提交通道
- `docs/subsystem-announcement.project-doc.md`，仅作为领域边界参考

### 3. 实现范围
- 新建 `discovery/errors.py`，定义 `DiscoveryError`、`InvalidAnnouncementEnvelopeError`、`NonOfficialSourceError`、`DocumentFetchError`、`DocumentCacheError`，异常信息必须包含 `announcement_id` 或 URL 便于 trace。
- 在 `discovery/envelope.py` 定义 `AnnouncementEnvelope(BaseModel)`，字段为 `announcement_id: str`、`ts_code: str`、`title: str`、`publish_time: datetime`、`official_url: AnyUrl`、`source_exchange: str`、`attachment_type: Literal['pdf', 'html', 'word']`，使用 pydantic v2 `ConfigDict(extra='forbid')`。
- 在 `discovery/document.py` 定义 `AnnouncementDocumentArtifact(BaseModel)` 和 `AnnouncementDiscoveryResult(BaseModel)`；artifact 至少包含 `announcement_id`、`content_hash`、`official_url`、`source_exchange`、`attachment_type`、`local_path`、`content_type`、`byte_size`、`fetched_at`。
- 在 `discovery/fetcher.py` 实现官方源策略 `validate_official_url(envelope: AnnouncementEnvelope) 