### PR TITLE
feat(#21): [milestone-1 review] P0: Envelope ts_code metadata is lost before extraction

### DIFF
--- a/src/subsystem_announcement/discovery/cache.py
+++ b/src/subsystem_announcement/discovery/cache.py
@@ -33,6 +33,9 @@ class AnnouncementDocumentCache:
         metadata_path = _metadata_path_for_document(document_path)
         artifact = AnnouncementDocumentArtifact(
             announcement_id=envelope.announcement_id,
+            ts_code=envelope.ts_code,
+            title=envelope.title,
+            publish_time=envelope.publish_time,
             content_hash=content_hash,
             official_url=envelope.official_url,
             source_exchange=envelope.source_exchange,

--- a/src/subsystem_announcement/discovery/dedupe.py
+++ b/src/subsystem_announcement/discovery/dedupe.py
@@ -39,7 +39,12 @@ class AnnouncementDedupeStore:
         metadata_path_text = self._read_index()["announcement_id"].get(announcement_id)
         if metadata_path_text is None:
             return None
-        return self._load_artifact(self._metadata_path_from_index(metadata_path_text))
+        artifact = self._load_artifact(
+            self._metadata_path_from_index(metadata_path_text)
+        )
+        if artifact.announcement_id != announcement_id:
+            return None
+        return artifact
 
     def find_by_content_hash(
         self,
@@ -72,11 +77,37 @@ class AnnouncementDedupeStore:
                     self._metadata_path_from_index(existing_for_id)
                 )
                 if existing_artifact.content_hash == artifact.content_hash:
-                    indexed_hash_path = index["content_hash"].get(
-                        artifact.content_hash
-                    )
-                    if indexed_hash_path != existing_for_id:
-                        index["content_hash"][artifact.content_hash] = existing_for_id
+                    if existing_artifact.announcement_id != target_announcement_id:
+                        canonical_metadata_path_text = index["content_hash"].get(
+                            artifact.content_hash,
+                            existing_for_id,
+                        )
+                        canonical_artifact = self._load_artifact(
+                            self._metadata_path_from_index(canonical_metadata_path_text)
+                        )
+                        announcement_artifact, metadata_path_text = (
+                            self._write_announcement_metadata(
+                                artifact=artifact,
+                                canonical_artifact=canonical_artifact,
+                                announcement_id=target_announcement_id,
+                            )
+                        )
+                        index["announcement_id"][
+                            target_announcement_id
+                        ] = metadata_path_text
+                        if artifact.content_hash not in index["content_hash"]:
+                            index["content_hash"][
+                                artifact.content_hash
+                            ] = canonical_metadata_path_text
+                        self._write_index(index)
+                        return
+                    if artifact.content_hash not in index["content_hash"]:
+                        index["content_hash"][
+                            artifact.content_hash
+                        ] = self._canonical_metadata_path_text(
+                            existing_artifact,
+                            fallback=existing_for_id,
+                        )
                         self._write_index(index)
                     return
                 raise DocumentCacheError(
@@ -86,11 +117,38 @@ class AnnouncementDedupeStore:
                     f"new_hash={artifact.content_hash}"
                 )
 
-            canonical_metadata_path = index["content_hash"].setdefault(
-                artifact.content_hash,
-                metadata_path_text,
-            )
-            index["announcement_id"][target_announcement_id] = canonical_metadata_path
+            canonical_metadata_path = index["content_hash"].get(artifact.content_hash)
+            if canonical_metadata_path is None:
+                index["content_hash"][artifact.content_hash] = metadata_path_text
+                if target_announcement_id == artifact.announcement_id:
+                    index["announcement_id"][
+                        target_announcement_id
+                    ] = metadata_path_text
+                else:
+                    announcement_artifact, alias_metadata_path_text = (
+                        self._write_announcement_metadata(
+                            artifact=artifact,
+                            canonical_artifact=artifact,
+                            announcement_id=target_announcement_id,
+                        )
+                    )
+                    index["announcement_id"][
+                        announcement_artifact.announcement_id
+                    ] = alias_metadata_path_text
+            else:
+                canonical_artifact = self._load_artifact(
+                    self._metadata_path_from_index(canonical_metadata_path)
+                )
+                announcement_artifact, duplicate_metadata_path_text = (
+                    self._write_announcement_metadata(
+                        artifact=artifact,
+                        canonical_artifact=canonical_artifact,
+                        announcement_id=target_announcement_id,
+                    )
+                )
+                index["announcement_id"][
+                    announcement_artifact.announcement_id
+                ] = duplicate_metadata_path_text
             self._write_index(index)
 
     def resolve_or_record(
@@ -116,8 +174,41 @@ class AnnouncementDedupeStore:
                         f"existing_hash={existing_artifact.content_hash} "
                         f"new_hash={content_hash}"
                     )
-                if index["content_hash"].get(content_hash) != existing_for_id:
-                    index["content_hash"][content_hash] = existing_for_id
+                if existing_artifact.announcement_id != announcement_id:
+                    canonical_metadata_path_text = index["content_hash"].get(
+                        content_hash,
+                        existing_for_id,
+                    )
+                    canonical_artifact = self._load_artifact(
+                        self._metadata_path_from_index(canonical_metadata_path_text)
+                    )
+                    artifact = create_artifact()
+                    self._validate_created_artifact(
+                        artifact,
+                        announcement_id=announcement_id,
+                        content_hash=content_hash,
+                    )
+                    announcement_artifact, metadata_path_text = (
+                        self._write_announcement_metadata(
+                            artifact=artifact,
+                            canonical_artifact=canonical_artifact,
+                            announcement_id=announcement_id,
+                        )
+                    )
+                    index["announcement_id"][announcement_id] = metadata_path_text
+                    if content_hash not in index["content_hash"]:
+                        index["content_hash"][
+                            content_hash
+                        ] = canonical_metadata_path_text
+                    self._write_index(index)
+                    return "duplicate", announcement_artifact
+                if content_hash not in index["content_hash"]:
+                    index["content_hash"][content_hash] = (
+                        self._canonical_metadata_path_text(
+                            existing_artifact,
+                            fallback=existing_for_id,
+                        )
+                    )
                     self._write_index(index)
                 return "duplicate", existing_artifact
 
@@ -126,23 +217,29 @@ class AnnouncementDedupeStore:
                 existing_artifact = self._load_artifact(
                     self._metadata_path_from_index(existing_for_hash)
                 )
-                index["announcement_id"][announcement_id] = existing_for_hash
+                artifact = create_artifact()
+                self._validate_created_artifact(
+                    artifact,
+                    announcement_id=announcement_id,
+                    content_hash=content_hash,
+                )
+                announcement_artifact, metadata_path_text = (
+                    self._write_announcement_metadata(
+                        artifact=artifact,
+                        canonical_artifact=existing_artifact,
+                        announcement_id=announcement_id,
+                    )
+                )
+                index["announcement_id"][announcement_id] = metadata_path_text
                 self._write_index(index)
-                return "duplicate", existing_artifact
+                return "duplicate", announcement_artifact
 
             artifact = create_artifact()
-            if artifact.announcement_id != announcement_id:
-                raise DocumentCacheError(
-                    "Cached artifact announcement_id mismatch: "
-                    f"announcement_id={announcement_id} "
-                    f"artifact_announcement_id={artifact.announcement_id}"
-                )
-            if artifact.content_hash != content_hash:
-                raise DocumentCacheError(
-                    "Cached artifact content_hash mismatch: "
-                    f"announcement_id={announcement_id} "
-                    f"expected_hash={content_hash} actual_hash={artifact.content_hash}"
-                )
+            self._validate_created_artifact(
+                artifact,
+                announcement_id=announcement_id,
+                content_hash=content_hash,
+            )
             metadata_path_text = self._metadata_path_to_index(
                 _metadata_path_for_document(artifact.local_path)
             )
@@ -177,7 +274,13 @@ class AnnouncementDedupeStore:
             )
             temp_path = Path(temp_path_text)
             with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
-                json.dump(index, temp_file, ensure_ascii=False, indent=2, sort_keys=True)
+                json.dump(
+                    index,
+                    temp_file,
+                    ensure_ascii=False,
+                    indent=2,
+                    sort_keys=True,
+                )
                 temp_file.write("\n")
             temp_path.replace(self.index_path)
         except OSError as exc:
@@ -203,9 +306,108 @@ class AnnouncementDedupeStore:
             return artifact.model_copy(update={"local_path": document_path})
         return artifact
 
+    def _write_announcement_metadata(
+        self,
+        *,
+        artifact: AnnouncementDocumentArtifact,
+        canonical_artifact: AnnouncementDocumentArtifact,
+        announcement_id: str,
+    ) -> tuple[AnnouncementDocumentArtifact, str]:
+        if artifact.content_hash != canonical_artifact.content_hash:
+            raise DocumentCacheError(
+                "Duplicate announcement content_hash mismatch: "
+                f"announcement_id={announcement_id} "
+                f"artifact_hash={artifact.content_hash} "
+                f"canonical_hash={canonical_artifact.content_hash}"
+            )
+        announcement_artifact = artifact.model_copy(
+            update={
+                "announcement_id": announcement_id,
+                "local_path": canonical_artifact.local_path,
+            }
+        )
+        metadata_path = _metadata_path_for_announcement(
+            canonical_artifact.local_path,
+            canonical_artifact.content_hash,
+            announcement_id,
+        )
+        try:
+            metadata_path.parent.mkdir(parents=True, exist_ok=True)
+            metadata_path.write_text(
+                announcement_artifact.model_dump_json(indent=2),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            raise DocumentCacheError(
+                "Unable to write announcement dedupe metadata: "
+                f"announcement_id={announcement_id} path={metadata_path}"
+            ) from exc
+
+        self._remove_redundant_artifact_files(
+            artifact=artifact,
+            canonical_artifact=canonical_artifact,
+        )
+        return announcement_artifact, self._metadata_path_to_index(metadata_path)
+
+    def _remove_redundant_artifact_files(
+        self,
+        *,
+        artifact: AnnouncementDocumentArtifact,
+        canonical_artifact: AnnouncementDocumentArtifact,
+    ) -> None:
+        if artifact.local_path == canonical_artifact.local_path:
+            return
+
+        paths = [
+            artifact.local_path,
+            _metadata_path_for_document(artifact.local_path),
+        ]
+        try:
+            for path in paths:
+                path.unlink(missing_ok=True)
+        except OSError as exc:
+            raise DocumentCacheError(
+                "Unable to remove redundant duplicate document cache files: "
+                f"announcement_id={artifact.announcement_id} path={path}"
+            ) from exc
+
+    def _canonical_metadata_path_text(
+        self,
+        artifact: AnnouncementDocumentArtifact,
+        *,
+        fallback: str,
+    ) -> str:
+        metadata_path = _metadata_path_for_document(artifact.local_path)
+        if not metadata_path.exists():
+            return fallback
+        return self._metadata_path_to_index(metadata_path)
+
+    def _validate_created_artifact(
+        self,
+        artifact: AnnouncementDocumentArtifact,
+        *,
+        announcement_id: str,
+        content_hash: str,
+    ) -> None:
+        if artifact.announcement_id != announcement_id:
+            raise DocumentCacheError(
+                "Cached artifact announcement_id mismatch: "
+                f"announcement_id={announcement_id} "
+                f"artifact_announcement_id={artifact.announcement_id}"
+            )
+        if artifact.content_hash != content_hash:
+            raise DocumentCacheError(
+                "Cached artifact content_hash mismatch: "
+                f"announcement_id={announcement_id} "
+                f"expected_hash={content_hash} actual_hash={artifact.content_hash}"
+            )
+
     def _metadata_path_to_index(self, metadata_path: Path) -> str:
         try:
-            return str(metadata_path.resolve().relative_to(self.artifact_root.resolve()))
+            relative_path = metadata_path.resolve().relative_to(
+                self.artifact_root.resolve()
+            )
+            return str(relative_path)
         except ValueError as exc:
             raise DocumentCacheError(
                 "Dedupe metadata path escaped artifact_root: "
@@ -240,6 +442,17 @@ def _metadata_path_for_document(local_path: Path) -> Path:
     return local_path.with_name(f"{local_path.stem}.metadata.json")
 
 
+def _metadata_path_for_announcement(
+    canonical_local_path: Path,
+    content_hash: str,
+    announcement_id: str,
+) -> Path:
+    announcement_digest = hashlib.sha256(announcement_id.encode("utf-8")).hexdigest()
+    return canonical_local_path.with_name(
+        f"{content_hash}.announcement-{announcement_digest}.metadata.json"
+    )
+
+
 def _document_path_for_metadata(
     metadata_path: Path,
     artifact: AnnouncementDocumentArtifact,
@@ -247,5 +460,6 @@ def _document_path_for_metadata(
     metadata_suffix = ".metadata.json"
     if not metadata_path.name.endswith(metadata_suffix):
         return artifact.local_path
-    content_stem = metadata_path.name[: -len(metadata_suffix)]
-    return metadata_path.with_name(f"{content_stem}{artifact.local_path.suffix}")
+    return metadata_path.with_name(
+        f"{artifact.content_hash}{artifact.local_path.suffix}"
+    )

--- a/src/subsystem_announcement/discovery/document.py
+++ b/src/subsystem_announcement/discovery/document.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
-from pydantic import AnyUrl, BaseModel, ConfigDict, Field
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, field_validator
 
 
 class AnnouncementDocumentArtifact(BaseModel):
@@ -15,6 +15,9 @@ class AnnouncementDocumentArtifact(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     announcement_id: str = Field(min_length=1)
+    ts_code: str | None = Field(default=None, min_length=1)
+    title: str | None = Field(default=None, min_length=1)
+    publish_time: datetime | None = None
     content_hash: str = Field(min_length=64, max_length=64)
     official_url: AnyUrl
     source_exchange: str = Field(min_length=1)
@@ -23,6 +26,29 @@ class AnnouncementDocumentArtifact(BaseModel):
     content_type: str = Field(min_length=1)
     byte_size: int = Field(ge=0)
     fetched_at: datetime
+
+    @field_validator("ts_code", "title")
+    @classmethod
+    def strip_optional_text(cls, value: str | None) -> str | None:
+        """Normalize optional envelope provenance without inventing values."""
+
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("optional envelope provenance must not be empty")
+        return stripped
+
+    @field_validator("publish_time", "fetched_at")
+    @classmethod
+    def require_timezone(cls, value: datetime | None) -> datetime | None:
+        """Reject naive datetimes so replay provenance is unambiguous."""
+
+        if value is None:
+            return None
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("announcement document datetimes must include timezone")
+        return value
 
 
 class AnnouncementDiscoveryResult(BaseModel):

--- a/src/subsystem_announcement/extract/candidates.py
+++ b/src/subsystem_announcement/extract/candidates.py
@@ -117,17 +117,25 @@ def build_source_reference(
 ) -> dict[str, Any]:
     """Build official-source reference without local filesystem metadata."""
 
-    official_url = str(parsed_artifact.source_document.official_url).strip()
+    source_document = parsed_artifact.source_document
+    official_url = str(source_document.official_url).strip()
     if not official_url:
         raise ValueError("official source reference is required")
-    return {
+    source_reference = {
         "announcement_id": parsed_artifact.announcement_id,
         "official_url": official_url,
-        "source_exchange": parsed_artifact.source_document.source_exchange,
-        "attachment_type": parsed_artifact.source_document.attachment_type,
+        "source_exchange": source_document.source_exchange,
+        "attachment_type": source_document.attachment_type,
         "content_hash": parsed_artifact.content_hash,
         "parser_version": parsed_artifact.parser_version,
     }
+    if source_document.ts_code is not None:
+        source_reference["ts_code"] = source_document.ts_code
+    if source_document.title is not None:
+        source_reference["title"] = source_document.title
+    if source_document.publish_time is not None:
+        source_reference["publish_time"] = source_document.publish_time.isoformat()
+    return source_reference
 
 
 def build_fact_candidate(

--- a/src/subsystem_announcement/extract/entity_anchor.py
+++ b/src/subsystem_announcement/extract/entity_anchor.py
@@ -99,6 +99,19 @@ class EntityAnchorer:
     ) -> EntityAnchor:
         """Anchor the announcing company from code/short-name before registry use."""
 
+        envelope_ts_code = _optional_str(parsed_artifact.source_document.ts_code)
+        if envelope_ts_code is not None:
+            normalized_code = _normalize_ts_code(
+                envelope_ts_code,
+                parsed_artifact.source_document.source_exchange,
+            )
+            return EntityAnchor(
+                mention_text=normalized_code,
+                entity_id=f"ts_code:{normalized_code}",
+                confidence=1.0,
+                resolution_method="ts_code",
+            )
+
         text = _artifact_body_text(parsed_artifact)
         ts_code = _extract_ts_code(text)
         short_name = _extract_short_name(text)

--- a/tests/extract_fixtures.py
+++ b/tests/extract_fixtures.py
@@ -16,6 +16,9 @@ def make_artifact(
     *,
     announcement_id: str = "ann-extract-1",
     title: str = "测试公告",
+    source_ts_code: str | None = None,
+    source_title: str | None = None,
+    source_publish_time: datetime | None = None,
     source_exchange: str = "sse",
     tables: list[AnnouncementTable] | None = None,
 ) -> ParsedAnnouncementArtifact:
@@ -53,6 +56,9 @@ def make_artifact(
         parsed_at=datetime(2026, 4, 18, 9, 31, tzinfo=timezone.utc),
         source_document=AnnouncementDocumentArtifact(
             announcement_id=announcement_id,
+            ts_code=source_ts_code,
+            title=source_title,
+            publish_time=source_publish_time,
             content_hash="a" * 64,
             official_url=f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf",
             source_exchange=source_exchange,

--- a/tests/test_discovery_cache.py
+++ b/tests/test_discovery_cache.py
@@ -21,17 +21,27 @@ from subsystem_announcement.discovery.dedupe import (
 )
 from subsystem_announcement.discovery.envelope import AnnouncementEnvelope
 from subsystem_announcement.discovery.errors import DocumentCacheError
+from subsystem_announcement.extract import extract_fact_candidates
+from subsystem_announcement.parse.artifact import (
+    AnnouncementSection,
+    ParsedAnnouncementArtifact,
+)
 
 
 def _envelope(
     announcement_id: str = "ann-1",
     url: str | None = None,
+    *,
+    ts_code: str = "600000.SH",
+    title: str = "重大合同公告",
+    publish_time: datetime | None = None,
 ) -> AnnouncementEnvelope:
     return AnnouncementEnvelope(
         announcement_id=announcement_id,
-        ts_code="600000.SH",
-        title="重大合同公告",
-        publish_time=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+        ts_code=ts_code,
+        title=title,
+        publish_time=publish_time
+        or datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
         official_url=url
         or f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf",
         source_exchange="sse",
@@ -116,6 +126,35 @@ def test_dedupe_store_rejects_same_announcement_id_with_conflicting_hash(
         store.record(second)
 
     assert store.find_by_announcement_id("ann-1") == first
+
+
+def test_dedupe_store_records_same_hash_with_per_announcement_metadata(
+    tmp_path: Path,
+) -> None:
+    config = AnnouncementConfig(artifact_root=tmp_path)
+    cache = AnnouncementDocumentCache(config)
+    first = cache.put(_envelope("ann-1", ts_code="600000.SH"), b"same pdf bytes")
+    second = cache.put(
+        _envelope(
+            "ann-2",
+            ts_code="000001.SZ",
+            title="平安银行业绩预告",
+        ),
+        b"same pdf bytes",
+    )
+    store = AnnouncementDedupeStore(tmp_path)
+
+    store.record(first)
+    store.record(second)
+
+    loaded_second = store.find_by_announcement_id("ann-2")
+    assert loaded_second is not None
+    assert loaded_second.announcement_id == "ann-2"
+    assert loaded_second.ts_code == "000001.SZ"
+    assert loaded_second.title == "平安银行业绩预告"
+    assert loaded_second.local_path == first.local_path
+    assert store.find_by_content_hash(first.content_hash) == first
+    assert len(_document_body_files(tmp_path)) == 1
 
 
 def test_dedupe_store_uses_relative_paths_after_artifact_root_move(
@@ -223,10 +262,68 @@ def test_consume_announcement_ref_marks_same_content_hash_duplicate(
     assert first.status == "fetched"
     assert second.status == "duplicate"
     assert third.status == "duplicate"
+    assert second.document.announcement_id == "ann-2"
+    assert third.document.announcement_id == "ann-2"
     assert second.document.local_path == first.document.local_path
     assert third.document.local_path == first.document.local_path
     assert request_count == 2
     assert len(body_files) == 1
+
+
+def test_duplicate_content_preserves_current_envelope_for_extraction_anchor(
+    tmp_path: Path,
+) -> None:
+    publish_time = datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"same pdf bytes")
+
+    async def scenario():
+        config = AnnouncementConfig(artifact_root=tmp_path)
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            first = await consume_announcement_ref(
+                _envelope(
+                    "ann-1",
+                    ts_code="600000.SH",
+                    title="浦发银行业绩预告",
+                ),
+                config,
+                client=client,
+            )
+            second = await consume_announcement_ref(
+                _envelope(
+                    "ann-2",
+                    ts_code="000001.SZ",
+                    title="平安银行业绩预告",
+                    publish_time=publish_time,
+                ),
+                config,
+                client=client,
+            )
+            return first, second
+
+    first, second = asyncio.run(scenario())
+    parsed = _parsed_artifact(
+        second.document,
+        "公司预计2026年净利润同比增长50%，本公告为业绩预告。",
+    )
+
+    fact = extract_fact_candidates(parsed)[0]
+
+    assert second.status == "duplicate"
+    assert second.document.local_path == first.document.local_path
+    assert second.document.announcement_id == "ann-2"
+    assert second.document.ts_code == "000001.SZ"
+    assert second.document.title == "平安银行业绩预告"
+    assert second.document.publish_time == publish_time
+    assert fact.announcement_id == "ann-2"
+    assert fact.primary_entity_id == "ts_code:000001.SZ"
+    assert fact.source_reference["ts_code"] == "000001.SZ"
+    assert fact.source_reference["title"] == "平安银行业绩预告"
+    assert fact.source_reference["publish_time"] == publish_time.isoformat()
+    assert len(_document_body_files(tmp_path)) == 1
 
 
 def test_consume_announcement_ref_concurrent_same_id_returns_canonical_artifact(
@@ -317,3 +414,30 @@ def _document_body_files(root: Path) -> list[Path]:
         for path in (root / "documents").rglob("*")
         if path.is_file() and path.suffix in {".pdf", ".html", ".doc", ".docx"}
     ]
+
+
+def _parsed_artifact(
+    document,
+    text: str,
+) -> ParsedAnnouncementArtifact:
+    return ParsedAnnouncementArtifact(
+        announcement_id=document.announcement_id,
+        content_hash=document.content_hash,
+        parser_version="docling==2.15.1",
+        title_hierarchy=[document.title or "测试公告"],
+        sections=[
+            AnnouncementSection(
+                section_id="sec-0001",
+                title=document.title,
+                level=1,
+                text=text,
+                start_offset=0,
+                end_offset=len(text),
+                parent_id=None,
+            )
+        ],
+        tables=[],
+        extracted_text=text,
+        parsed_at=datetime(2026, 4, 18, 9, 31, tzinfo=timezone.utc),
+        source_document=document,
+    )

--- a/tests/test_discovery_cache.py
+++ b/tests/test_discovery_cache.py
@@ -61,6 +61,9 @@ def test_document_cache_put_writes_bytes_and_round_trips_metadata(
     assert cache.load(artifact.local_path) == artifact
     assert artifact.byte_size == len(b"pdf bytes")
     assert artifact.content_type == "application/pdf"
+    assert artifact.ts_code == "600000.SH"
+    assert artifact.title == "重大合同公告"
+    assert artifact.publish_time == _envelope().publish_time
 
 
 def test_dedupe_store_finds_recorded_artifact_by_id_and_hash(

--- a/tests/test_extract_fact_candidates.py
+++ b/tests/test_extract_fact_candidates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -86,6 +87,26 @@ def test_unresolved_primary_entity_is_retained_without_guessing() -> None:
     assert fact.fact_content["primary_entity"]["unresolved_ref"].startswith(
         "unresolved:"
     )
+
+
+def test_envelope_ts_code_anchors_primary_entity_when_body_has_no_code() -> None:
+    publish_time = datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc)
+    artifact = make_artifact(
+        "公司预计2026年净利润同比增长50%，本公告为业绩预告。",
+        announcement_id="ann-envelope-code",
+        source_ts_code="600519.SH",
+        source_title="贵州茅台业绩预告",
+        source_publish_time=publish_time,
+        source_exchange="sse",
+    )
+
+    fact = extract_fact_candidates(artifact)[0]
+
+    assert fact.primary_entity_id == "ts_code:600519.SH"
+    assert fact.fact_content["primary_entity"]["resolution_method"] == "ts_code"
+    assert fact.source_reference["ts_code"] == "600519.SH"
+    assert fact.source_reference["title"] == "贵州茅台业绩预告"
+    assert fact.source_reference["publish_time"] == publish_time.isoformat()
 
 
 class RecordingReasoner:

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -170,6 +170,9 @@ async def _fake_discovery(
     document_path.write_bytes(b"%PDF mocked fixture")
     document = AnnouncementDocumentArtifact(
         announcement_id=envelope.announcement_id,
+        ts_code=envelope.ts_code,
+        title=envelope.title,
+        publish_time=envelope.publish_time,
         content_hash="b" * 64,
         official_url=envelope.official_url,
         source_exchange=envelope.source_exchange,


### PR DESCRIPTION
Closes #21

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/subsystem_announcement/discovery/cache.py`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/runtime/submit.py`, `tests/contracts/test_ex1_contract.py`, `tests/test_parse_docling_client.py`, `tests/test_runtime_sdk.py`


---
## 背景与目标
Milestone review for milestone-1 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
AnnouncementEnvelope carries ts_code, title, and publish_time, but AnnouncementDocumentArtifact and ParsedAnnouncementArtifact do not preserve that metadata. EntityAnchorer then tries to recover the primary entity by regex over normalized body sections. If Docling drops header text or the body lacks a securities-code line, deterministic anchoring falls back to unresolved even though the upstream envelope had the canonical ts_code. This violates the required anchoring order and makes later Ex-2/Ex-3 outputs depend on brittle body parsing.

## 实现范围
- 修改文件: `cross-cutting`
- Carry at least ts_code, title, and publish_time through the document or parsed artifact provenance, build ExtractionContext.primary_entity from that metadata before body regex, include ts_code in source provenance where appropriate, and add a regression where the body has no code but the envelope does.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/subsystem-announcement/.venv/bin/python -m pytest
```
