### PR TITLE
feat(#20): [milestone-1 review] P0: Pipeline never wires configured entity registry or reasoner

### DIFF
--- a/src/subsystem_announcement/runtime/pipeline.py
+++ b/src/subsystem_announcement/runtime/pipeline.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable, Sequence
+import importlib
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,11 @@ from subsystem_announcement.discovery import (
 from subsystem_announcement.discovery.document import AnnouncementDocumentArtifact
 from subsystem_announcement.extract import (
     AnnouncementFactCandidate,
+    EntityMention,
+    EntityRegistryClient,
+    EntityResolution,
+    ReasonerRuntimeBridge,
+    StructuredReasoner,
     extract_fact_candidates,
 )
 from subsystem_announcement.parse import ParsedAnnouncementArtifact, parse_announcement
@@ -37,7 +43,7 @@ ParseFunc = Callable[
     ParsedAnnouncementArtifact | Awaitable[ParsedAnnouncementArtifact],
 ]
 ExtractFunc = Callable[
-    [ParsedAnnouncementArtifact],
+    ...,
     Sequence[AnnouncementFactCandidate] | Awaitable[Sequence[AnnouncementFactCandidate]],
 ]
 
@@ -61,6 +67,8 @@ class AnnouncementPipeline:
         self._discovery_func = discovery_func
         self._parse_func = parse_func
         self._extract_func = extract_func
+        self._entity_registry = _build_entity_registry(config)
+        self._reasoner = _build_reasoner(config)
         self._idempotency_store = idempotency_store or SubmitIdempotencyStore(
             Path(config.artifact_root) / "runs" / "submit_idempotency.json"
         )
@@ -130,7 +138,13 @@ class AnnouncementPipeline:
         self,
         artifact: ParsedAnnouncementArtifact,
     ) -> Sequence[AnnouncementFactCandidate]:
-        return await _maybe_await(self._extract_func(artifact))
+        kwargs: dict[str, Any] = {}
+        if self._entity_registry is not None:
+            kwargs["entity_registry"] = self._entity_registry
+        if self._reasoner is not None:
+            kwargs["reasoner"] = self._reasoner
+        supported_kwargs = _supported_extract_kwargs(self._extract_func, kwargs)
+        return await _maybe_await(self._extract_func(artifact, **supported_kwargs))
 
     def _get_subsystem(self) -> AnnouncementSubsystem:
         if self._subsystem is None:
@@ -138,10 +152,99 @@ class AnnouncementPipeline:
         return self._subsystem
 
 
+class EntityRegistryRuntimeAdapter:
+    """Adapter around the entity-registry runtime module."""
+
+    def __init__(self, *, endpoint: str | None = None) -> None:
+        self.endpoint = endpoint
+
+    def lookup_alias(self, name: str) -> EntityResolution | Mapping[str, Any] | None:
+        """Resolve a deterministic alias through entity-registry."""
+
+        return self._call_runtime("lookup_alias", name)
+
+    def resolve_mentions(
+        self,
+        mentions: Sequence[EntityMention],
+    ) -> Sequence[EntityResolution | Mapping[str, Any]]:
+        """Resolve fuzzy mentions through entity-registry."""
+
+        payload = [mention.model_dump(mode="json") for mention in mentions]
+        result = self._call_runtime("resolve_mentions", payload)
+        if result is None:
+            return []
+        if isinstance(result, Sequence) and not isinstance(
+            result,
+            str | bytes | bytearray,
+        ):
+            return result
+        raise TypeError("entity_registry.resolve_mentions returned non-sequence")
+
+    def _call_runtime(self, function_name: str, *args: Any) -> Any:
+        try:
+            entity_registry = importlib.import_module("entity_registry")
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "entity-registry endpoint is configured but "
+                "the entity_registry runtime module is not importable"
+            ) from exc
+        runtime_func = getattr(entity_registry, function_name, None)
+        if not callable(runtime_func):
+            raise RuntimeError(f"entity_registry.{function_name} is not callable")
+        if _accepts_keyword(runtime_func, "endpoint") and self.endpoint is not None:
+            return runtime_func(*args, endpoint=self.endpoint)
+        return runtime_func(*args)
+
+
 async def _maybe_await(value: Any) -> Any:
     if inspect.isawaitable(value):
         return await value
     return value
