### PR TITLE
feat(#6): Ex-1 公告事实抽取与实体锚点协同

### DIFF
--- a/src/subsystem_announcement/extract/__init__.py
+++ b/src/subsystem_announcement/extract/__init__.py
@@ -1,1 +1,241 @@
-__all__: list[str] = []
+"""Announcement Ex-1 extraction public API."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from .candidates import (
+    AnnouncementFactCandidate,
+    ExtractionContext,
+    FactType,
+    build_extraction_context,
+    build_fact_candidate,
+)
+from .classifier import classify_disclosure_types
+from .entity_anchor import (
+    EntityAnchor,
+    EntityAnchorer,
+    EntityMention,
+    EntityRegistryClient,
+    EntityResolution,
+)
+from .evidence import (
+    EvidenceSpan,
+    build_evidence_span,
+    build_table_evidence_span,
+    iter_evidence_sources,
+)
+from .reasoner_bridge import (
+    ReasonerRuntimeBridge,
+    StructuredExtractionRequest,
+    StructuredExtractionSegment,
+    StructuredReasoner,
+    bounded_segments,
+    ex1_reasoner_schema,
+)
+from .rules import (
+    earnings,
+    equity_pledge,
+    fundraising,
+    major_contract,
+    regulatory,
+    shareholder,
+    trading,
+)
+
+
+_FACT_TYPE_ORDER = (
+    FactType.EARNINGS_PREANNOUNCE,
+    FactType.MAJOR_CONTRACT,
+    FactType.SHAREHOLDER_CHANGE,
+    FactType.EQUITY_PLEDGE,
+    FactType.REGULATORY_ACTION,
+    FactType.TRADING_HALT_RESUME,
+    FactType.FUNDRAISING_CHANGE,
+)
+
+_RULE_EXTRACTORS = {
+    FactType.EARNINGS_PREANNOUNCE: earnings.extract,
+    FactType.MAJOR_CONTRACT: major_contract.extract,
+    FactType.SHAREHOLDER_CHANGE: shareholder.extract,
+    FactType.EQUITY_PLEDGE: equity_pledge.extract,
+    FactType.REGULATORY_ACTION: regulatory.extract,
+    FactType.TRADING_HALT_RESUME: trading.extract,
+    FactType.FUNDRAISING_CHANGE: fundraising.extract,
+}
+
+_REASONER_HINTS: dict[FactType, tuple[re.Pattern[str], ...]] = {
+    FactType.EARNINGS_PREANNOUNCE: (
+        re.compile(r"业绩|净利润|盈利|亏损"),
+    ),
+    FactType.MAJOR_CONTRACT: (re.compile(r"合同|中标|项目|合作"),),
+    FactType.SHAREHOLDER_CHANGE: (re.compile(r"股东|持股|增持|减持|控制"),),
+    FactType.EQUITY_PLEDGE: (re.compile(r"质押"),),
+    FactType.REGULATORY_ACTION: (re.compile(r"监管|处罚|调查|问询"),),
+    FactType.TRADING_HALT_RESUME: (re.compile(r"停牌|复牌|交易"),),
+    FactType.FUNDRAISING_CHANGE: (re.compile(r"募集资金|募投|发行方案"),),
+}
+
+
+def extract_fact_candidates(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    *,
+    entity_registry: EntityRegistryClient | None = None,
+    reasoner: StructuredReasoner | None = None,
+) -> list[AnnouncementFactCandidate]:
+    """Extract evidence-backed Ex-1 fact candidates from a parsed artifact."""
+
+    context = build_extraction_context(
+        parsed_artifact,
+        entity_registry=entity_registry,
+        reasoner=reasoner,
+    )
+    classified_types = classify_disclosure_types(parsed_artifact)
+    candidates: list[AnnouncementFactCandidate] = []
+    for fact_type in _FACT_TYPE_ORDER:
+        if fact_type not in classified_types:
+            continue
+        extracted = _RULE_EXTRACTORS[fact_type](parsed_artifact, context)
+        if not extracted and reasoner is not None:
+            extracted = _extract_with_reasoner(parsed_artifact, context, fact_type)
+        candidates.extend(extracted)
+    return _dedupe_candidates(candidates)
+
+
+def _extract_with_reasoner(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+    fact_type: FactType,
+) -> list[AnnouncementFactCandidate]:
+    if context.reasoner is None:
+        return []
+    request = _build_reasoner_request(parsed_artifact, fact_type)
+    if request is None:
+        return []
+    result = context.reasoner.generate_structured(request)
+    raw_facts = result.get("facts") if isinstance(result, Mapping) else None
+    if not isinstance(raw_facts, Sequence) or isinstance(raw_facts, str):
+        return []
+
+    candidates: list[AnnouncementFactCandidate] = []
+    for raw_fact in raw_facts:
+        if not isinstance(raw_fact, Mapping):
+            continue
+        quote = raw_fact.get("quote")
+        fact_content = raw_fact.get("fact_content")
+        if not isinstance(quote, str) or not isinstance(fact_content, Mapping):
+            continue
+        span = _span_for_quote(parsed_artifact, quote)
+        if span is None:
+            continue
+        related_mentions = [
+            EntityMention(name=name, role="related_entity")
+            for name in raw_fact.get("related_mentions", [])
+            if isinstance(name, str) and name.strip()
+        ]
+        related_entities = context.entity_anchorer.resolve_related_mentions(
+            related_mentions
+        )
+        confidence = raw_fact.get("confidence", 0.65)
+        candidates.append(
+            build_fact_candidate(
+                parsed_artifact,
+                context,
+                fact_type=fact_type,
+                fact_content={
+                    "disclosure_type": fact_type.value,
+                    "summary": quote,
+                    "reasoner_fact_content": dict(fact_content),
+                },
+                evidence_spans=[span],
+                related_entities=related_entities,
+                confidence=max(0.0, min(1.0, float(confidence))),
+            )
+        )
+    return candidates
+
+
+def _build_reasoner_request(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    fact_type: FactType,
+) -> StructuredExtractionRequest | None:
+    hints = _REASONER_HINTS[fact_type]
+    raw_segments: list[tuple[str, str, str, str | None]] = []
+    for index, source in enumerate(iter_evidence_sources(parsed_artifact), start=1):
+        if any(pattern.search(source.text) for pattern in hints):
+            raw_segments.append(
+                (
+                    f"segment-{index:04d}",
+                    source.section_id,
+                    source.text,
+                    source.table_ref,
+                )
+            )
+    segments = bounded_segments(raw_segments)
+    if not segments:
+        return None
+    return StructuredExtractionRequest(
+        announcement_id=parsed_artifact.announcement_id,
+        fact_type=fact_type.value,
+        segments=segments,
+        schema=ex1_reasoner_schema(fact_type.value),
+    )
+
+
+def _span_for_quote(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    quote: str,
+) -> EvidenceSpan | None:
+    normalized_quote = " ".join(quote.split())
+    if not normalized_quote:
+        return None
+    for source in iter_evidence_sources(parsed_artifact):
+        offset = source.text.find(quote)
+        if offset == -1:
+            continue
+        return EvidenceSpan(
+            section_id=source.section_id,
+            start_offset=offset,
+            end_offset=offset + len(quote),
+            quote=quote,
+            table_ref=source.table_ref,
+        )
+    return None
+
+
+def _dedupe_candidates(
+    candidates: Sequence[AnnouncementFactCandidate],
+) -> list[AnnouncementFactCandidate]:
+    deduped: list[AnnouncementFactCandidate] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate.fact_id in seen:
+            continue
+        seen.add(candidate.fact_id)
+        deduped.append(candidate)
+    return deduped
+
+
+__all__ = [
+    "AnnouncementFactCandidate",
+    "EntityAnchor",
+    "EntityAnchorer",
+    "EntityMention",
+    "EntityRegistryClient",
+    "EntityResolution",
+    "EvidenceSpan",
+    "ExtractionContext",
+    "FactType",
+    "ReasonerRuntimeBridge",
+    "StructuredExtractionRequest",
+    "StructuredExtractionSegment",
+    "StructuredReasoner",
+    "build_evidence_span",
+    "build_table_evidence_span",
+    "classify_disclosure_types",
+    "extract_fact_candidates",
+]

--- a/src/subsystem_announcement/extract/candidates.py
+++ b/src/subsystem_announcement/extract/candidates.py
@@ -1,0 +1,221 @@
+"""Ex-1 fact candidate models and construction helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from .entity_anchor import EntityAnchor, EntityAnchorer
+from .evidence import EvidenceSpan
+
+
+class FactType(str, Enum):
+    """Supported Ex-1 announcement fact types."""
+
+    EARNINGS_PREANNOUNCE = "earnings_preannounce"
+    MAJOR_CONTRACT = "major_contract"
+    SHAREHOLDER_CHANGE = "shareholder_change"
+    EQUITY_PLEDGE = "equity_pledge"
+    REGULATORY_ACTION = "regulatory_action"
+    TRADING_HALT_RESUME = "trading_halt_resume"
+    FUNDRAISING_CHANGE = "fundraising_change"
+
+
+FORBIDDEN_PAYLOAD_KEYS = {
+    "submitted_at",
+    "ingest_seq",
+    "layer_b_receipt_id",
+    "local_path",
+}
+
+
+class AnnouncementFactCandidate(BaseModel):
+    """Contract-ready Ex-1 announcement fact candidate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ex_type: Literal["Ex-1"] = "Ex-1"
+    fact_id: str = Field(min_length=1)
+    announcement_id: str = Field(min_length=1)
+    fact_type: FactType
+    primary_entity_id: str = Field(min_length=1)
+    related_entity_ids: list[str] = Field(default_factory=list)
+    fact_content: dict[str, Any] = Field(default_factory=dict)
+    confidence: float = Field(ge=0.0, le=1.0)
+    source_reference: dict[str, Any] = Field(default_factory=dict)
+    evidence_spans: list[EvidenceSpan] = Field(min_length=1)
+    extracted_at: datetime
+
+    @field_validator("extracted_at")
+    @classmethod
+    def require_timezone(cls, value: datetime) -> datetime:
+        """Reject naive extraction timestamps."""
+
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("extracted_at must include timezone information")
+        return value
+
+    @model_validator(mode="after")
+    def validate_source_reference(self) -> "AnnouncementFactCandidate":
+        """Require official source provenance without local ingest metadata."""
+
+        official_url = self.source_reference.get("official_url")
+        if not isinstance(official_url, str) or not official_url.strip():
+            raise ValueError("source_reference.official_url is required")
+        _reject_forbidden_keys(self.model_dump(mode="python"))
+        return self
+
+    def to_ex_payload(self) -> dict[str, Any]:
+        """Return the Ex-1 payload for subsystem-sdk submission."""
+
+        payload = self.model_dump(mode="json")
+        _reject_forbidden_keys(payload)
+        return payload
+
+
+class ExtractionContext(BaseModel):
+    """Shared state used by deterministic and reasoner extractors."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    primary_entity: EntityAnchor
+    source_reference: dict[str, Any]
+    entity_anchorer: EntityAnchorer = Field(exclude=True)
+    entity_registry: Any = Field(default=None, exclude=True)
+    reasoner: Any = Field(default=None, exclude=True)
+
+
+def build_extraction_context(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    *,
+    entity_registry: Any = None,
+    reasoner: Any = None,
+) -> ExtractionContext:
+    """Build shared extraction context from a parsed artifact."""
+
+    anchorer = EntityAnchorer(entity_registry)
+    source_reference = build_source_reference(parsed_artifact)
+    return ExtractionContext(
+        primary_entity=anchorer.anchor_primary_entity(parsed_artifact),
+        source_reference=source_reference,
+        entity_anchorer=anchorer,
+        entity_registry=entity_registry,
+        reasoner=reasoner,
+    )
+
+
+def build_source_reference(
+    parsed_artifact: ParsedAnnouncementArtifact,
+) -> dict[str, Any]:
+    """Build official-source reference without local filesystem metadata."""
+
+    official_url = str(parsed_artifact.source_document.official_url).strip()
+    if not official_url:
+        raise ValueError("official source reference is required")
+    return {
+        "announcement_id": parsed_artifact.announcement_id,
+        "official_url": official_url,
+        "source_exchange": parsed_artifact.source_document.source_exchange,
+        "attachment_type": parsed_artifact.source_document.attachment_type,
+        "content_hash": parsed_artifact.content_hash,
+        "parser_version": parsed_artifact.parser_version,
+    }
+
+
+def build_fact_candidate(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+    *,
+    fact_type: FactType,
+    fact_content: Mapping[str, Any],
+    evidence_spans: Sequence[EvidenceSpan],
+    related_entities: Sequence[EntityAnchor] = (),
+    confidence: float,
+    extracted_at: datetime | None = None,
+) -> AnnouncementFactCandidate:
+    """Create a fact candidate with deterministic identity."""
+
+    related_entity_ids = [entity.identifier for entity in related_entities]
+    content = dict(fact_content)
+    content.setdefault("primary_entity", context.primary_entity.to_payload())
+    if related_entities:
+        content.setdefault(
+            "related_entities",
+            [entity.to_payload() for entity in related_entities],
+        )
+    fact_id = make_fact_id(
+        parsed_artifact.announcement_id,
+        fact_type,
+        evidence_spans,
+        content,
+    )
+    return AnnouncementFactCandidate(
+        fact_id=fact_id,
+        announcement_id=parsed_artifact.announcement_id,
+        fact_type=fact_type,
+        primary_entity_id=context.primary_entity.identifier,
+        related_entity_ids=related_entity_ids,
+        fact_content=content,
+        confidence=confidence,
+        source_reference=context.source_reference,
+        evidence_spans=list(evidence_spans),
+        extracted_at=extracted_at or datetime.now(timezone.utc),
+    )
+
+
+def make_fact_id(
+    announcement_id: str,
+    fact_type: FactType,
+    evidence_spans: Sequence[EvidenceSpan],
+    fact_content: Mapping[str, Any],
+) -> str:
+    """Generate a deterministic fact id for dedupe/replay."""
+
+    evidence_quotes = [
+        " ".join(span.quote.split()) for span in evidence_spans if span.quote.strip()
+    ]
+    payload = {
+        "announcement_id": announcement_id,
+        "fact_type": fact_type.value,
+        "evidence_quotes": evidence_quotes,
+        "fact_content": _stable_jsonable(fact_content),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"fact:{announcement_id}:{fact_type.value}:{digest}"
+
+
+def _stable_jsonable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _stable_jsonable(item)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_stable_jsonable(item) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _reject_forbidden_keys(value: Any, path: str = "") -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            key_text = str(key)
+            if key_text in FORBIDDEN_PAYLOAD_KEYS:
+                raise ValueError(f"Ex-1 payload contains forbidden key: {path}{key_text}")
+            _reject_forbidden_keys(item, f"{path}{key_text}.")
+    elif isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        for index, item in enumerate(value):
+            _reject_forbidden_keys(item, f"{path}{index}.")

--- a/src/subsystem_announcement/extract/classifier.py
+++ b/src/subsystem_announcement/extract/classifier.py
@@ -1,0 +1,48 @@
+"""Disclosure type classifier for parsed announcement artifacts."""
+
+from __future__ import annotations
+
+import re
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from .candidates import FactType
+from .evidence import iter_evidence_sources
+
+
+_DISCLOSURE_PATTERNS: dict[FactType, tuple[re.Pattern[str], ...]] = {
+    FactType.EARNINGS_PREANNOUNCE: (
+        re.compile(r"业绩预告|业绩快报|预计.*(?:净利润|盈利|亏损)|净利润.*同比"),
+    ),
+    FactType.MAJOR_CONTRACT: (
+        re.compile(r"重大合同|签订.*合同|合同金额|中标.*项目|合作协议"),
+    ),
+    FactType.SHAREHOLDER_CHANGE: (
+        re.compile(r"权益变动|持股比例|增持|减持|控股股东|实际控制人|股份变动"),
+    ),
+    FactType.EQUITY_PLEDGE: (
+        re.compile(r"股份质押|股权质押|解除质押|质押.*股份"),
+    ),
+    FactType.REGULATORY_ACTION: (
+        re.compile(r"行政处罚|监管函|纪律处分|立案调查|监管措施|问询函"),
+    ),
+    FactType.TRADING_HALT_RESUME: (
+        re.compile(r"停牌|复牌|恢复交易|暂停交易"),
+    ),
+    FactType.FUNDRAISING_CHANGE: (
+        re.compile(r"募集资金.*变更|变更.*募集资金|募投项目.*变更|发行方案.*调整"),
+    ),
+}
+
+
+def classify_disclosure_types(
+    parsed_artifact: ParsedAnnouncementArtifact,
+) -> set[FactType]:
+    """Classify disclosure types from body sections/tables, not title alone."""
+
+    fact_types: set[FactType] = set()
+    for source in iter_evidence_sources(parsed_artifact):
+        for fact_type, patterns in _DISCLOSURE_PATTERNS.items():
+            if any(pattern.search(source.text) for pattern in patterns):
+                fact_types.add(fact_type)
+    return fact_types

--- a/src/subsystem_announcement/extract/entity_anchor.py
+++ b/src/subsystem_announcement/extract/entity_anchor.py
@@ -1,0 +1,310 @@
+"""Entity anchoring coordination for announcement extraction."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+
+class EntityMention(BaseModel):
+    """A raw entity mention found in announcement text."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    role: str | None = None
+
+
+class EntityResolution(BaseModel):
+    """Resolution returned by an entity registry client."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mention: EntityMention
+    entity_id: str | None = None
+    entity_name: str | None = None
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    unresolved_ref: str | None = None
+    resolution_method: str = "entity_registry"
+
+
+class EntityAnchor(BaseModel):
+    """Entity anchor attached to an extraction candidate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mention_text: str = Field(min_length=1)
+    entity_id: str | None = None
+    entity_name: str | None = None
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    resolution_method: str
+    unresolved_ref: str | None = None
+
+    @property
+    def identifier(self) -> str:
+        """Return a resolved id or an explicit unresolved reference."""
+
+        if self.entity_id:
+            return self.entity_id
+        if self.unresolved_ref:
+            return self.unresolved_ref
+        return _unresolved_ref(self.mention_text)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize anchor details without inventing missing ids."""
+
+        payload: dict[str, Any] = {
+            "mention_text": self.mention_text,
+            "identifier": self.identifier,
+            "resolution_method": self.resolution_method,
+            "confidence": self.confidence,
+        }
+        if self.entity_id is not None:
+            payload["entity_id"] = self.entity_id
+        if self.entity_name is not None:
+            payload["entity_name"] = self.entity_name
+        if self.unresolved_ref is not None:
+            payload["unresolved_ref"] = self.unresolved_ref
+        return payload
+
+
+class EntityRegistryClient(Protocol):
+    """Entity registry surface used by extraction code."""
+
+    def lookup_alias(self, name: str) -> EntityResolution | Mapping[str, Any] | None:
+        """Resolve a deterministic alias quickly."""
+
+    def resolve_mentions(
+        self,
+        mentions: Sequence[EntityMention],
+    ) -> Sequence[EntityResolution | Mapping[str, Any]]:
+        """Resolve fuzzy mentions in batch."""
+
+
+class EntityAnchorer:
+    """Resolve entities in the required deterministic-to-fuzzy order."""
+
+    def __init__(self, registry: EntityRegistryClient | None = None) -> None:
+        self._registry = registry
+
+    def anchor_primary_entity(
+        self,
+        parsed_artifact: ParsedAnnouncementArtifact,
+    ) -> EntityAnchor:
+        """Anchor the announcing company from code/short-name before registry use."""
+
+        text = _artifact_body_text(parsed_artifact)
+        ts_code = _extract_ts_code(text)
+        short_name = _extract_short_name(text)
+        if ts_code is not None:
+            normalized_code = _normalize_ts_code(
+                ts_code,
+                parsed_artifact.source_document.source_exchange,
+            )
+            return EntityAnchor(
+                mention_text=short_name or normalized_code,
+                entity_id=f"ts_code:{normalized_code}",
+                entity_name=short_name,
+                confidence=1.0,
+                resolution_method="ts_code",
+            )
+
+        if short_name is not None:
+            return EntityAnchor(
+                mention_text=short_name,
+                confidence=0.8,
+                resolution_method="company_short_name",
+                unresolved_ref=_unresolved_ref(f"company_short_name:{short_name}"),
+            )
+
+        mention = _primary_name_candidate(parsed_artifact)
+        if mention is not None and self._registry is not None:
+            alias_anchor = self._lookup_alias_anchor(mention)
+            if alias_anchor.entity_id is not None:
+                return alias_anchor
+
+            fuzzy_anchors = self.resolve_related_mentions(
+                [EntityMention(name=mention.name, role="primary_entity")]
+            )
+            if fuzzy_anchors:
+                return fuzzy_anchors[0]
+
+        if mention is None:
+            mention = EntityMention(
+                name=parsed_artifact.announcement_id,
+                role="primary_entity",
+            )
+        return _unresolved_anchor(mention, method="unresolved_primary")
+
+    def resolve_related_mentions(
+        self,
+        mentions: Sequence[EntityMention | str],
+    ) -> list[EntityAnchor]:
+        """Resolve related mentions with alias lookup before fuzzy resolution."""
+
+        normalized_mentions = [_coerce_mention(mention) for mention in mentions]
+        if not normalized_mentions:
+            return []
+        if self._registry is None:
+            return [
+                _unresolved_anchor(mention, method="unresolved_related")
+                for mention in normalized_mentions
+            ]
+
+        anchors_by_name: dict[str, EntityAnchor] = {}
+        unresolved_mentions: list[EntityMention] = []
+        for mention in normalized_mentions:
+            anchor = self._lookup_alias_anchor(mention)
+            if anchor.entity_id is None:
+                unresolved_mentions.append(mention)
+            else:
+                anchors_by_name[mention.name] = anchor
+
+        if unresolved_mentions:
+            fuzzy_results = self._registry.resolve_mentions(unresolved_mentions)
+            for mention, raw_result in zip(unresolved_mentions, fuzzy_results, strict=False):
+                resolution = _coerce_resolution(raw_result, mention)
+                anchor = _anchor_from_resolution(resolution)
+                if anchor.entity_id is None:
+                    anchor = _unresolved_anchor(mention, method="unresolved_related")
+                anchors_by_name[mention.name] = anchor
+
+        return [
+            anchors_by_name.get(mention.name)
+            or _unresolved_anchor(mention, method="unresolved_related")
+            for mention in normalized_mentions
+        ]
+
+    def _lookup_alias_anchor(self, mention: EntityMention) -> EntityAnchor:
+        if self._registry is None:
+            return _unresolved_anchor(mention, method="unresolved_related")
+        raw_result = self._registry.lookup_alias(mention.name)
+        resolution = _coerce_resolution(raw_result, mention)
+        if resolution is None:
+            return _unresolved_anchor(mention, method="lookup_alias")
+        return _anchor_from_resolution(resolution)
+
+
+def _anchor_from_resolution(resolution: EntityResolution) -> EntityAnchor:
+    return EntityAnchor(
+        mention_text=resolution.mention.name,
+        entity_id=resolution.entity_id,
+        entity_name=resolution.entity_name,
+        confidence=resolution.confidence,
+        resolution_method=resolution.resolution_method,
+        unresolved_ref=resolution.unresolved_ref
+        or (None if resolution.entity_id else _unresolved_ref(resolution.mention.name)),
+    )
+
+
+def _coerce_resolution(
+    raw_result: EntityResolution | Mapping[str, Any] | None,
+    mention: EntityMention,
+) -> EntityResolution | None:
+    if raw_result is None:
+        return None
+    if isinstance(raw_result, EntityResolution):
+        return raw_result
+    raw = dict(raw_result)
+    raw_mention = raw.get("mention")
+    if isinstance(raw_mention, EntityMention):
+        coerced_mention = raw_mention
+    elif isinstance(raw_mention, Mapping):
+        coerced_mention = EntityMention.model_validate(raw_mention)
+    elif isinstance(raw_mention, str):
+        coerced_mention = EntityMention(name=raw_mention, role=mention.role)
+    else:
+        coerced_mention = mention
+    return EntityResolution(
+        mention=coerced_mention,
+        entity_id=_optional_str(raw.get("entity_id")),
+        entity_name=_optional_str(raw.get("entity_name")),
+        confidence=float(raw.get("confidence") or 0.0),
+        unresolved_ref=_optional_str(raw.get("unresolved_ref")),
+        resolution_method=_optional_str(raw.get("resolution_method"))
+        or "entity_registry",
+    )
+
+
+def _coerce_mention(mention: EntityMention | str) -> EntityMention:
+    if isinstance(mention, EntityMention):
+        return mention
+    return EntityMention(name=mention)
+
+
+def _unresolved_anchor(mention: EntityMention, *, method: str) -> EntityAnchor:
+    return EntityAnchor(
+        mention_text=mention.name,
+        confidence=0.0,
+        resolution_method=method,
+        unresolved_ref=_unresolved_ref(mention.name),
+    )
+
+
+def _extract_ts_code(text: str) -> str | None:
+    match = re.search(
+        r"(?:证券代码|股票代码|A股代码)\s*[:：]\s*(?P<code>\d{6}(?:\.(?:SH|SZ|BJ))?)",
+        text,
+        re.IGNORECASE,
+    )
+    return match.group("code") if match else None
+
+
+def _extract_short_name(text: str) -> str | None:
+    match = re.search(
+        r"(?:证券简称|股票简称|公司简称)\s*[:：]\s*(?P<name>[^\s，,；;。]{2,20})",
+        text,
+    )
+    return match.group("name") if match else None
+
+
+def _primary_name_candidate(
+    parsed_artifact: ParsedAnnouncementArtifact,
+) -> EntityMention | None:
+    text = _artifact_body_text(parsed_artifact)
+    match = re.search(r"(?:公司名称|发行人)\s*[:：]\s*(?P<name>[^\s，,；;。]{2,40})", text)
+    if match:
+        return EntityMention(name=match.group("name"), role="primary_entity")
+    for title in parsed_artifact.title_hierarchy:
+        cleaned = re.sub(r"(公告|报告|提示性公告)$", "", title).strip()
+        if 2 <= len(cleaned) <= 40:
+            return EntityMention(name=cleaned, role="primary_entity")
+    return None
+
+
+def _artifact_body_text(parsed_artifact: ParsedAnnouncementArtifact) -> str:
+    return "\n".join(section.text for section in parsed_artifact.sections)
+
+
+def _normalize_ts_code(code: str, source_exchange: str) -> str:
+    code = code.upper()
+    if "." in code:
+        return code
+    exchange = source_exchange.lower()
+    suffix = {
+        "sse": "SH",
+        "sh": "SH",
+        "szse": "SZ",
+        "sz": "SZ",
+        "bse": "BJ",
+        "neeq": "BJ",
+    }.get(exchange)
+    return f"{code}.{suffix}" if suffix else code
+
+
+def _unresolved_ref(value: str) -> str:
+    digest = hashlib.sha256(" ".join(value.split()).encode("utf-8")).hexdigest()[:12]
+    return f"unresolved:{digest}"
+
+
+def _optional_str(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None

--- a/src/subsystem_announcement/extract/evidence.py
+++ b/src/subsystem_announcement/extract/evidence.py
@@ -1,0 +1,220 @@
+"""Evidence span helpers for announcement extraction."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Pattern
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from subsystem_announcement.parse.artifact import (
+    AnnouncementSection,
+    AnnouncementTable,
+    ParsedAnnouncementArtifact,
+)
+
+
+class EvidenceSpan(BaseModel):
+    """A reproducible quote inside a parsed announcement section or table."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    section_id: str = Field(min_length=1)
+    start_offset: int = Field(ge=0)
+    end_offset: int = Field(ge=0)
+    quote: str = Field(min_length=1)
+    table_ref: str | None = None
+
+    @model_validator(mode="after")
+    def validate_offsets_match_quote(self) -> "EvidenceSpan":
+        """Keep span offsets and quote length internally consistent."""
+
+        if self.end_offset <= self.start_offset:
+            raise ValueError("end_offset must be greater than start_offset")
+        if self.end_offset - self.start_offset != len(self.quote):
+            raise ValueError("quote length must match end_offset - start_offset")
+        if not self.quote.strip():
+            raise ValueError("quote must contain non-whitespace evidence")
+        return self
+
+
+@dataclass(frozen=True)
+class EvidenceSource:
+    """Searchable text source backed by a section or rendered table."""
+
+    section_id: str
+    text: str
+    table_ref: str | None = None
+
+
+PatternLike = str | Pattern[str]
+
+
+def build_evidence_span(
+    section: AnnouncementSection,
+    start_offset: int,
+    end_offset: int,
+    *,
+    table_ref: str | None = None,
+) -> EvidenceSpan:
+    """Build an evidence span using offsets relative to ``section.text``."""
+
+    quote = _slice_text(section.text, start_offset, end_offset)
+    return EvidenceSpan(
+        section_id=section.section_id,
+        start_offset=start_offset,
+        end_offset=end_offset,
+        quote=quote,
+        table_ref=table_ref,
+    )
+
+
+def build_table_evidence_span(
+    table: AnnouncementTable,
+    start_offset: int,
+    end_offset: int,
+) -> EvidenceSpan:
+    """Build an evidence span using offsets relative to rendered table text."""
+
+    text = render_table_text(table)
+    quote = _slice_text(text, start_offset, end_offset)
+    return EvidenceSpan(
+        section_id=table.section_id,
+        start_offset=start_offset,
+        end_offset=end_offset,
+        quote=quote,
+        table_ref=table.table_id,
+    )
+
+
+def iter_evidence_sources(
+    parsed_artifact: ParsedAnnouncementArtifact,
+) -> Iterable[EvidenceSource]:
+    """Yield section text and rendered table text for classification/extraction."""
+
+    for section in parsed_artifact.sections:
+        yield EvidenceSource(section_id=section.section_id, text=section.text)
+    for table in parsed_artifact.tables:
+        text = render_table_text(table)
+        if text:
+            yield EvidenceSource(
+                section_id=table.section_id,
+                text=text,
+                table_ref=table.table_id,
+            )
+
+
+def render_table_text(table: AnnouncementTable) -> str:
+    """Render a normalized table the same way parse normalization does."""
+
+    lines: list[str] = []
+    if table.caption:
+        lines.append(_clean_text(table.caption))
+    if table.headers:
+        lines.append("\t".join(_clean_cell(header) for header in table.headers))
+    for row in table.rows:
+        lines.append("\t".join(_clean_cell(cell) for cell in row))
+    return _clean_text("\n".join(lines))
+
+
+def find_evidence_span(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    patterns: Sequence[PatternLike],
+) -> EvidenceSpan | None:
+    """Find the first sentence-level evidence span matching any pattern."""
+
+    for source in iter_evidence_sources(parsed_artifact):
+        for pattern in patterns:
+            match = _search(pattern, source.text)
+            if match is None:
+                continue
+            start_offset, end_offset = _sentence_bounds(
+                source.text,
+                match.start(),
+                match.end(),
+            )
+            quote = source.text[start_offset:end_offset]
+            return EvidenceSpan(
+                section_id=source.section_id,
+                start_offset=start_offset,
+                end_offset=end_offset,
+                quote=quote,
+                table_ref=source.table_ref,
+            )
+    return None
+
+
+def quote_from_artifact(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    span: EvidenceSpan,
+) -> str:
+    """Reconstruct a span quote from its parsed artifact source."""
+
+    if span.table_ref is not None:
+        for table in parsed_artifact.tables:
+            if table.table_id == span.table_ref:
+                return render_table_text(table)[span.start_offset : span.end_offset]
+        raise ValueError(f"unknown table_ref: {span.table_ref}")
+
+    for section in parsed_artifact.sections:
+        if section.section_id == span.section_id:
+            return section.text[span.start_offset : span.end_offset]
+    raise ValueError(f"unknown section_id: {span.section_id}")
+
+
+def evidence_matches_artifact(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    span: EvidenceSpan,
+) -> bool:
+    """Return whether a span can be reconstructed exactly from the artifact."""
+
+    try:
+        return quote_from_artifact(parsed_artifact, span) == span.quote
+    except ValueError:
+        return False
+
+
+def _slice_text(text: str, start_offset: int, end_offset: int) -> str:
+    if start_offset < 0 or end_offset > len(text) or end_offset <= start_offset:
+        raise ValueError("evidence offsets are outside source text")
+    return text[start_offset:end_offset]
+
+
+def _search(pattern: PatternLike, text: str) -> re.Match[str] | None:
+    if isinstance(pattern, str):
+        return re.search(re.escape(pattern), text)
+    return pattern.search(text)
+
+
+def _sentence_bounds(text: str, start: int, end: int) -> tuple[int, int]:
+    sentence_start = max(
+        text.rfind("。", 0, start),
+        text.rfind("！", 0, start),
+        text.rfind("？", 0, start),
+        text.rfind("\n", 0, start),
+    )
+    sentence_start = 0 if sentence_start == -1 else sentence_start + 1
+
+    sentence_end_candidates = [
+        index
+        for marker in ("。", "！", "？", "\n")
+        if (index := text.find(marker, end)) != -1
+    ]
+    sentence_end = min(sentence_end_candidates) + 1 if sentence_end_candidates else len(text)
+
+    if sentence_end - sentence_start > 320:
+        window_start = max(0, start - 120)
+        window_end = min(len(text), end + 180)
+        return window_start, window_end
+    return sentence_start, sentence_end
+
+
+def _clean_cell(value: object) -> str:
+    return " ".join(str(value).split())
+
+
+def _clean_text(value: str) -> str:
+    lines = [" ".join(line.split()) for line in value.splitlines()]
+    return "\n".join(line for line in lines if line).strip()

--- a/src/subsystem_announcement/extract/reasoner_bridge.py
+++ b/src/subsystem_announcement/extract/reasoner_bridge.py
@@ -1,0 +1,120 @@
+"""Bridge to reasoner-runtime for difficult structured extraction."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StructuredExtractionSegment(BaseModel):
+    """Bounded text/table segment sent to reasoner-runtime."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    segment_id: str = Field(min_length=1)
+    section_id: str = Field(min_length=1)
+    text: str = Field(min_length=1, max_length=2_000)
+    table_ref: str | None = None
+
+
+class StructuredExtractionRequest(BaseModel):
+    """Reasoner request that avoids sending unbounded full documents."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    announcement_id: str = Field(min_length=1)
+    fact_type: str = Field(min_length=1)
+    segments: list[StructuredExtractionSegment] = Field(min_length=1, max_length=5)
+    extraction_schema: dict[str, Any] = Field(alias="schema")
+
+    @property
+    def schema(self) -> dict[str, Any]:
+        """Expose the request schema under the contract-facing name."""
+
+        return self.extraction_schema
+
+
+class StructuredReasoner(Protocol):
+    """Narrow structured generation surface used by this subsystem."""
+
+    def generate_structured(
+        self,
+        request: StructuredExtractionRequest,
+    ) -> Mapping[str, Any]:
+        """Generate structured extraction output."""
+
+
+class ReasonerRuntimeBridge:
+    """Adapter around ``reasoner_runtime.generate_structured``."""
+
+    def __init__(self, *, endpoint: str | None = None) -> None:
+        self.endpoint = endpoint
+
+    def generate_structured(
+        self,
+        request: StructuredExtractionRequest,
+    ) -> Mapping[str, Any]:
+        """Call reasoner-runtime without importing provider SDKs."""
+
+        reasoner_runtime = importlib.import_module("reasoner_runtime")
+        payload = request.model_dump(mode="json", by_alias=True)
+        if self.endpoint is not None:
+            payload["endpoint"] = self.endpoint
+        result = reasoner_runtime.generate_structured(payload)
+        if not isinstance(result, Mapping):
+            raise TypeError("reasoner_runtime.generate_structured returned non-mapping")
+        return result
+
+
+def ex1_reasoner_schema(fact_type: str) -> dict[str, Any]:
+    """Return the minimal schema requested from the reasoner."""
+
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "facts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "required": ["quote", "fact_content"],
+                    "properties": {
+                        "quote": {"type": "string"},
+                        "fact_content": {"type": "object"},
+                        "confidence": {"type": "number"},
+                        "related_mentions": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                },
+            }
+        },
+        "required": ["facts"],
+        "x-fact-type": fact_type,
+    }
+
+
+def bounded_segments(
+    segments: Sequence[tuple[str, str, str, str | None]],
+) -> list[StructuredExtractionSegment]:
+    """Coerce raw segment tuples into the bounded request model."""
+
+    bounded: list[StructuredExtractionSegment] = []
+    for segment_id, section_id, text, table_ref in segments[:5]:
+        stripped = text.strip()
+        if not stripped:
+            continue
+        bounded.append(
+            StructuredExtractionSegment(
+                segment_id=segment_id,
+                section_id=section_id,
+                text=stripped[:2_000],
+                table_ref=table_ref,
+            )
+        )
+    return bounded

