### PR TITLE
feat(#7): 通过 subsystem-sdk 批量提交 Ex-1 候选与 run trace

### DIFF
--- a/src/subsystem_announcement/__main__.py
+++ b/src/subsystem_announcement/__main__.py
@@ -91,6 +91,50 @@ if typer is not None:
             typer.echo(f"run failed: {exc}", err=True)
             raise typer.Exit(code=1) from exc
         typer.echo("ok")
+
+    @app.command("process")
+    def process_command(
+        envelope: Path = typer.Option(
+            ...,
+            "--envelope",
+            help="Announcement envelope JSON path.",
+        ),
+        config: Path = typer.Option(
+            ...,
+            "--config",
+            "-c",
+            help="Announcement TOML config path.",
+        ),
+        trace_output: Path | None = typer.Option(
+            None,
+            "--trace-output",
+            help="Optional path for an additional trace JSON copy.",
+        ),
+    ) -> None:
+        """Process one announcement envelope through Ex-1 submit."""
+
+        try:
+            configure_logging()
+            runtime_config = load_config(config)
+            announcement_envelope = _load_envelope(envelope)
+            from .runtime.pipeline import AnnouncementPipeline
+
+            run = asyncio.run(
+                AnnouncementPipeline(runtime_config).process_envelope(
+                    announcement_envelope
+                )
+            )
+            _write_trace_copy(run, trace_output)
+        except Exception as exc:
+            typer.echo(f"process failed: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+        if run.status != "succeeded":
+            typer.echo(
+                f"process failed: status={run.status} trace={run.trace_path}",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        typer.echo(f"ok trace={run.trace_path}")
 else:
     app = None
 
@@ -137,9 +181,43 @@ def _fallback_main(argv: list[str]) -> int:
             return 1
         print("ok")
         return 0
+    if command == "process":
+        envelope_path = _option_path(argv, "--envelope")
+        config_path = _option_path(argv, "--config") or _option_path(argv, "-c")
+        trace_output = _option_path(argv, "--trace-output")
+        if envelope_path is None or config_path is None:
+            print(
+                "usage: python -m subsystem_announcement process "
+                "--envelope PATH --config PATH [--trace-output PATH]",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            configure_logging()
+            runtime_config = load_config(config_path)
+            announcement_envelope = _load_envelope(envelope_path)
+            from .runtime.pipeline import AnnouncementPipeline
+
+            run = asyncio.run(
+                AnnouncementPipeline(runtime_config).process_envelope(
+                    announcement_envelope
+                )
+            )
+            _write_trace_copy(run, trace_output)
+        except Exception as exc:
+            print(f"process failed: {exc}", file=sys.stderr)
+            return 1
+        if run.status != "succeeded":
+            print(
+                f"process failed: status={run.status} trace={run.trace_path}",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"ok trace={run.trace_path}")
+        return 0
 
     print(
-        "usage: python -m subsystem_announcement [version|doctor|ping|run]",
+        "usage: python -m subsystem_announcement [version|doctor|ping|run|process]",
         file=sys.stderr,
     )
     return 1
@@ -177,6 +255,36 @@ def _version_status(value: str) -> str:
     if value == "not-configured":
         return "not-configured (unset)"
     return value
+
+
+def _load_envelope(path: Path) -> object:
+    from .discovery import AnnouncementEnvelope
+
+    try:
+        return AnnouncementEnvelope.model_validate_json(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"Unable to load announcement envelope: path={path}") from exc
+
+
+def _write_trace_copy(run: object, trace_output: Path | None) -> None:
+    if trace_output is None:
+        return
+    if not hasattr(run, "model_dump_json"):
+        raise RuntimeError("Trace object does not support JSON serialization")
+    try:
+        trace_output.parent.mkdir(parents=True, exist_ok=True)
+        trace_output.write_text(run.model_dump_json(indent=2), encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Unable to write trace output: path={trace_output}") from exc
+
+
+def _option_path(argv: list[str], option: str) -> Path | None:
+    if option not in argv:
+        return None
+    index = argv.index(option)
+    if index + 1 >= len(argv):
+        return None
+    return Path(argv[index + 1])
 
 
 if __name__ == "__main__":

--- a/src/subsystem_announcement/runtime/__init__.py
+++ b/src/subsystem_announcement/runtime/__init__.py
@@ -1,1 +1,32 @@
-__all__: list[str] = []
+"""Runtime public API for announcement processing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .pipeline import AnnouncementPipeline
+    from .submit import submit_candidates
+    from .trace import AnnouncementExtractionRun
+
+__all__ = [
+    "AnnouncementExtractionRun",
+    "AnnouncementPipeline",
+    "submit_candidates",
+]
+
+
+def __getattr__(name: str) -> object:
+    if name == "AnnouncementPipeline":
+        from .pipeline import AnnouncementPipeline
+
+        return AnnouncementPipeline
+    if name == "submit_candidates":
+        from .submit import submit_candidates
+
+        return submit_candidates
+    if name == "AnnouncementExtractionRun":
+        from .trace import AnnouncementExtractionRun
+
+        return AnnouncementExtractionRun
+    raise AttributeError(name)

--- a/src/subsystem_announcement/runtime/pipeline.py
+++ b/src/subsystem_announcement/runtime/pipeline.py
@@ -1,0 +1,187 @@
+"""Single-envelope announcement processing pipeline."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.discovery import (
+    AnnouncementDiscoveryResult,
+    AnnouncementEnvelope,
+    consume_announcement_ref,
+)
+from subsystem_announcement.discovery.document import AnnouncementDocumentArtifact
+from subsystem_announcement.extract import (
+    AnnouncementFactCandidate,
+    extract_fact_candidates,
+)
+from subsystem_announcement.parse import ParsedAnnouncementArtifact, parse_announcement
+from subsystem_announcement.parse.artifact import write_parsed_artifact
+
+from .sdk_adapter import AnnouncementSubsystem
+from .submit import SubmitBatchResult, SubmitIdempotencyStore, submit_candidates
+from .trace import AnnouncementExtractionRun, RunTraceError, TraceStore
+
+
+DiscoveryFunc = Callable[
+    [AnnouncementEnvelope, AnnouncementConfig],
+    AnnouncementDiscoveryResult | Awaitable[AnnouncementDiscoveryResult],
+]
+ParseFunc = Callable[
+    [AnnouncementDocumentArtifact, AnnouncementConfig],
+    ParsedAnnouncementArtifact | Awaitable[ParsedAnnouncementArtifact],
+]
+ExtractFunc = Callable[
+    [ParsedAnnouncementArtifact],
+    Sequence[AnnouncementFactCandidate] | Awaitable[Sequence[AnnouncementFactCandidate]],
+]
+
+
+class AnnouncementPipeline:
+    """Process one announcement envelope through Ex-1 submission."""
+
+    def __init__(
+        self,
+        config: AnnouncementConfig,
+        *,
+        subsystem: AnnouncementSubsystem | None = None,
+        discovery_func: DiscoveryFunc = consume_announcement_ref,
+        parse_func: ParseFunc = parse_announcement,
+        extract_func: ExtractFunc = extract_fact_candidates,
+        idempotency_store: SubmitIdempotencyStore | None = None,
+        trace_store: TraceStore | None = None,
+    ) -> None:
+        self.config = config
+        self._subsystem = subsystem
+        self._discovery_func = discovery_func
+        self._parse_func = parse_func
+        self._extract_func = extract_func
+        self._idempotency_store = idempotency_store or SubmitIdempotencyStore(
+            Path(config.artifact_root) / "runs" / "submit_idempotency.json"
+        )
+        self._trace_store = trace_store or TraceStore(config)
+
+    async def process_envelope(
+        self,
+        envelope: AnnouncementEnvelope,
+    ) -> AnnouncementExtractionRun:
+        """Run discovery, parse, Ex-1 extraction, submit, and trace persistence."""
+
+        run = AnnouncementExtractionRun(
+            run_id=str(uuid4()),
+            announcement_id=envelope.announcement_id,
+            started_at=datetime.now(timezone.utc),
+        )
+        try:
+            discovery_result = await self._call_discovery(envelope)
+            run.document_artifact_path = discovery_result.document.local_path
+
+            parsed_artifact = await self._call_parse(discovery_result.document)
+            run.parsed_artifact_path = write_parsed_artifact(
+                parsed_artifact,
+                self.config.artifact_root,
+            )
+
+            candidates = list(await self._call_extract(parsed_artifact))
+            run.candidate_count = len(candidates)
+
+            if candidates:
+                submit_result = submit_candidates(
+                    candidates,
+                    self._get_subsystem(),
+                    idempotency_store=self._idempotency_store,
+                )
+            else:
+                submit_result = SubmitBatchResult(
+                    submitted=0,
+                    skipped_duplicates=0,
+                    failed=0,
+                )
+            _apply_submit_result(run, submit_result)
+            run.status = _status_from_submit_result(submit_result, len(candidates))
+        except Exception as exc:
+            run.status = "failed"
+            run.errors.append(
+                RunTraceError(stage=_stage_for_run(run), message=str(exc))
+            )
+        finally:
+            run.finished_at = datetime.now(timezone.utc)
+            self._trace_store.write(run)
+        return run
+
+    async def _call_discovery(
+        self,
+        envelope: AnnouncementEnvelope,
+    ) -> AnnouncementDiscoveryResult:
+        return await _maybe_await(self._discovery_func(envelope, self.config))
+
+    async def _call_parse(
+        self,
+        document: AnnouncementDocumentArtifact,
+    ) -> ParsedAnnouncementArtifact:
+        return await _maybe_await(self._parse_func(document, self.config))
+
+    async def _call_extract(
+        self,
+        artifact: ParsedAnnouncementArtifact,
+    ) -> Sequence[AnnouncementFactCandidate]:
+        return await _maybe_await(self._extract_func(artifact))
+
+    def _get_subsystem(self) -> AnnouncementSubsystem:
+        if self._subsystem is None:
+            self._subsystem = AnnouncementSubsystem(self.config)
+        return self._subsystem
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _apply_submit_result(
+    run: AnnouncementExtractionRun,
+    result: SubmitBatchResult,
+) -> None:
+    run.submit_success_count = result.submitted
+    run.submit_duplicate_count = result.skipped_duplicates
+    run.submit_failure_count = result.failed
+    run.submit_receipts = [
+        receipt.model_dump(mode="json") for receipt in result.receipts
+    ]
+    run.candidate_traces = result.traces
+    for failure in result.failures:
+        message = "; ".join(failure.errors) if failure.errors else "submit failed"
+        run.errors.append(
+            RunTraceError(
+                stage="submit",
+                fact_id=failure.fact_id,
+                message=message,
+            )
+        )
+
+
+def _status_from_submit_result(
+    result: SubmitBatchResult,
+    candidate_count: int,
+) -> str:
+    if result.failed == 0:
+        return "succeeded"
+    if candidate_count == 0 or result.failed == candidate_count:
+        return "failed"
+    return "partial_failed"
+
+
+def _stage_for_run(run: AnnouncementExtractionRun) -> str:
+    if run.document_artifact_path is None:
+        return "discovery"
+    if run.parsed_artifact_path is None:
+        return "parse"
+    if run.candidate_count == 0 and not run.candidate_traces:
+        return "extract"
+    return "submit"

--- a/src/subsystem_announcement/runtime/submit.py
+++ b/src/subsystem_announcement/runtime/submit.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import threading
 from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -12,11 +14,18 @@ from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from subsystem_announcement.discovery.errors import NonOfficialSourceError
+from subsystem_announcement.discovery.fetcher import _validate_official_url_text
 from subsystem_announcement.extract import AnnouncementFactCandidate
 from subsystem_announcement.extract.candidates import FORBIDDEN_PAYLOAD_KEYS
 
 from .sdk_adapter import AnnouncementSubsystem
 from .trace import CandidateSubmitTrace
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - fcntl is available on supported CI hosts.
+    fcntl = None  # type: ignore[assignment]
 
 
 _FORBIDDEN_RUNTIME_KEYS = FORBIDDEN_PAYLOAD_KEYS | {
@@ -60,11 +69,21 @@ class SubmitBatchResult(BaseModel):
 class SubmitIdempotencyStore:
     """Idempotency records keyed by ``fact_id`` and payload hash."""
 
+    _path_locks: dict[Path, threading.RLock] = {}
+    _path_locks_guard = threading.Lock()
+
     def __init__(self, path: Path | None = None) -> None:
         self.path = Path(path) if path is not None else None
+        self._lock_path = (
+            self.path.expanduser().resolve(strict=False)
+            if self.path is not None
+            else None
+        )
+        self._thread_lock = self._get_thread_lock(self._lock_path)
         self._records: dict[str, CandidateSubmitReceipt] = {}
         if self.path is not None and self.path.exists():
-            self._load()
+            with self.locked():
+                pass
 
     def seen(
         self,
@@ -73,7 +92,8 @@ class SubmitIdempotencyStore:
     ) -> CandidateSubmitReceipt | None:
         """Return the previous receipt for an identical candidate payload."""
 
-        return self._records.get(_idempotency_key(candidate_id, payload_hash))
+        with self.locked():
+            return self._seen_loaded(candidate_id, payload_hash)
 
     def record(
         self,
@@ -83,6 +103,70 @@ class SubmitIdempotencyStore:
     ) -> None:
         """Record an accepted candidate receipt."""
 
+        with self.locked():
+            self._record_loaded(candidate_id, payload_hash, receipt)
+
+    @contextmanager
+    def locked(self) -> Any:
+        """Hold the in-process and file-backed idempotency locks."""
+
+        with self._thread_lock:
+            with self._file_lock():
+                if self.path is not None:
+                    if self.path.exists():
+                        self._load()
+                    else:
+                        self._records = {}
+                yield
+
+    @classmethod
+    def _get_thread_lock(cls, lock_path: Path | None) -> threading.RLock:
+        if lock_path is None:
+            return threading.RLock()
+        with cls._path_locks_guard:
+            lock = cls._path_locks.get(lock_path)
+            if lock is None:
+                lock = threading.RLock()
+                cls._path_locks[lock_path] = lock
+            return lock
+
+    @contextmanager
+    def _file_lock(self) -> Any:
+        if self.path is None:
+            yield
+            return
+        if fcntl is None:
+            raise RuntimeError(
+                "File-backed submit idempotency requires fcntl locking support"
+            )
+
+        lock_path = self.path.with_name(f"{self.path.name}.lock")
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            with lock_path.open("a+", encoding="utf-8") as lock_file:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Unable to lock submit idempotency store: path={self.path}"
+            ) from exc
+
+    def _seen_loaded(
+        self,
+        candidate_id: str,
+        payload_hash: str,
+    ) -> CandidateSubmitReceipt | None:
+        return self._records.get(_idempotency_key(candidate_id, payload_hash))
+
+    def _record_loaded(
+        self,
+        candidate_id: str,
+        payload_hash: str,
+        receipt: CandidateSubmitReceipt,
+    ) -> None:
         self._records[_idempotency_key(candidate_id, payload_hash)] = receipt
         self._persist()
 
@@ -166,36 +250,37 @@ def submit_candidates(
             traces.append(trace)
             continue
 
-        previous_receipt = store.seen(candidate.fact_id, payload_hash)
-        if previous_receipt is not None:
-            skipped_duplicates += 1
-            trace = CandidateSubmitTrace(
-                fact_id=candidate.fact_id,
-                status="duplicate",
-                receipt_id=previous_receipt.receipt_id,
-                attempts=0,
-                errors=[],
+        with store.locked():
+            previous_receipt = store._seen_loaded(candidate.fact_id, payload_hash)
+            if previous_receipt is not None:
+                skipped_duplicates += 1
+                trace = CandidateSubmitTrace(
+                    fact_id=candidate.fact_id,
+                    status="duplicate",
+                    receipt_id=previous_receipt.receipt_id,
+                    attempts=0,
+                    errors=[],
+                )
+                receipts.append(previous_receipt)
+                traces.append(trace)
+                continue
+
+            receipt, trace = _submit_one(
+                candidate.fact_id,
+                payload_hash,
+                payload,
+                subsystem,
+                max_attempts=max_attempts,
             )
-            receipts.append(previous_receipt)
             traces.append(trace)
-            continue
+            if receipt is None:
+                failed += 1
+                failures.append(trace)
+                continue
 
-        receipt, trace = _submit_one(
-            candidate.fact_id,
-            payload_hash,
-            payload,
-            subsystem,
-            max_attempts=max_attempts,
-        )
-        traces.append(trace)
-        if receipt is None:
-            failed += 1
-            failures.append(trace)
-            continue
-
-        submitted += 1
-        receipts.append(receipt)
-        store.record(candidate.fact_id, payload_hash, receipt)
+            submitted += 1
+            receipts.append(receipt)
+            store._record_loaded(candidate.fact_id, payload_hash, receipt)
 
     return SubmitBatchResult(
         submitted=submitted,
@@ -296,6 +381,15 @@ def _validate_source_reference(
     parsed_url = urlsplit(official_url)
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
         raise ValueError("source_reference.official_url must be an official HTTP URL")
+    try:
+        _validate_official_url_text(
+            official_url,
+            announcement_id=str(payload.get("announcement_id") or "unknown"),
+        )
+    except NonOfficialSourceError as exc:
+        raise ValueError(
+            "source_reference.official_url must use an official disclosure domain"
+        ) from exc
     source_announcement_id = source_reference.get("announcement_id")
     if (
         source_announcement_id is not None

--- a/src/subsystem_announcement/runtime/submit.py
+++ b/src/subsystem_announcement/runtime/submit.py
@@ -1,0 +1,363 @@
+"""Batch Ex-1 submission through the announcement SDK adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from subsystem_announcement.extract import AnnouncementFactCandidate
+from subsystem_announcement.extract.candidates import FORBIDDEN_PAYLOAD_KEYS
+
+from .sdk_adapter import AnnouncementSubsystem
+from .trace import CandidateSubmitTrace
+
+
+_FORBIDDEN_RUNTIME_KEYS = FORBIDDEN_PAYLOAD_KEYS | {
+    "cache_path",
+    "artifact_path",
+    "document_path",
+    "parsed_path",
+    "document_artifact_path",
+    "parsed_artifact_path",
+}
+
+
+class CandidateSubmitReceipt(BaseModel):
+    """Stable receipt recorded after a candidate submit is accepted."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fact_id: str = Field(min_length=1)
+    payload_hash: str = Field(min_length=64, max_length=64)
+    receipt_id: str = Field(min_length=1)
+    ex_type: Literal["Ex-1"] = "Ex-1"
+    attempts: int = Field(ge=1)
+    accepted_at: datetime
+    warnings: tuple[str, ...] = Field(default_factory=tuple)
+    errors: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class SubmitBatchResult(BaseModel):
+    """Summary of an ordered Ex-1 batch submission."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    submitted: int = Field(ge=0)
+    skipped_duplicates: int = Field(ge=0)
+    failed: int = Field(ge=0)
+    receipts: list[CandidateSubmitReceipt] = Field(default_factory=list)
+    failures: list[CandidateSubmitTrace] = Field(default_factory=list)
+    traces: list[CandidateSubmitTrace] = Field(default_factory=list)
+
+
+class SubmitIdempotencyStore:
+    """Idempotency records keyed by ``fact_id`` and payload hash."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = Path(path) if path is not None else None
+        self._records: dict[str, CandidateSubmitReceipt] = {}
+        if self.path is not None and self.path.exists():
+            self._load()
+
+    def seen(
+        self,
+        candidate_id: str,
+        payload_hash: str,
+    ) -> CandidateSubmitReceipt | None:
+        """Return the previous receipt for an identical candidate payload."""
+
+        return self._records.get(_idempotency_key(candidate_id, payload_hash))
+
+    def record(
+        self,
+        candidate_id: str,
+        payload_hash: str,
+        receipt: CandidateSubmitReceipt,
+    ) -> None:
+        """Record an accepted candidate receipt."""
+
+        self._records[_idempotency_key(candidate_id, payload_hash)] = receipt
+        self._persist()
+
+    def _load(self) -> None:
+        if self.path is None:
+            return
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                f"Unable to load submit idempotency store: path={self.path}"
+            ) from exc
+        if not isinstance(raw, Mapping):
+            raise RuntimeError(
+                f"Invalid submit idempotency store: path={self.path}"
+            )
+        self._records = {
+            str(key): CandidateSubmitReceipt.model_validate(value)
+            for key, value in raw.items()
+        }
+
+    def _persist(self) -> None:
+        if self.path is None:
+            return
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self.path.with_name(f"{self.path.name}.tmp")
+            tmp_path.write_text(
+                json.dumps(
+                    {
+                        key: receipt.model_dump(mode="json")
+                        for key, receipt in self._records.items()
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            tmp_path.replace(self.path)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Unable to persist submit idempotency store: path={self.path}"
+            ) from exc
+
+
+def submit_candidates(
+    candidates: Sequence[AnnouncementFactCandidate],
+    subsystem: AnnouncementSubsystem,
+    *,
+    idempotency_store: SubmitIdempotencyStore | None = None,
+    max_attempts: int = 3,
+) -> SubmitBatchResult:
+    """Submit Ex-1 fact candidates in order with retry and idempotency."""
+
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+
+    store = idempotency_store or SubmitIdempotencyStore()
+    submitted = 0
+    skipped_duplicates = 0
+    failed = 0
+    receipts: list[CandidateSubmitReceipt] = []
+    failures: list[CandidateSubmitTrace] = []
+    traces: list[CandidateSubmitTrace] = []
+
+    for candidate in candidates:
+        try:
+            payload = _validated_payload(candidate)
+            payload_hash = _payload_hash(payload)
+        except Exception as exc:
+            failed += 1
+            fact_id = getattr(candidate, "fact_id", "unknown")
+            trace = CandidateSubmitTrace(
+                fact_id=str(fact_id),
+                status="failed",
+                attempts=0,
+                errors=[str(exc)],
+            )
+            failures.append(trace)
+            traces.append(trace)
+            continue
+
+        previous_receipt = store.seen(candidate.fact_id, payload_hash)
+        if previous_receipt is not None:
+            skipped_duplicates += 1
+            trace = CandidateSubmitTrace(
+                fact_id=candidate.fact_id,
+                status="duplicate",
+                receipt_id=previous_receipt.receipt_id,
+                attempts=0,
+                errors=[],
+            )
+            receipts.append(previous_receipt)
+            traces.append(trace)
+            continue
+
+        receipt, trace = _submit_one(
+            candidate.fact_id,
+            payload_hash,
+            payload,
+            subsystem,
+            max_attempts=max_attempts,
+        )
+        traces.append(trace)
+        if receipt is None:
+            failed += 1
+            failures.append(trace)
+            continue
+
+        submitted += 1
+        receipts.append(receipt)
+        store.record(candidate.fact_id, payload_hash, receipt)
+
+    return SubmitBatchResult(
+        submitted=submitted,
+        skipped_duplicates=skipped_duplicates,
+        failed=failed,
+        receipts=receipts,
+        failures=failures,
+        traces=traces,
+    )
+
+
+def _submit_one(
+    fact_id: str,
+    payload_hash: str,
+    payload: dict[str, Any],
+    subsystem: AnnouncementSubsystem,
+    *,
+    max_attempts: int,
+) -> tuple[CandidateSubmitReceipt | None, CandidateSubmitTrace]:
+    errors: list[str] = []
+    last_receipt_id: str | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            result = subsystem.submit(payload)
+        except Exception as exc:
+            errors.append(str(exc))
+            continue
+
+        last_receipt_id = _result_receipt_id(result)
+        if _result_accepted(result):
+            if last_receipt_id is None:
+                errors.append("subsystem-sdk accepted payload without receipt_id")
+                continue
+            receipt = CandidateSubmitReceipt(
+                fact_id=fact_id,
+                payload_hash=payload_hash,
+                receipt_id=last_receipt_id,
+                attempts=attempt,
+                accepted_at=datetime.now(timezone.utc),
+                warnings=_string_tuple(_result_field(result, "warnings")),
+                errors=_string_tuple(_result_field(result, "errors")),
+            )
+            trace = CandidateSubmitTrace(
+                fact_id=fact_id,
+                status="accepted",
+                receipt_id=receipt.receipt_id,
+                attempts=attempt,
+                errors=[],
+            )
+            return receipt, trace
+
+        rejection_errors = _string_tuple(_result_field(result, "errors"))
+        rejection_warnings = _string_tuple(_result_field(result, "warnings"))
+        detail = ", ".join(
+            part
+            for part in (
+                f"errors={list(rejection_errors)}" if rejection_errors else "",
+                f"warnings={list(rejection_warnings)}" if rejection_warnings else "",
+            )
+            if part
+        )
+        errors.append(
+            "subsystem-sdk rejected Ex-1 payload"
+            + (f": {detail}" if detail else "")
+        )
+
+    return None, CandidateSubmitTrace(
+        fact_id=fact_id,
+        status="failed",
+        receipt_id=last_receipt_id,
+        attempts=max_attempts,
+        errors=errors,
+    )
+
+
+def _validated_payload(candidate: AnnouncementFactCandidate) -> dict[str, Any]:
+    payload = candidate.to_ex_payload()
+    if payload.get("ex_type") != "Ex-1":
+        raise ValueError("submit_candidates only accepts Ex-1 payloads")
+    if not payload.get("evidence_spans"):
+        raise ValueError("Ex-1 payload requires at least one evidence span")
+    source_reference = payload.get("source_reference")
+    if not isinstance(source_reference, Mapping):
+        raise ValueError("Ex-1 payload requires source_reference")
+    _validate_source_reference(payload, source_reference)
+    _reject_forbidden_runtime_keys(payload)
+    validated = AnnouncementFactCandidate.model_validate(payload)
+    return validated.model_dump(mode="json")
+
+
+def _validate_source_reference(
+    payload: Mapping[str, Any],
+    source_reference: Mapping[str, Any],
+) -> None:
+    official_url = source_reference.get("official_url")
+    if not isinstance(official_url, str) or not official_url.strip():
+        raise ValueError("source_reference.official_url is required")
+    parsed_url = urlsplit(official_url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+        raise ValueError("source_reference.official_url must be an official HTTP URL")
+    source_announcement_id = source_reference.get("announcement_id")
+    if (
+        source_announcement_id is not None
+        and source_announcement_id != payload.get("announcement_id")
+    ):
+        raise ValueError("source_reference.announcement_id must match candidate")
+
+
+def _reject_forbidden_runtime_keys(value: Any, path: str = "") -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            key_text = str(key)
+            if key_text in _FORBIDDEN_RUNTIME_KEYS:
+                raise ValueError(
+                    f"Ex-1 payload contains forbidden runtime key: {path}{key_text}"
+                )
+            _reject_forbidden_runtime_keys(item, f"{path}{key_text}.")
+    elif isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        for index, item in enumerate(value):
+            _reject_forbidden_runtime_keys(item, f"{path}{index}.")
+
+
+def _payload_hash(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _idempotency_key(candidate_id: str, payload_hash: str) -> str:
+    return f"{candidate_id}:{payload_hash}"
+
+
+def _result_accepted(result: Any) -> bool:
+    return bool(_result_field(result, "accepted"))
+
+
+def _result_receipt_id(result: Any) -> str | None:
+    value = _result_field(result, "receipt_id")
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _result_field(result: Any, field: str) -> Any:
+    if isinstance(result, Mapping):
+        return result.get(field)
+    if hasattr(result, "model_dump"):
+        return result.model_dump().get(field)
+    return getattr(result, field, None)
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence):
+        return tuple(str(item) for item in value)
+    return (str(value),)

--- a/src/subsystem_announcement/runtime/submit.py
+++ b/src/subsystem_announcement/runtime/submit.py
@@ -36,6 +36,7 @@ _FORBIDDEN_RUNTIME_KEYS = FORBIDDEN_PAYLOAD_KEYS | {
     "document_artifact_path",
     "parsed_artifact_path",
 }
+_VOLATILE_IDEMPOTENCY_PAYLOAD_KEYS = {"extracted_at"}
 
 
 class CandidateSubmitReceipt(BaseModel):
@@ -413,9 +414,14 @@ def _reject_forbidden_runtime_keys(value: Any, path: str = "") -> None:
 
 
 def _payload_hash(payload: Mapping[str, Any]) -> str:
+    stable_payload = {
+        key: value
+        for key, value in payload.items()
+        if key not in _VOLATILE_IDEMPOTENCY_PAYLOAD_KEYS
+    }
     return hashlib.sha256(
         json.dumps(
-            payload,
+            stable_payload,
             ensure_ascii=False,
             sort_keys=True,
             separators=(",", ":"),

--- a/src/subsystem_announcement/runtime/trace.py
+++ b/src/subsystem_announcement/runtime/trace.py
@@ -1,0 +1,117 @@
+"""Auditable run trace models and persistence."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from subsystem_announcement.config import AnnouncementConfig
+
+
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+
+
+class CandidateSubmitTrace(BaseModel):
+    """Per-candidate submit trace for one Ex-1 candidate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fact_id: str = Field(min_length=1)
+    status: Literal["accepted", "duplicate", "failed"]
+    receipt_id: str | None = None
+    attempts: int = Field(ge=0)
+    errors: list[str] = Field(default_factory=list)
+
+
+class RunTraceError(BaseModel):
+    """Stage-localized error recorded in an extraction run trace."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stage: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+    fact_id: str | None = None
+
+
+class AnnouncementExtractionRun(BaseModel):
+    """Audit trace for one announcement envelope processing run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str = Field(min_length=1)
+    announcement_id: str = Field(min_length=1)
+    status: Literal["running", "succeeded", "partial_failed", "failed"] = "running"
+    started_at: datetime
+    finished_at: datetime | None = None
+    document_artifact_path: Path | None = None
+    parsed_artifact_path: Path | None = None
+    candidate_count: int = Field(default=0, ge=0)
+    submit_success_count: int = Field(default=0, ge=0)
+    submit_duplicate_count: int = Field(default=0, ge=0)
+    submit_failure_count: int = Field(default=0, ge=0)
+    submit_receipts: list[dict[str, object]] = Field(default_factory=list)
+    candidate_traces: list[CandidateSubmitTrace] = Field(default_factory=list)
+    errors: list[RunTraceError] = Field(default_factory=list)
+    trace_path: Path | None = None
+
+    @field_validator("started_at", "finished_at")
+    @classmethod
+    def require_timezone(cls, value: datetime | None) -> datetime | None:
+        """Reject naive timestamps so trace ordering is replayable."""
+
+        if value is None:
+            return value
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("trace timestamps must include timezone information")
+        return value
+
+
+class TraceStore:
+    """Read and write run traces under ``artifact_root/runs``."""
+
+    def __init__(self, config_or_root: AnnouncementConfig | Path) -> None:
+        if isinstance(config_or_root, AnnouncementConfig):
+            artifact_root = config_or_root.artifact_root
+        else:
+            artifact_root = config_or_root
+        self.run_root = Path(artifact_root) / "runs"
+
+    def write(self, run: AnnouncementExtractionRun) -> Path:
+        """Persist a run trace and return the JSON path."""
+
+        run_id = _safe_run_id(run.run_id)
+        path = self.run_root / f"{run_id}.json"
+        try:
+            self.run_root.mkdir(parents=True, exist_ok=True)
+            run.trace_path = path
+            path.write_text(run.model_dump_json(indent=2), encoding="utf-8")
+        except OSError as exc:
+            raise RuntimeError(f"Unable to write run trace: path={path}") from exc
+        return path
+
+    def load(self, path: Path) -> AnnouncementExtractionRun:
+        """Load a run trace JSON file."""
+
+        trace_path = Path(path)
+        try:
+            return AnnouncementExtractionRun.model_validate_json(
+                trace_path.read_text(encoding="utf-8")
+            )
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(f"Unable to load run trace: path={trace_path}") from exc
+
+
+def _safe_run_id(value: str) -> str:
+    if (
+        not _RUN_ID_RE.fullmatch(value)
+        or "/" in value
+        or "\\" in value
+        or value in {".", ".."}
+        or Path(value).is_absolute()
+    ):
+        raise ValueError(f"Unsafe run_id for trace path: {value!r}")
+    return value

--- a/tests/fixtures/announcement.toml
+++ b/tests/fixtures/announcement.toml
@@ -1,0 +1,5 @@
+artifact_root = "artifacts/announcement-test"
+docling_version = "docling==2.15.1"
+llama_index_version = "llama-index-core==0.10.0"
+heartbeat_interval_seconds = 60
+registration_ttl_seconds = 900

--- a/tests/fixtures/announcements/earnings_envelope.json
+++ b/tests/fixtures/announcements/earnings_envelope.json
@@ -1,0 +1,9 @@
+{
+  "announcement_id": "ann-e2e",
+  "ts_code": "600000.SH",
+  "title": "测试公司2026年第一季度业绩预告",
+  "publish_time": "2026-04-18T09:00:00+08:00",
+  "official_url": "https://static.sse.com.cn/disclosure/ann-e2e.pdf",
+  "source_exchange": "sse",
+  "attachment_type": "pdf"
+}

--- a/tests/test_package_layout.py
+++ b/tests/test_package_layout.py
@@ -67,6 +67,12 @@ def test_subpackages_are_importable(subpackage: str) -> None:
             "classify_disclosure_types",
             "extract_fact_candidates",
         }.issubset(set(module.__all__))
+    elif subpackage == "runtime":
+        assert {
+            "AnnouncementExtractionRun",
+            "AnnouncementPipeline",
+            "submit_candidates",
+        }.issubset(set(module.__all__))
     else:
         assert module.__all__ == []
 

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -98,6 +98,64 @@ def test_process_envelope_records_submit_rejection_as_failed_trace(
     assert run.trace_path.exists()
 
 
+def test_process_envelope_skips_reextracted_duplicate_with_file_backed_idempotency(
+    tmp_path: Path,
+) -> None:
+    envelope = _fixture_envelope()
+    subsystem = RecordingSubsystem()
+    config = _config(tmp_path)
+    parsed_artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n"
+        "公司预计2026年净利润同比增长50%，本公告为业绩预告。",
+        announcement_id=envelope.announcement_id,
+    )
+    extraction_times = [
+        datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 18, 10, 1, tzinfo=timezone.utc),
+    ]
+
+    def parse_same_artifact(
+        _document: AnnouncementDocumentArtifact,
+        _config: AnnouncementConfig,
+    ) -> ParsedAnnouncementArtifact:
+        return parsed_artifact
+
+    def extract_with_replay_timestamp(artifact: ParsedAnnouncementArtifact) -> Any:
+        assert artifact is parsed_artifact
+        timestamp = extraction_times.pop(0)
+        return [
+            candidate.model_copy(update={"extracted_at": timestamp})
+            for candidate in extract_fact_candidates(artifact)
+        ]
+
+    first_pipeline = AnnouncementPipeline(
+        config,
+        subsystem=subsystem,  # type: ignore[arg-type]
+        discovery_func=_fake_discovery,
+        parse_func=parse_same_artifact,
+        extract_func=extract_with_replay_timestamp,
+    )
+    second_pipeline = AnnouncementPipeline(
+        config,
+        subsystem=subsystem,  # type: ignore[arg-type]
+        discovery_func=_fake_discovery,
+        parse_func=parse_same_artifact,
+        extract_func=extract_with_replay_timestamp,
+    )
+
+    first_run = asyncio.run(first_pipeline.process_envelope(envelope))
+    second_run = asyncio.run(second_pipeline.process_envelope(envelope))
+
+    assert first_run.candidate_count >= 1
+    assert first_run.submit_success_count == first_run.candidate_count
+    assert second_run.candidate_count == first_run.candidate_count
+    assert second_run.submit_success_count == 0
+    assert second_run.submit_duplicate_count == second_run.candidate_count
+    assert second_run.submit_failure_count == 0
+    assert len(subsystem.submissions) == first_run.candidate_count
+    assert all(trace.status == "duplicate" for trace in second_run.candidate_traces)
+
+
 def _fixture_envelope() -> AnnouncementEnvelope:
     path = ROOT / "tests" / "fixtures" / "announcements" / "earnings_envelope.json"
     return AnnouncementEnvelope.model_validate_json(path.read_text(encoding="utf-8"))

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.discovery import (
+    AnnouncementDiscoveryResult,
+    AnnouncementEnvelope,
+)
+from subsystem_announcement.discovery.document import AnnouncementDocumentArtifact
+from subsystem_announcement.extract import extract_fact_candidates
+from subsystem_announcement.parse import ParsedAnnouncementArtifact
+from subsystem_announcement.runtime.pipeline import AnnouncementPipeline
+from subsystem_announcement.runtime.trace import TraceStore
+
+from .extract_fixtures import make_artifact
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RecordingSubsystem:
+    def __init__(self, *, accepted: bool = True) -> None:
+        self.accepted = accepted
+        self.submissions: list[dict[str, Any]] = []
+
+    def submit(self, candidate: dict[str, Any]) -> dict[str, Any]:
+        self.submissions.append(candidate)
+        return {
+            "accepted": self.accepted,
+            "receipt_id": f"receipt-{len(self.submissions)}",
+            "warnings": (),
+            "errors": () if self.accepted else ("sdk rejected",),
+        }
+
+
+def test_process_envelope_discovers_parses_extracts_and_submits_ex1(
+    tmp_path: Path,
+) -> None:
+    envelope = _fixture_envelope()
+    subsystem = RecordingSubsystem()
+    config = _config(tmp_path)
+
+    pipeline = AnnouncementPipeline(
+        config,
+        subsystem=subsystem,  # type: ignore[arg-type]
+        discovery_func=_fake_discovery,
+        parse_func=_fake_parse,
+        extract_func=extract_fact_candidates,
+    )
+
+    run = asyncio.run(pipeline.process_envelope(envelope))
+
+    assert run.status == "succeeded"
+    assert run.candidate_count >= 1
+    assert run.submit_success_count == run.candidate_count
+    assert run.submit_failure_count == 0
+    assert run.document_artifact_path == tmp_path / "documents" / "ann-e2e.pdf"
+    assert run.parsed_artifact_path is not None
+    assert run.parsed_artifact_path.exists()
+    assert run.trace_path is not None
+    assert run.trace_path.exists()
+    assert subsystem.submissions
+    assert all(payload["ex_type"] == "Ex-1" for payload in subsystem.submissions)
+    assert all(payload["evidence_spans"] for payload in subsystem.submissions)
+    assert all(
+        payload["source_reference"]["official_url"].startswith("https://")
+        for payload in subsystem.submissions
+    )
+
+    loaded = TraceStore(config).load(run.trace_path)
+    assert loaded == run
+
+
+def test_process_envelope_records_submit_rejection_as_failed_trace(
+    tmp_path: Path,
+) -> None:
+    envelope = _fixture_envelope()
+    subsystem = RecordingSubsystem(accepted=False)
+    pipeline = AnnouncementPipeline(
+        _config(tmp_path),
+        subsystem=subsystem,  # type: ignore[arg-type]
+        discovery_func=_fake_discovery,
+        parse_func=_fake_parse,
+        extract_func=extract_fact_candidates,
+    )
+
+    run = asyncio.run(pipeline.process_envelope(envelope))
+
+    assert run.status == "failed"
+    assert run.submit_failure_count == run.candidate_count
+    assert run.errors
+    assert run.errors[0].stage == "submit"
+    assert "sdk rejected" in run.errors[0].message
+    assert run.trace_path is not None
+    assert run.trace_path.exists()
+
+
+def _fixture_envelope() -> AnnouncementEnvelope:
+    path = ROOT / "tests" / "fixtures" / "announcements" / "earnings_envelope.json"
+    return AnnouncementEnvelope.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+async def _fake_discovery(
+    envelope: AnnouncementEnvelope,
+    config: AnnouncementConfig,
+) -> AnnouncementDiscoveryResult:
+    document_path = Path(config.artifact_root) / "documents" / "ann-e2e.pdf"
+    document_path.parent.mkdir(parents=True, exist_ok=True)
+    document_path.write_bytes(b"%PDF mocked fixture")
+    document = AnnouncementDocumentArtifact(
+        announcement_id=envelope.announcement_id,
+        content_hash="b" * 64,
+        official_url=envelope.official_url,
+        source_exchange=envelope.source_exchange,
+        attachment_type=envelope.attachment_type,
+        local_path=document_path,
+        content_type="application/pdf",
+        byte_size=document_path.stat().st_size,
+        fetched_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+    )
+    return AnnouncementDiscoveryResult(status="fetched", document=document)
+
+
+def _fake_parse(
+    document: AnnouncementDocumentArtifact,
+    config: AnnouncementConfig,
+) -> ParsedAnnouncementArtifact:
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n"
+        "公司预计2026年净利润同比增长50%，本公告为业绩预告。",
+        announcement_id=document.announcement_id,
+    )
+    return artifact.model_copy(
+        update={
+            "content_hash": document.content_hash,
+            "source_document": document,
+        }
+    )
+
+
+def _config(tmp_path: Path) -> AnnouncementConfig:
+    return AnnouncementConfig(
+        artifact_root=tmp_path,
+        docling_version="docling==2.15.1",
+        llama_index_version="llama-index-core==0.10.0",
+    )

--- a/tests/test_runtime_submit.py
+++ b/tests/test_runtime_submit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import threading
 from typing import Any
 
 from subsystem_announcement.extract import AnnouncementFactCandidate, extract_fact_candidates
@@ -26,6 +27,27 @@ class RecordingSubsystem:
         if isinstance(outcome, Exception):
             raise outcome
         return outcome
+
+
+class BlockingSubsystem:
+    def __init__(self) -> None:
+        self.submissions: list[dict[str, Any]] = []
+        self.first_submit_started = threading.Event()
+        self.second_submit_started = threading.Event()
+        self.release_submit = threading.Event()
+        self._lock = threading.Lock()
+
+    def submit(self, candidate: dict[str, Any]) -> Any:
+        with self._lock:
+            self.submissions.append(candidate)
+            call_count = len(self.submissions)
+            if call_count == 1:
+                self.first_submit_started.set()
+            if call_count == 2:
+                self.second_submit_started.set()
+        if not self.release_submit.wait(timeout=2):
+            raise TimeoutError("test submit was not released")
+        return _accepted(f"receipt-{call_count}")
 
 
 def test_submit_candidates_preserves_order_and_records_receipts() -> None:
@@ -65,6 +87,48 @@ def test_submit_candidates_skips_duplicate_fact_id_and_payload_hash() -> None:
     assert second.receipts[0].receipt_id == "receipt-original"
     assert second.traces[0].status == "duplicate"
     assert second.traces[0].receipt_id == "receipt-original"
+
+
+def test_submit_candidates_serializes_file_backed_idempotency(
+    tmp_path,
+) -> None:
+    fact = _fact("ann-concurrent-duplicate")
+    subsystem = BlockingSubsystem()
+    store_path = tmp_path / "runs" / "submit_idempotency.json"
+    results: list[Any] = [None, None]
+    errors: list[BaseException | None] = [None, None]
+
+    def submit_with_store(index: int) -> None:
+        try:
+            results[index] = submit_candidates(
+                [fact],
+                subsystem,  # type: ignore[arg-type]
+                idempotency_store=SubmitIdempotencyStore(store_path),
+            )
+        except BaseException as exc:  # pragma: no cover - surfaced below.
+            errors[index] = exc
+
+    first = threading.Thread(target=submit_with_store, args=(0,))
+    second = threading.Thread(target=submit_with_store, args=(1,))
+
+    first.start()
+    assert subsystem.first_submit_started.wait(timeout=2)
+    second.start()
+    assert not subsystem.second_submit_started.wait(timeout=0.2)
+    subsystem.release_submit.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == [None, None]
+    assert len(subsystem.submissions) == 1
+    assert [result.submitted for result in results] == [1, 0]
+    assert [result.skipped_duplicates for result in results] == [0, 1]
+    assert [result.traces[0].status for result in results] == [
+        "accepted",
+        "duplicate",
+    ]
 
 
 def test_submit_candidates_retries_transient_exception() -> None:
@@ -132,6 +196,26 @@ def test_submit_candidates_rejects_runtime_metadata_before_sdk_call() -> None:
     assert result.failed == 1
     assert subsystem.submissions == []
     assert "forbidden" in result.failures[0].errors[0]
+
+
+def test_submit_candidates_rejects_non_official_source_reference_before_sdk_call() -> None:
+    fact = _fact("ann-non-official-source")
+    invalid = fact.model_copy(
+        update={
+            "source_reference": {
+                **fact.source_reference,
+                "official_url": "https://example.com/disclosure/ann.pdf",
+            }
+        }
+    )
+    subsystem = RecordingSubsystem([_accepted("should-not-submit")])
+
+    result = submit_candidates([invalid], subsystem)  # type: ignore[arg-type]
+
+    assert result.submitted == 0
+    assert result.failed == 1
+    assert subsystem.submissions == []
+    assert "official disclosure domain" in result.failures[0].errors[0]
 
 
 def test_runtime_submit_does_not_import_sdk_transport_directly() -> None:

--- a/tests/test_runtime_submit.py
+++ b/tests/test_runtime_submit.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from subsystem_announcement.extract import AnnouncementFactCandidate, extract_fact_candidates
+from subsystem_announcement.runtime import submit as submit_module
+from subsystem_announcement.runtime.submit import (
+    SubmitIdempotencyStore,
+    submit_candidates,
+)
+
+from .extract_fixtures import make_artifact
+
+
+class RecordingSubsystem:
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
+        self.submissions: list[dict[str, Any]] = []
+
+    def submit(self, candidate: dict[str, Any]) -> Any:
+        self.submissions.append(candidate)
+        if not self.outcomes:
+            return _accepted(f"receipt-{len(self.submissions)}")
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def test_submit_candidates_preserves_order_and_records_receipts() -> None:
+    first = _fact("ann-submit-1")
+    second = first.model_copy(update={"fact_id": f"{first.fact_id}:second"})
+    subsystem = RecordingSubsystem([_accepted("receipt-1"), _accepted("receipt-2")])
+
+    result = submit_candidates([first, second], subsystem)  # type: ignore[arg-type]
+
+    assert [payload["fact_id"] for payload in subsystem.submissions] == [
+        first.fact_id,
+        second.fact_id,
+    ]
+    assert result.submitted == 2
+    assert result.skipped_duplicates == 0
+    assert result.failed == 0
+    assert [receipt.receipt_id for receipt in result.receipts] == [
+        "receipt-1",
+        "receipt-2",
+    ]
+    assert [trace.status for trace in result.traces] == ["accepted", "accepted"]
+
+
+def test_submit_candidates_skips_duplicate_fact_id_and_payload_hash() -> None:
+    fact = _fact("ann-duplicate")
+    subsystem = RecordingSubsystem([_accepted("receipt-original")])
+    store = SubmitIdempotencyStore()
+
+    first = submit_candidates([fact], subsystem, idempotency_store=store)  # type: ignore[arg-type]
+    second = submit_candidates([fact], subsystem, idempotency_store=store)  # type: ignore[arg-type]
+
+    assert first.submitted == 1
+    assert second.submitted == 0
+    assert second.skipped_duplicates == 1
+    assert second.failed == 0
+    assert len(subsystem.submissions) == 1
+    assert second.receipts[0].receipt_id == "receipt-original"
+    assert second.traces[0].status == "duplicate"
+    assert second.traces[0].receipt_id == "receipt-original"
+
+
+def test_submit_candidates_retries_transient_exception() -> None:
+    fact = _fact("ann-retry")
+    subsystem = RecordingSubsystem(
+        [RuntimeError("temporary transport failure"), _accepted("receipt-after-retry")]
+    )
+
+    result = submit_candidates([fact], subsystem, max_attempts=3)  # type: ignore[arg-type]
+
+    assert result.submitted == 1
+    assert result.failed == 0
+    assert len(subsystem.submissions) == 2
+    assert result.receipts[0].attempts == 2
+    assert result.traces[0].attempts == 2
+
+
+def test_submit_candidates_records_rejected_result_as_failure() -> None:
+    fact = _fact("ann-rejected")
+    subsystem = RecordingSubsystem(
+        [
+            _rejected("receipt-rejected-1", "contract rejected"),
+            _rejected("receipt-rejected-2", "contract still rejected"),
+        ]
+    )
+
+    result = submit_candidates([fact], subsystem, max_attempts=2)  # type: ignore[arg-type]
+
+    assert result.submitted == 0
+    assert result.failed == 1
+    assert len(subsystem.submissions) == 2
+    assert result.failures[0].fact_id == fact.fact_id
+    assert result.failures[0].attempts == 2
+    assert "contract still rejected" in result.failures[0].errors[-1]
+
+
+def test_submit_candidates_rejects_invalid_payload_before_sdk_call() -> None:
+    fact = _fact("ann-invalid")
+    invalid = fact.model_copy(update={"evidence_spans": []})
+    subsystem = RecordingSubsystem([_accepted("should-not-submit")])
+
+    result = submit_candidates([invalid], subsystem)  # type: ignore[arg-type]
+
+    assert result.submitted == 0
+    assert result.failed == 1
+    assert subsystem.submissions == []
+    assert "evidence span" in result.failures[0].errors[0]
+
+
+def test_submit_candidates_rejects_runtime_metadata_before_sdk_call() -> None:
+    fact = _fact("ann-runtime-metadata")
+    invalid = fact.model_copy(
+        update={
+            "source_reference": {
+                **fact.source_reference,
+                "local_path": "/tmp/cache.pdf",
+            }
+        }
+    )
+    subsystem = RecordingSubsystem([_accepted("should-not-submit")])
+
+    result = submit_candidates([invalid], subsystem)  # type: ignore[arg-type]
+
+    assert result.submitted == 0
+    assert result.failed == 1
+    assert subsystem.submissions == []
+    assert "forbidden" in result.failures[0].errors[0]
+
+
+def test_runtime_submit_does_not_import_sdk_transport_directly() -> None:
+    source = inspect.getsource(submit_module)
+
+    assert "subsystem_sdk.submit" not in source
+    assert "from subsystem_sdk" not in source
+
+
+def _fact(announcement_id: str) -> AnnouncementFactCandidate:
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n"
+        "公司与华东能源签订重大合同，合同金额为1000万元。",
+        announcement_id=announcement_id,
+    )
+    return extract_fact_candidates(artifact)[0]
+
+
+def _accepted(receipt_id: str) -> dict[str, Any]:
+    return {
+        "accepted": True,
+        "receipt_id": receipt_id,
+        "warnings": (),
+        "errors": (),
+    }
+
+
+def _rejected(receipt_id: str, error: str) -> dict[str, Any]:
+    return {
+        "accepted": False,
+        "receipt_id": receipt_id,
+        "warnings": (),
+        "errors": (error,),
+    }

--- a/tests/test_runtime_trace.py
+++ b/tests/test_runtime_trace.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.runtime.trace import (
+    AnnouncementExtractionRun,
+    CandidateSubmitTrace,
+    RunTraceError,
+    TraceStore,
+)
+
+
+def test_trace_store_round_trips_run_json(tmp_path: Path) -> None:
+    store = TraceStore(AnnouncementConfig(artifact_root=tmp_path))
+    run = AnnouncementExtractionRun(
+        run_id="run-1",
+        announcement_id="ann-1",
+        status="partial_failed",
+        started_at=datetime(2026, 4, 18, 9, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 4, 18, 9, 1, tzinfo=timezone.utc),
+        document_artifact_path=tmp_path / "documents" / "ann-1.pdf",
+        parsed_artifact_path=tmp_path / "parsed" / "ann-1.json",
+        candidate_count=2,
+        submit_success_count=1,
+        submit_failure_count=1,
+        candidate_traces=[
+            CandidateSubmitTrace(
+                fact_id="fact-1",
+                status="accepted",
+                receipt_id="receipt-1",
+                attempts=1,
+            ),
+            CandidateSubmitTrace(
+                fact_id="fact-2",
+                status="failed",
+                attempts=3,
+                errors=["rejected"],
+            ),
+        ],
+        errors=[RunTraceError(stage="submit", fact_id="fact-2", message="rejected")],
+    )
+
+    trace_path = store.write(run)
+    loaded = store.load(trace_path)
+
+    assert trace_path == tmp_path / "runs" / "run-1.json"
+    assert loaded == run
+    assert loaded.trace_path == trace_path
+    assert loaded.candidate_traces[0].receipt_id == "receipt-1"
+    assert loaded.errors[0].stage == "submit"
+
+
+def test_trace_store_rejects_unsafe_run_id(tmp_path: Path) -> None:
+    store = TraceStore(tmp_path)
+    run = AnnouncementExtractionRun(
+        run_id="../outside",
+        announcement_id="ann-1",
+        started_at=datetime.now(timezone.utc),
+    )
+
+    with pytest.raises(ValueError, match="Unsafe run_id"):
+        store.write(run)


### PR DESCRIPTION
Closes #7

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/subsystem_announcement/discovery/cache.py`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `tests/test_parse_docling_client.py`, `tests/test_runtime_sdk.py`


---
### 1. 背景与目标
项目文档 §8.2、§16.1 和 §21 阶段 1 要求把 discovery、parse、extract 串成 `元数据引用 -> 正文 -> Ex-1 -> subsystem-sdk submit` 的主链，并记录可审计 run trace。当前 runtime 已有 `AnnouncementSubsystem.submit()`、`lifecycle.run()`、CLI `ping/run` 和 JSON logging，但还没有 `runtime/submit.py`、`runtime/pipeline.py`、`runtime/trace.py` 或 CLI `process`。本 issue 在 #6 的 `AnnouncementFactCandidate.to_ex_payload()` 之上实现批量提交、幂等、失败记录和端到端 process 命令。

### 2. 所属模块
Primary writable paths:
- `src/subsystem_announcement/runtime/submit.py`
- `src/subsystem_announcement/runtime/pipeline.py`
- `src/subsystem_announcement/runtime/trace.py`
- `src/subsystem_announcement/runtime/__init__.py`
- `src/subsystem_announcement/__main__.py`
- `tests/test_runtime_submit.py`
- `tests/test_runtime_trace.py`
- `tests/test_pipeline_e2e.py`
- `tests/fixtures/announcements/`

Adjacent read-only / integration paths:
- `src/subsystem_announcement/runtime/sdk_adapter.py`，直接复用 `AnnouncementSubsystem.submit()`，不绕过 adapter
- `src/subsystem_announcement/runtime/lifecycle.py`，只做回归验证，避免 process 与 heartbeat 混淆
- `src/subsystem_announcement/discovery/*`，调用 #4 的 `consume_announcement_ref`
- `src/subsystem_announcement/parse/*`，调用 #5 的 `parse_announcement`
- `src/subsystem_announcement/extract/*`，调用 #6 的 `extract_fact_candidates`

### 3. 实现范围
- 新建 `runtime/trace.py`，定义 `AnnouncementExtractionRun(BaseModel)`、`CandidateSubmitTrace(BaseModel)`、`TraceStore`，trace JSON 写入 `config.artifact_root / runs / {run_id}.json`。
- 新建 `runtime/submit.py`，定义 `CandidateSubmitReceipt(BaseModel)`、`SubmitBatchResult(BaseModel)`、`SubmitIdempotencyStore`，按 `fact_id` 和 payload hash 做幂等记录。
- 实现 `submit_candidates(candidates: Sequence[AnnouncementFactCandidate], subsystem: AnnouncementSubsystem, *, idempotency_store: SubmitIdempotencyStore | None = None, max_attempts: int = 3) -> SubmitBatchResult`。
- `submit_candidates` 必须保序处理所有候选；提交前验证 `ex_type == 'Ex-1'`、`evidence_spans` 非空、`source_reference` 合法，并拒绝 ingest metadata。
- 对 transient exception 或 SDK rejected result 做有界 retry；最