+
+
+def _build_entity_registry(
+    config: AnnouncementConfig,
+) -> EntityRegistryClient | None:
+    if config.entity_registry_endpoint is None:
+        return None
+    return EntityRegistryRuntimeAdapter(endpoint=config.entity_registry_endpoint)
+
+
+def _build_reasoner(config: AnnouncementConfig) -> StructuredReasoner | None:
+    if config.reasoner_endpoint is None:
+        return None
+    return ReasonerRuntimeBridge(endpoint=config.reasoner_endpoint)
+
+
+def _supported_extract_kwargs(
+    extract_func: ExtractFunc,
+    kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        name: value
+        for name, value in kwargs.items()
+        if _accepts_keyword(extract_func, name)
+    }
+
+
+def _accepts_keyword(func: Callable[..., Any], name: str) -> bool:
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return True
+    parameters = signature.parameters
+    if any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    ):
+        return True
+    parameter = parameters.get(name)
+    if parameter is None:
+        return False
+    return parameter.kind in {
+        inspect.Parameter.KEYWORD_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    }
 
 
 def _apply_submit_result(

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -156,6 +158,110 @@ def test_process_envelope_skips_reextracted_duplicate_with_file_backed_idempoten
     assert all(trace.status == "duplicate" for trace in second_run.candidate_traces)
 
 
+def test_process_envelope_wires_configured_registry_and_reasoner(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    envelope = _fixture_envelope()
+    subsystem = RecordingSubsystem()
+    registry_endpoint = "entity-registry://fake"
+    reasoner_endpoint = "reasoner-runtime://fake"
+    registry_calls: list[tuple[str, Any, str | None]] = []
+    reasoner_payloads: list[dict[str, Any]] = []
+
+    def lookup_alias(name: str, *, endpoint: str | None = None) -> dict[str, Any] | None:
+        registry_calls.append(("lookup_alias", name, endpoint))
+        if name == "测试股份":
+            return {
+                "mention": name,
+                "entity_id": "entity-primary",
+                "entity_name": "测试股份有限公司",
+                "confidence": 0.96,
+                "resolution_method": "lookup_alias",
+            }
+        return None
+
+    def resolve_mentions(
+        mentions: list[dict[str, Any]],
+        *,
+        endpoint: str | None = None,
+    ) -> list[dict[str, Any]]:
+        registry_calls.append(
+            ("resolve_mentions", [mention["name"] for mention in mentions], endpoint)
+        )
+        return [
+            {
+                "mention": mention,
+                "entity_id": "entity-counterparty",
+                "entity_name": "银河资本有限公司",
+                "confidence": 0.82,
+                "resolution_method": "resolve_mentions",
+            }
+            for mention in mentions
+        ]
+
+    def generate_structured(payload: dict[str, Any]) -> dict[str, Any]:
+        reasoner_payloads.append(payload)
+        return {
+            "facts": [
+                {
+                    "quote": "公司与银河资本签署战略合作协议。",
+                    "fact_content": {"agreement_type": "strategic_cooperation"},
+                    "confidence": 0.72,
+                    "related_mentions": ["银河资本"],
+                }
+            ]
+        }
+
+    monkeypatch.setitem(
+        sys.modules,
+        "entity_registry",
+        types.SimpleNamespace(
+            lookup_alias=lookup_alias,
+            resolve_mentions=resolve_mentions,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "reasoner_runtime",
+        types.SimpleNamespace(generate_structured=generate_structured),
+    )
+
+    config = _config(tmp_path).model_copy(
+        update={
+            "entity_registry_endpoint": registry_endpoint,
+            "reasoner_endpoint": reasoner_endpoint,
+        }
+    )
+
+    pipeline = AnnouncementPipeline(
+        config,
+        subsystem=subsystem,  # type: ignore[arg-type]
+        discovery_func=_fake_discovery,
+        parse_func=_parse_reasoner_only_major_contract,
+    )
+
+    run = asyncio.run(pipeline.process_envelope(envelope))
+
+    assert run.status == "succeeded"
+    assert run.candidate_count == 1
+    assert reasoner_payloads
+    assert reasoner_payloads[0]["endpoint"] == reasoner_endpoint
+    assert registry_calls == [
+        ("lookup_alias", "测试股份", registry_endpoint),
+        ("lookup_alias", "银河资本", registry_endpoint),
+        ("resolve_mentions", ["银河资本"], registry_endpoint),
+    ]
+    assert subsystem.submissions[0]["primary_entity_id"] == "entity-primary"
+    assert subsystem.submissions[0]["related_entity_ids"] == ["entity-counterparty"]
+    assert (
+        subsystem.submissions[0]["fact_content"]["reasoner_fact_content"][
+            "agreement_type"
+        ]
+        == "strategic_cooperation"
+    )
+
+
 def _fixture_envelope() -> AnnouncementEnvelope:
     path = ROOT / "tests" / "fixtures" / "announcements" / "earnings_envelope.json"
     return AnnouncementEnvelope.model_validate_json(path.read_text(encoding="utf-8"))
@@ -190,6 +296,23 @@ def _fake_parse(
         "证券代码：600000\n证券简称：测试公司\n"
         "公司预计2026年净利润同比增长50%，本公告为业绩预告。",
         announcement_id=document.announcement_id,
+    )
+    return artifact.model_copy(
+        update={
+            "content_hash": document.content_hash,
+            "source_document": document,
+        }
+    )
+
+
+def _parse_reasoner_only_major_contract(
+    document: AnnouncementDocumentArtifact,
+    config: AnnouncementConfig,
+) -> ParsedAnnouncementArtifact:
+    artifact = make_artifact(
+        "公司名称：测试股份\n公司与银河资本签署战略合作协议。",
+        announcement_id=document.announcement_id,
+        title="战略合作公告",
     )
     return artifact.model_copy(
         update={


### PR DESCRIPTION
Closes #20

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/runtime/submit.py`, `tests/contracts/test_ex1_contract.py`, `tests/test_parse_docling_client.py`, `tests/test_runtime_sdk.py`


---
## 背景与目标
Milestone review for milestone-1 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The extract layer accepts entity_registry and reasoner dependencies, and AnnouncementConfig exposes entity_registry_endpoint and reasoner_endpoint, but AnnouncementPipeline calls extract_fact_candidates with only the parsed artifact. The CLI process path therefore runs deterministic rules only; it never constructs an entity-registry client or ReasonerRuntimeBridge from config. This breaks the milestone's integrated Ex-1 goal because entity anchoring and difficult-segment extraction were implemented but are unreachable in the main path.

## 实现范围
- 修改文件: `src/subsystem_announcement/runtime/pipeline.py`
- Add runtime adapters for entity-registry and reasoner-runtime, construct them from AnnouncementConfig in AnnouncementPipeline, pass them into extract_fact_candidates, and add an end-to-end process test with fake registry and fake reasoner proving the configured integrations are invoked.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/subsystem-announcement/.venv/bin/python -m pytest
```