--- a/src/subsystem_announcement/extract/rules/__init__.py
+++ b/src/subsystem_announcement/extract/rules/__init__.py
@@ -1,0 +1,83 @@
+"""Shared helpers for deterministic announcement fact extractors."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, Pattern
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from subsystem_announcement.extract.candidates import (
+    AnnouncementFactCandidate,
+    ExtractionContext,
+    FactType,
+    build_fact_candidate,
+)
+from subsystem_announcement.extract.entity_anchor import EntityMention
+from subsystem_announcement.extract.evidence import EvidenceSpan, find_evidence_span
+
+
+PatternLike = str | Pattern[str]
+
+
+def build_single_evidence_candidate(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+    *,
+    fact_type: FactType,
+    evidence_patterns: Sequence[PatternLike] = (),
+    span: EvidenceSpan | None = None,
+    fact_content: Mapping[str, Any],
+    related_mention_patterns: Sequence[Pattern[str]] = (),
+    confidence: float = 0.86,
+) -> list[AnnouncementFactCandidate]:
+    """Build one deterministic candidate when body evidence is present."""
+
+    evidence_span = span or find_evidence_span(parsed_artifact, evidence_patterns)
+    if evidence_span is None:
+        return []
+    related_mentions = _related_mentions(evidence_span, related_mention_patterns)
+    related_entities = context.entity_anchorer.resolve_related_mentions(related_mentions)
+    content = {
+        "disclosure_type": fact_type.value,
+        "summary": evidence_span.quote,
+        **dict(fact_content),
+    }
+    return [
+        build_fact_candidate(
+            parsed_artifact,
+            context,
+            fact_type=fact_type,
+            fact_content=content,
+            evidence_spans=[evidence_span],
+            related_entities=related_entities,
+            confidence=confidence,
+        )
+    ]
+
+
+def keyword_present(span: EvidenceSpan, keyword: str) -> bool:
+    """Return whether a quote contains a keyword."""
+
+    return keyword in span.quote
+
+
+def _related_mentions(
+    span: EvidenceSpan,
+    patterns: Sequence[Pattern[str]],
+) -> list[EntityMention]:
+    mentions: list[EntityMention] = []
+    seen: set[str] = set()
+    for pattern in patterns:
+        for match in pattern.finditer(span.quote):
+            name = (match.groupdict().get("name") or match.group(1)).strip()
+            name = re.sub(r"^(?:公司|与|收到|股东)", "", name).strip(" ：:，,")
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            mentions.append(EntityMention(name=name, role="related_entity"))
+    return mentions
+
+
+__all__ = ["build_single_evidence_candidate", "keyword_present"]

--- a/src/subsystem_announcement/extract/rules/earnings.py
+++ b/src/subsystem_announcement/extract/rules/earnings.py
@@ -1,0 +1,45 @@
+"""Deterministic extraction for earnings preannouncement facts."""
+
+from __future__ import annotations
+
+import re
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from subsystem_announcement.extract.candidates import (
+    AnnouncementFactCandidate,
+    ExtractionContext,
+    FactType,
+)
+
+from . import build_single_evidence_candidate
+from subsystem_announcement.extract.evidence import find_evidence_span
+
+
+_PATTERNS = (
+    re.compile(r"业绩预告|预计.*(?:净利润|盈利|亏损)|净利润.*同比"),
+)
+
+
+def extract(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+) -> list[AnnouncementFactCandidate]:
+    """Extract earnings preannouncement facts."""
+
+    span = find_evidence_span(parsed_artifact, _PATTERNS)
+    if span is None:
+        return []
+    direction = "uncertain"
+    if "亏损" in span.quote or "下降" in span.quote or "减少" in span.quote:
+        direction = "negative"
+    elif "增长" in span.quote or "增加" in span.quote or "盈利" in span.quote:
+        direction = "positive"
+    return build_single_evidence_candidate(
+        parsed_artifact,
+        context,
+        fact_type=FactType.EARNINGS_PREANNOUNCE,
+        span=span,
+        fact_content={"performance_direction": direction},
+        confidence=0.88,
+    )

--- a/src/subsystem_announcement/extract/rules/equity_pledge.py
+++ b/src/subsystem_announcement/extract/rules/equity_pledge.py
@@ -1,0 +1,45 @@
+"""Deterministic extraction for equity pledge facts."""
+
+from __future__ import annotations
+
+import re
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from subsystem_announcement.extract.candidates import (
+    AnnouncementFactCandidate,
+    ExtractionContext,
+    FactType,
+)
+
+from . import build_single_evidence_candidate
+from subsystem_announcement.extract.evidence import find_evidence_span
+
+
+_PATTERNS = (
+    re.compile(r"股份质押|股权质押|解除质押|质押.*股份"),
+)
+_RELATED_PATTERNS = (
+    re.compile(r"(?:股东|质押人)(?P<name>[^，。；;]{2,40})"),
+)
+
+
+def extract(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+) -> list[AnnouncementFactCandidate]:
+    """Extract equity pledge facts."""
+
+    span = find_evidence_span(parsed_artifact, _PATTERNS)
+    if span is None:
+        return []
+    pledge_action = "release" if "解除质押" in span.quote else "pledge"
+    return build_single_evidence_candidate(
+        parsed_artifact,
+        context,
+        fact_type=FactType.EQUITY_PLEDGE,
+        span=span,
+        fact_content={"pledge_action": pledge_action},
+        related_mention_patterns=_RELATED_PATTERNS,
+        confidence=0.88,
+    )

--- a/src/subsystem_announcement/extract/rules/fundraising.py
+++ b/src/subsystem_announcement/extract/rules/fundraising.py
@@ -1,0 +1,36 @@
+"""Deterministic extraction for fundraising change facts."""
+
+from __future__ import annotations
+
+import re
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from subsystem_announcement.extract.candidates import (
+    AnnouncementFactCandidate,
+    ExtractionContext,
+    FactType,
+)
+
+from . import build_single_evidence_candidate
+
+
+_PATTERNS = (
+    re.compile(r"募集资金.*变更|变更.*募集资金|募投项目.*变更|发行方案.*调整"),
+)
+
+
+def extract(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+) -> list[AnnouncementFactCandidate]:
+    """Extract fundraising change facts."""
+
+    return build_single_evidence_candidate(
+        parsed_artifact,
+        context,
+        fact_type=FactType.FUNDRAISING_CHANGE,
+        evidence_patterns=_PATTERNS,
+        fact_content={"fundraising_change_type": "use_or_plan_change"},
+        confidence=0.86,
+    )

--- a/src/subsystem_announcement/extract/rules/major_contract.py
+++ b/src/subsystem_announcement/extract/rules/major_contract.py
@@ -1,0 +1,41 @@
+"""Deterministic extraction for major contract facts."""
+
+from __future__ import annotations
+
+import re
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from subsystem_announcement.extract.candidates import (
+    AnnouncementFactCandidate,
+    ExtractionContext,
+    FactType,
+)
+
+from . import build_single_evidence_candidate
+
+
+_PATTERNS = (
+    re.compile(r"重大合同|签订.*合同|合同金额|中标.*项目"),
+)
+_RELATED_PATTERNS = (
+    re.compile(r"与(?P<name>[^，。；;]{2,40}?)(?:签订|签署|订立)"),
+    re.compile(r"中标(?P<name>[^，。；;]{2,40}?)(?:项目|工程)"),
+)
+
+
+def extract(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+) -> list[AnnouncementFactCandidate]:
+    """Extract major contract facts."""
+
+    return build_single_evidence_candidate(
+        parsed_artifact,
+        context,
+        fact_type=FactType.MAJOR_CONTRACT,
+        evidence_patterns=_PATTERNS,
+        fact_content={"event": "major_contract"},
+        related_mention_patterns=_RELATED_PATTERNS,
+        confidence=0.9,
+    )

--- a/src/subsystem_announcement/extract/rules/regulatory.py
+++ b/src/subsystem_announcement/extract/rules/regulatory.py
@@ -1,0 +1,50 @@
+"""Deterministic extraction for regulatory action facts."""
+
+from __future__ import annotations
+
+import re
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from subsystem_announcement.extract.candidates import (
+    AnnouncementFactCandidate,
+    ExtractionContext,
+    FactType,
+)
+
+from . import build_single_evidence_candidate
+from subsystem_announcement.extract.evidence import find_evidence_span
+
+
+_PATTERNS = (
+    re.compile(r"行政处罚|监管函|纪律处分|立案调查|监管措施|问询函"),
+)
+_RELATED_PATTERNS = (
+    re.compile(r"收到(?P<name>[^，。；;]{2,40}?)(?:出具|下发|送达|发出)"),
+)
+
+
+def extract(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+) -> list[AnnouncementFactCandidate]:
+    """Extract regulatory action facts."""
+
+    span = find_evidence_span(parsed_artifact, _PATTERNS)
+    if span is None:
+        return []
+    if "行政处罚" in span.quote:
+        action_type = "administrative_penalty"
+    elif "立案调查" in span.quote:
+        action_type = "investigation"
+    else:
+        action_type = "regulatory_notice"
+    return build_single_evidence_candidate(
+        parsed_artifact,
+        context,
+        fact_type=FactType.REGULATORY_ACTION,
+        span=span,
+        fact_content={"regulatory_action_type": action_type},
+        related_mention_patterns=_RELATED_PATTERNS,
+        confidence=0.87,
+    )

--- a/src/subsystem_announcement/extract/rules/shareholder.py
+++ b/src/subsystem_announcement/extract/rules/shareholder.py
@@ -1,0 +1,51 @@
+"""Deterministic extraction for shareholder change facts."""
+
+from __future__ import annotations
+
+import re
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from subsystem_announcement.extract.candidates import (
+    AnnouncementFactCandidate,
+    ExtractionContext,
+    FactType,
+)
+
+from . import build_single_evidence_candidate
+from subsystem_announcement.extract.evidence import find_evidence_span
+
+
+_PATTERNS = (
+    re.compile(r"权益变动|持股比例|增持|减持|控股股东|实际控制人|股份变动"),
+)
+_RELATED_PATTERNS = (
+    re.compile(r"(?:股东|控股股东|实际控制人)(?P<name>[^，。；;]{2,40})"),
+)
+
+
+def extract(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+) -> list[AnnouncementFactCandidate]:
+    """Extract shareholder change facts."""
+
+    span = find_evidence_span(parsed_artifact, _PATTERNS)
+    if span is None:
+        return []
+    change_type = "change"
+    if "减持" in span.quote:
+        change_type = "decrease"
+    elif "增持" in span.quote:
+        change_type = "increase"
+    elif "控股股东" in span.quote or "实际控制人" in span.quote:
+        change_type = "control_change"
+    return build_single_evidence_candidate(
+        parsed_artifact,
+        context,
+        fact_type=FactType.SHAREHOLDER_CHANGE,
+        span=span,
+        fact_content={"shareholder_change_type": change_type},
+        related_mention_patterns=_RELATED_PATTERNS,
+        confidence=0.87,
+    )

--- a/src/subsystem_announcement/extract/rules/trading.py
+++ b/src/subsystem_announcement/extract/rules/trading.py
@@ -1,0 +1,41 @@
+"""Deterministic extraction for trading halt/resume facts."""
+
+from __future__ import annotations
+
+import re
+
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+from subsystem_announcement.extract.candidates import (
+    AnnouncementFactCandidate,
+    ExtractionContext,
+    FactType,
+)
+
+from . import build_single_evidence_candidate
+from subsystem_announcement.extract.evidence import find_evidence_span
+
+
+_PATTERNS = (
+    re.compile(r"停牌|复牌|恢复交易|暂停交易"),
+)
+
+
+def extract(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    context: ExtractionContext,
+) -> list[AnnouncementFactCandidate]:
+    """Extract trading halt/resume facts."""
+
+    span = find_evidence_span(parsed_artifact, _PATTERNS)
+    if span is None:
+        return []
+    trading_status = "resume" if "复牌" in span.quote or "恢复交易" in span.quote else "halt"
+    return build_single_evidence_candidate(
+        parsed_artifact,
+        context,
+        fact_type=FactType.TRADING_HALT_RESUME,
+        span=span,
+        fact_content={"trading_status": trading_status},
+        confidence=0.89,
+    )

--- a/tests/contracts/test_ex1_contract.py
+++ b/tests/contracts/test_ex1_contract.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import inspect
+import re
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+import subsystem_announcement.extract.reasoner_bridge as reasoner_bridge
+from subsystem_announcement.extract import AnnouncementFactCandidate, extract_fact_candidates
+
+from tests.extract_fixtures import make_artifact
+
+
+FORBIDDEN_KEYS = {"submitted_at", "ingest_seq", "layer_b_receipt_id", "local_path"}
+
+
+def test_ex1_payload_shape_and_forbidden_metadata() -> None:
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n公司与华东能源签订重大合同，合同金额为1000万元。",
+        announcement_id="ann-contract",
+    )
+    fact = extract_fact_candidates(artifact)[0]
+
+    payload = fact.to_ex_payload()
+
+    assert payload["ex_type"] == "Ex-1"
+    assert payload["fact_id"]
+    assert payload["announcement_id"] == "ann-contract"
+    assert payload["fact_type"] == "major_contract"
+    assert payload["primary_entity_id"] == "ts_code:600000.SH"
+    assert payload["confidence"] > 0
+    assert payload["source_reference"]["official_url"].startswith("https://")
+    assert payload["evidence_spans"]
+    _assert_no_forbidden_keys(payload)
+
+
+def test_ex1_candidate_requires_official_source_reference() -> None:
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n公司与华东能源签订重大合同。",
+    )
+    data = extract_fact_candidates(artifact)[0].model_dump()
+    data["source_reference"] = {}
+
+    with pytest.raises(ValidationError, match="official_url"):
+        AnnouncementFactCandidate.model_validate(data)
+
+
+def test_reasoner_bridge_does_not_import_provider_sdks() -> None:
+    source = inspect.getsource(reasoner_bridge)
+
+    assert re.search(r"\b(openai|anthropic|dashscope)\b", source) is None
+    assert "reasoner_runtime" in source
+
+
+def _assert_no_forbidden_keys(value: Any) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            assert key not in FORBIDDEN_KEYS
+            _assert_no_forbidden_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_forbidden_keys(item)

--- a/tests/extract_fixtures.py
+++ b/tests/extract_fixtures.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from subsystem_announcement.discovery.document import AnnouncementDocumentArtifact
+from subsystem_announcement.parse.artifact import (
+    AnnouncementSection,
+    AnnouncementTable,
+    ParsedAnnouncementArtifact,
+)
+
+
+def make_artifact(
+    text: str,
+    *,
+    announcement_id: str = "ann-extract-1",
+    title: str = "测试公告",
+    source_exchange: str = "sse",
+    tables: list[AnnouncementTable] | None = None,
+) -> ParsedAnnouncementArtifact:
+    table_text = ""
+    if tables:
+        rendered_tables = []
+        for table in tables:
+            lines = []
+            if table.caption:
+                lines.append(table.caption)
+            if table.headers:
+                lines.append("\t".join(table.headers))
+            lines.extend("\t".join(row) for row in table.rows)
+            rendered_tables.append("\n".join(lines))
+        table_text = "\n\n" + "\n\n".join(rendered_tables)
+    extracted_text = text + table_text
+    return ParsedAnnouncementArtifact(
+        announcement_id=announcement_id,
+        content_hash="a" * 64,
+        parser_version="docling==2.15.1",
+        title_hierarchy=[title],
+        sections=[
+            AnnouncementSection(
+                section_id="sec-0001",
+                title=title,
+                level=1,
+                text=text,
+                start_offset=0,
+                end_offset=len(text),
+                parent_id=None,
+            )
+        ],
+        tables=tables or [],
+        extracted_text=extracted_text,
+        parsed_at=datetime(2026, 4, 18, 9, 31, tzinfo=timezone.utc),
+        source_document=AnnouncementDocumentArtifact(
+            announcement_id=announcement_id,
+            content_hash="a" * 64,
+            official_url=f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf",
+            source_exchange=source_exchange,
+            attachment_type="pdf",
+            local_path=Path("fixtures") / f"{announcement_id}.pdf",
+            content_type="application/pdf",
+            byte_size=100,
+            fetched_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+        ),
+    )

--- a/tests/test_extract_classifier.py
+++ b/tests/test_extract_classifier.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from subsystem_announcement.extract import FactType, classify_disclosure_types
+
+from .extract_fixtures import make_artifact
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("公司预计2026年净利润同比增长50%，本公告为业绩预告。", FactType.EARNINGS_PREANNOUNCE),
+        ("公司与客户签订重大合同，合同金额为1000万元。", FactType.MAJOR_CONTRACT),
+        ("公司股东明德投资减持股份后持股比例降至5%。", FactType.SHAREHOLDER_CHANGE),
+        ("公司股东明德投资将其持有股份质押。", FactType.EQUITY_PLEDGE),
+        ("公司收到上海证券交易所出具的监管函。", FactType.REGULATORY_ACTION),
+        ("公司股票将于2026年4月20日开市起复牌并恢复交易。", FactType.TRADING_HALT_RESUME),
+        ("公司拟变更募集资金用途，调整募投项目。", FactType.FUNDRAISING_CHANGE),
+    ],
+)
+def test_classify_disclosure_types_from_body_text(
+    body: str,
+    expected: FactType,
+) -> None:
+    artifact = make_artifact(body, title="普通提示公告")
+
+    assert expected in classify_disclosure_types(artifact)
+
+
+def test_classifier_does_not_emit_when_only_title_matches() -> None:
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n公司日常经营情况正常。",
+        title="重大合同公告",
+    )
+
+    assert FactType.MAJOR_CONTRACT not in classify_disclosure_types(artifact)

--- a/tests/test_extract_entity_anchor.py
+++ b/tests/test_extract_entity_anchor.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from subsystem_announcement.extract.entity_anchor import (
+    EntityAnchorer,
+    EntityMention,
+    EntityResolution,
+)
+
+from .extract_fixtures import make_artifact
+
+
+class FakeEntityRegistry:
+    def __init__(self) -> None:
+        self.lookup_calls: list[str] = []
+        self.resolve_calls: list[list[str]] = []
+        self.alias_results: dict[str, Mapping[str, Any] | None] = {}
+        self.fuzzy_results: dict[str, Mapping[str, Any] | None] = {}
+
+    def lookup_alias(self, name: str) -> Mapping[str, Any] | None:
+        self.lookup_calls.append(name)
+        return self.alias_results.get(name)
+
+    def resolve_mentions(
+        self,
+        mentions: Sequence[EntityMention],
+    ) -> list[Mapping[str, Any]]:
+        self.resolve_calls.append([mention.name for mention in mentions])
+        return [
+            self.fuzzy_results.get(mention.name)
+            or {
+                "mention": mention,
+                "unresolved_ref": f"unresolved:{mention.name}",
+                "resolution_method": "resolve_mentions",
+            }
+            for mention in mentions
+        ]
+
+
+def test_ts_code_primary_anchor_is_deterministic_without_registry_calls() -> None:
+    registry = FakeEntityRegistry()
+    artifact = make_artifact("证券代码：600000\n证券简称：浦发银行\n公司预计净利润增长。")
+
+    anchor = EntityAnchorer(registry).anchor_primary_entity(artifact)
+
+    assert anchor.entity_id == "ts_code:600000.SH"
+    assert anchor.entity_name == "浦发银行"
+    assert registry.lookup_calls == []
+    assert registry.resolve_calls == []
+
+
+def test_lookup_alias_runs_after_deterministic_primary_failure() -> None:
+    registry = FakeEntityRegistry()
+    registry.alias_results["测试股份"] = {
+        "mention": "测试股份",
+        "entity_id": "entity-001",
+        "entity_name": "测试股份有限公司",
+        "confidence": 0.95,
+        "resolution_method": "lookup_alias",
+    }
+    artifact = make_artifact("公司名称：测试股份\n公司与客户签订重大合同。")
+
+    anchor = EntityAnchorer(registry).anchor_primary_entity(artifact)
+
+    assert anchor.entity_id == "entity-001"
+    assert registry.lookup_calls == ["测试股份"]
+    assert registry.resolve_calls == []
+
+
+def test_fuzzy_resolver_runs_for_unresolved_related_mentions() -> None:
+    registry = FakeEntityRegistry()
+    registry.fuzzy_results["模糊客户"] = {
+        "mention": "模糊客户",
+        "entity_id": "entity-fuzzy",
+        "entity_name": "模糊客户有限公司",
+        "confidence": 0.72,
+        "resolution_method": "resolve_mentions",
+    }
+
+    anchors = EntityAnchorer(registry).resolve_related_mentions(
+        [EntityMention(name="模糊客户", role="counterparty")]
+    )
+
+    assert anchors[0].entity_id == "entity-fuzzy"
+    assert registry.lookup_calls == ["模糊客户"]
+    assert registry.resolve_calls == [["模糊客户"]]
+
+
+def test_unresolved_mentions_keep_explicit_unresolved_reference() -> None:
+    anchor = EntityAnchorer().resolve_related_mentions(["未知客户"])[0]
+
+    assert anchor.entity_id is None
+    assert anchor.identifier.startswith("unresolved:")
+
+
+def test_entity_resolution_model_accepts_unresolved_ref() -> None:
+    resolution = EntityResolution(
+        mention=EntityMention(name="未知客户"),
+        unresolved_ref="unresolved:abc",
+        resolution_method="resolve_mentions",
+    )
+
+    assert resolution.entity_id is None
+    assert resolution.unresolved_ref == "unresolved:abc"

--- a/tests/test_extract_evidence.py
+++ b/tests/test_extract_evidence.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from subsystem_announcement.extract.evidence import (
+    EvidenceSpan,
+    build_evidence_span,
+    build_table_evidence_span,
+    evidence_matches_artifact,
+    quote_from_artifact,
+)
+from subsystem_announcement.parse.artifact import AnnouncementTable
+
+from .extract_fixtures import make_artifact
+
+
+def test_build_evidence_span_reconstructs_section_quote() -> None:
+    artifact = make_artifact("公司签订重大合同，合同金额为1000万元。")
+    section = artifact.sections[0]
+    start = section.text.index("重大合同")
+    end = start + len("重大合同")
+
+    span = build_evidence_span(section, start, end)
+
+    assert span.quote == "重大合同"
+    assert quote_from_artifact(artifact, span) == "重大合同"
+    assert evidence_matches_artifact(artifact, span)
+
+
+def test_evidence_span_rejects_quote_offset_mismatch() -> None:
+    with pytest.raises(ValidationError, match="quote length"):
+        EvidenceSpan(
+            section_id="sec-0001",
+            start_offset=0,
+            end_offset=3,
+            quote="重大合同",
+            table_ref=None,
+        )
+
+
+def test_build_table_evidence_span_reconstructs_table_quote() -> None:
+    section_text = "公司签订重大合同。"
+    table_text = "项目\t金额\n合同\t1000万元"
+    table_start = len(section_text) + 2
+    table = AnnouncementTable(
+        table_id="tbl-0001",
+        section_id="sec-0001",
+        caption=None,
+        headers=["项目", "金额"],
+        rows=[["合同", "1000万元"]],
+        start_offset=table_start,
+        end_offset=table_start + len(table_text),
+    )
+    artifact = make_artifact(section_text, tables=[table])
+    start = table_text.index("1000万元")
+    end = start + len("1000万元")
+
+    span = build_table_evidence_span(table, start, end)
+
+    assert span.table_ref == "tbl-0001"
+    assert quote_from_artifact(artifact, span) == "1000万元"
+    assert evidence_matches_artifact(artifact, span)

--- a/tests/test_extract_fact_candidates.py
+++ b/tests/test_extract_fact_candidates.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import pytest
+
+import subsystem_announcement.extract as extract_module
+from subsystem_announcement.extract import (
+    FactType,
+    StructuredExtractionRequest,
+    extract_fact_candidates,
+)
+from subsystem_announcement.extract.evidence import evidence_matches_artifact
+
+from .extract_fixtures import make_artifact
+
+
+PREFIX = "证券代码：600000\n证券简称：测试公司\n"
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (
+            "公司预计2026年净利润同比增长50%，本公告为业绩预告。",
+            FactType.EARNINGS_PREANNOUNCE,
+        ),
+        ("公司与华东能源签订重大合同，合同金额为1000万元。", FactType.MAJOR_CONTRACT),
+        ("公司股东明德投资减持股份后持股比例降至5%。", FactType.SHAREHOLDER_CHANGE),
+        ("公司股东明德投资将其持有的1000万股股份质押。", FactType.EQUITY_PLEDGE),
+        ("公司收到上海证券交易所出具的监管函。", FactType.REGULATORY_ACTION),
+        ("公司股票将于2026年4月20日开市起复牌并恢复交易。", FactType.TRADING_HALT_RESUME),
+        ("公司拟变更募集资金用途，调整募投项目。", FactType.FUNDRAISING_CHANGE),
+    ],
+)
+def test_extract_fact_candidates_covers_all_fact_types(
+    body: str,
+    expected: FactType,
+) -> None:
+    artifact = make_artifact(PREFIX + body, announcement_id=f"ann-{expected.value}")
+
+    facts = extract_fact_candidates(artifact)
+
+    assert [fact.fact_type for fact in facts] == [expected]
+    fact = facts[0]
+    assert fact.ex_type == "Ex-1"
+    assert fact.evidence_spans
+    assert evidence_matches_artifact(artifact, fact.evidence_spans[0])
+    assert fact.primary_entity_id == "ts_code:600000.SH"
+    assert fact.source_reference["official_url"].startswith("https://")
+
+
+def test_fact_id_is_deterministic_and_duplicate_free() -> None:
+    artifact = make_artifact(
+        PREFIX + "公司与华东能源签订重大合同，合同金额为1000万元。",
+        announcement_id="ann-dedupe",
+    )
+
+    first = extract_fact_candidates(artifact)
+    second = extract_fact_candidates(artifact)
+
+    assert [fact.fact_id for fact in first] == [fact.fact_id for fact in second]
+    assert len({fact.fact_id for fact in first}) == len(first)
+
+
+def test_title_only_match_does_not_produce_ex1() -> None:
+    artifact = make_artifact(
+        PREFIX + "公司日常经营情况正常。",
+        title="重大合同公告",
+        announcement_id="ann-title-only",
+    )
+
+    assert extract_fact_candidates(artifact) == []
+
+
+def test_unresolved_primary_entity_is_retained_without_guessing() -> None:
+    artifact = make_artifact(
+        "公司与华东能源签订重大合同，合同金额为1000万元。",
+        announcement_id="ann-unresolved-primary",
+    )
+
+    fact = extract_fact_candidates(artifact)[0]
+
+    assert fact.primary_entity_id.startswith("unresolved:")
+    assert fact.fact_content["primary_entity"]["unresolved_ref"].startswith(
+        "unresolved:"
+    )
+
+
+class RecordingReasoner:
+    def __init__(self) -> None:
+        self.requests: list[StructuredExtractionRequest] = []
+
+    def generate_structured(
+        self,
+        request: StructuredExtractionRequest,
+    ) -> Mapping[str, Any]:
+        self.requests.append(request)
+        return {
+            "facts": [
+                {
+                    "quote": "合同金额为1000万元。",
+                    "fact_content": {"amount": "1000万元"},
+                    "confidence": 0.7,
+                    "related_mentions": ["华东能源"],
+                }
+            ]
+        }
+
+
+def test_reasoner_fallback_uses_bounded_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = make_artifact(
+        PREFIX + "合同金额为1000万元。" + "补充说明" * 900,
+        announcement_id="ann-reasoner",
+    )
+    reasoner = RecordingReasoner()
+    monkeypatch.setitem(
+        extract_module._RULE_EXTRACTORS,
+        FactType.MAJOR_CONTRACT,
+        lambda parsed_artifact, context: [],
+    )
+
+    facts = extract_fact_candidates(artifact, reasoner=reasoner)
+
+    assert [fact.fact_type for fact in facts] == [FactType.MAJOR_CONTRACT]
+    assert reasoner.requests
+    request = reasoner.requests[0]
+    assert request.fact_type == FactType.MAJOR_CONTRACT.value
+    assert len(request.segments) == 1
+    assert len(request.segments[0].text) <= 2_000
+    assert request.schema["x-fact-type"] == FactType.MAJOR_CONTRACT.value
+    assert "schema" in request.model_dump(by_alias=True)
+
+
+def test_reasoner_is_not_called_when_classifier_finds_no_body_evidence() -> None:
+    artifact = make_artifact(PREFIX + "公司日常经营情况正常。", title="重大合同公告")
+    reasoner = RecordingReasoner()
+
+    assert extract_fact_candidates(artifact, reasoner=reasoner) == []
+    assert reasoner.requests == []

--- a/tests/test_package_layout.py
+++ b/tests/test_package_layout.py
@@ -59,6 +59,14 @@ def test_subpackages_are_importable(subpackage: str) -> None:
             "ParsedAnnouncementArtifact",
             "parse_announcement",
         }.issubset(set(module.__all__))
+    elif subpackage == "extract":
+        assert {
+            "AnnouncementFactCandidate",
+            "EvidenceSpan",
+            "FactType",
+            "classify_disclosure_types",
+            "extract_fact_candidates",
+        }.issubset(set(module.__all__))
     else:
         assert module.__all__ == []
 


### PR DESCRIPTION
Closes #6

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/subsystem_announcement/discovery/cache.py`, `src/subsystem_announcement/discovery/fetcher.py`, `tests/test_parse_docling_client.py`, `tests/test_runtime_sdk.py`


---
### 1. 背景与目标
项目文档 §11.3 和 §11.6 要求 Ex-1 先于信号和图谱候选，且每条事实必须有 EvidenceSpan 和实体锚点。当前代码中 `src/subsystem_announcement/extract/__init__.py` 为空，`AnnouncementConfig` 已提供 `reasoner_endpoint` 与 `entity_registry_endpoint` 配置入口，#5 将提供稳定的 `ParsedAnnouncementArtifact`。本 issue 的目标是在 parse artifact 上实现 7 类公告事实抽取、证据定位、实体锚点协同和 contract-ready Ex-1 payload。

### 2. 所属模块
Primary writable paths:
- `src/subsystem_announcement/extract/__init__.py`
- `src/subsystem_announcement/extract/candidates.py`
- `src/subsystem_announcement/extract/evidence.py`
- `src/subsystem_announcement/extract/classifier.py`
- `src/subsystem_announcement/extract/entity_anchor.py`
- `src/subsystem_announcement/extract/reasoner_bridge.py`
- `src/subsystem_announcement/extract/rules/__init__.py`
- `src/subsystem_announcement/extract/rules/earnings.py`
- `src/subsystem_announcement/extract/rules/major_contract.py`
- `src/subsystem_announcement/extract/rules/shareholder.py`
- `src/subsystem_announcement/extract/rules/equity_pledge.py`
- `src/subsystem_announcement/extract/rules/regulatory.py`
- `src/subsystem_announcement/extract/rules/trading.py`
- `src/subsystem_announcement/extract/rules/fundraising.py`
- `tests/test_extract_evidence.py`
- `tests/test_extract_classifier.py`
- `tests/test_extract_entity_anchor.py`
- `tests/test_extract_fact_candidates.py`
- `tests/contracts/test_ex1_contract.py`

Adjacent read-only / integration paths:
- `src/subsystem_announcement/parse/artifact.py`，读取 `ParsedAnnouncementArtifact`、section、table
- `src/subsystem_announcement/config.py`，读取 reasoner/entity-registry endpoint 配置
- `src/subsystem_announcement/discovery/envelope.py`，仅复用公告元数据字段语义

### 3. 实现范围
- 在 `extract/candidates.py` 定义 `FactType` 枚举或 Literal，覆盖 `earnings_preannounce`、`major_contract`、`shareholder_change`、`equity_pledge`、`regulatory_action`、`trading_halt_resume`、`fundraising_change`。
- 在 `extract/evidence.py` 定义 `EvidenceSpan(BaseModel)`，字段为 `section_id: str`、`start_offset: int`、`end_offset: int`、`quote: str`、`table_ref: