### PR TITLE
feat(#8): Ex-2 公告信号生成

### DIFF
--- a/src/subsystem_announcement/runtime/pipeline.py
+++ b/src/subsystem_announcement/runtime/pipeline.py
@@ -28,9 +28,19 @@ from subsystem_announcement.extract import (
 )
 from subsystem_announcement.parse import ParsedAnnouncementArtifact, parse_announcement
 from subsystem_announcement.parse.artifact import write_parsed_artifact
+from subsystem_announcement.signals import (
+    AnnouncementSignalCandidate,
+    SignalFunc,
+    derive_signal_candidates,
+)
 
 from .sdk_adapter import AnnouncementSubsystem
-from .submit import SubmitBatchResult, SubmitIdempotencyStore, submit_candidates
+from .submit import (
+    CandidatePayload,
+    SubmitBatchResult,
+    SubmitIdempotencyStore,
+    submit_candidates,
+)
 from .trace import AnnouncementExtractionRun, RunTraceError, TraceStore
 
 
@@ -49,7 +59,7 @@ ExtractFunc = Callable[
 
 
 class AnnouncementPipeline:
-    """Process one announcement envelope through Ex-1 submission."""
+    """Process one announcement envelope through Ex-1/Ex-2 submission."""
 
     def __init__(
         self,
@@ -59,6 +69,7 @@ class AnnouncementPipeline:
         discovery_func: DiscoveryFunc = consume_announcement_ref,
         parse_func: ParseFunc = parse_announcement,
         extract_func: ExtractFunc = extract_fact_candidates,
+        signal_func: SignalFunc = derive_signal_candidates,
         idempotency_store: SubmitIdempotencyStore | None = None,
         trace_store: TraceStore | None = None,
     ) -> None:
@@ -67,6 +78,7 @@ class AnnouncementPipeline:
         self._discovery_func = discovery_func
         self._parse_func = parse_func
         self._extract_func = extract_func
+        self._signal_func = signal_func
         self._entity_registry = _build_entity_registry(config)
         self._reasoner = _build_reasoner(config)
         self._idempotency_store = idempotency_store or SubmitIdempotencyStore(
@@ -78,7 +90,7 @@ class AnnouncementPipeline:
         self,
         envelope: AnnouncementEnvelope,
     ) -> AnnouncementExtractionRun:
-        """Run discovery, parse, Ex-1 extraction, submit, and trace persistence."""
+        """Run discovery, parse, Ex-1 extraction, Ex-2 signals, submit, and trace."""
 
         run = AnnouncementExtractionRun(
             run_id=str(uuid4()),
@@ -95,7 +107,9 @@ class AnnouncementPipeline:
                 self.config.artifact_root,
             )
 
-            candidates = list(await self._call_extract(parsed_artifact))
+            facts = list(await self._call_extract(parsed_artifact))
+            signals = list(await self._call_signals(facts))
+            candidates: list[CandidatePayload] = [*facts, *signals]
             run.candidate_count = len(candidates)
 
             if candidates:
@@ -145,6 +159,12 @@ class AnnouncementPipeline:
             kwargs["reasoner"] = self._reasoner
         supported_kwargs = _supported_extract_kwargs(self._extract_func, kwargs)
         return await _maybe_await(self._extract_func(artifact, **supported_kwargs))
+
+    async def _call_signals(
+        self,
+        facts: Sequence[AnnouncementFactCandidate],
+    ) -> Sequence[AnnouncementSignalCandidate]:
+        return await _maybe_await(self._signal_func(facts))
 
     def _get_subsystem(self) -> AnnouncementSubsystem:
         if self._subsystem is None:

--- a/src/subsystem_announcement/runtime/submit.py
+++ b/src/subsystem_announcement/runtime/submit.py
@@ -1,4 +1,4 @@
-"""Batch Ex-1 submission through the announcement SDK adapter."""
+"""Batch Ex candidate submission through the announcement SDK adapter."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -18,6 +18,7 @@ from subsystem_announcement.discovery.errors import NonOfficialSourceError
 from subsystem_announcement.discovery.fetcher import _validate_official_url_text
 from subsystem_announcement.extract import AnnouncementFactCandidate
 from subsystem_announcement.extract.candidates import FORBIDDEN_PAYLOAD_KEYS
+from subsystem_announcement.signals import AnnouncementSignalCandidate
 
 from .sdk_adapter import AnnouncementSubsystem
 from .trace import CandidateSubmitTrace
@@ -36,7 +37,9 @@ _FORBIDDEN_RUNTIME_KEYS = FORBIDDEN_PAYLOAD_KEYS | {
     "document_artifact_path",
     "parsed_artifact_path",
 }
-_VOLATILE_IDEMPOTENCY_PAYLOAD_KEYS = {"extracted_at"}
+_VOLATILE_IDEMPOTENCY_PAYLOAD_KEYS = {"extracted_at", "generated_at"}
+
+CandidatePayload: TypeAlias = AnnouncementFactCandidate | AnnouncementSignalCandidate
 
 
 class CandidateSubmitReceipt(BaseModel):
@@ -45,17 +48,19 @@ class CandidateSubmitReceipt(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     fact_id: str = Field(min_length=1)
+    candidate_id: str | None = None
     payload_hash: str = Field(min_length=64, max_length=64)
     receipt_id: str = Field(min_length=1)
-    ex_type: Literal["Ex-1"] = "Ex-1"
+    ex_type: Literal["Ex-1", "Ex-2"] = "Ex-1"
     attempts: int = Field(ge=1)
     accepted_at: datetime
     warnings: tuple[str, ...] = Field(default_factory=tuple)
     errors: tuple[str, ...] = Field(default_factory=tuple)
+    requires_reconciliation: bool = False
 
 
 class SubmitBatchResult(BaseModel):
-    """Summary of an ordered Ex-1 batch submission."""
+    """Summary of an ordered Ex candidate batch submission."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -68,7 +73,7 @@ class SubmitBatchResult(BaseModel):
 
 
 class SubmitIdempotencyStore:
-    """Idempotency records keyed by ``fact_id`` and payload hash."""
+    """Idempotency records keyed by ``ex_type``, candidate id, and payload hash."""
 
     _path_locks: dict[Path, threading.RLock] = {}
     _path_locks_guard = threading.Lock()
@@ -90,22 +95,29 @@ class SubmitIdempotencyStore:
         self,
         candidate_id: str,
         payload_hash: str,
+        ex_type: str = "Ex-1",
     ) -> CandidateSubmitReceipt | None:
         """Return the previous receipt for an identical candidate payload."""
 
         with self.locked():
-            return self._seen_loaded(candidate_id, payload_hash)
+            return self._seen_loaded(ex_type, candidate_id, payload_hash)
 
     def record(
         self,
         candidate_id: str,
         payload_hash: str,
         receipt: CandidateSubmitReceipt,
+        ex_type: str | None = None,
     ) -> None:
         """Record an accepted candidate receipt."""
 
         with self.locked():
-            self._record_loaded(candidate_id, payload_hash, receipt)
+            self._record_loaded(
+                ex_type or receipt.ex_type,
+                candidate_id,
+                payload_hash,
+                receipt,
+            )
 
     @contextmanager
     def locked(self) -> Any:
@@ -116,8 +128,6 @@ class SubmitIdempotencyStore:
                 if self.path is not None:
                     if self.path.exists():
                         self._load()
-                    else:
-                        self._records = {}
                 yield
 
     @classmethod
@@ -157,18 +167,27 @@ class SubmitIdempotencyStore:
 
     def _seen_loaded(
         self,
+        ex_type: str,
         candidate_id: str,
         payload_hash: str,
     ) -> CandidateSubmitReceipt | None:
-        return self._records.get(_idempotency_key(candidate_id, payload_hash))
+        receipt = self._records.get(
+            _idempotency_key(ex_type, candidate_id, payload_hash)
+        )
+        if receipt is not None:
+            return receipt
+        if ex_type == "Ex-1":
+            return self._records.get(_legacy_idempotency_key(candidate_id, payload_hash))
+        return None
 
     def _record_loaded(
         self,
+        ex_type: str,
         candidate_id: str,
         payload_hash: str,
         receipt: CandidateSubmitReceipt,
     ) -> None:
-        self._records[_idempotency_key(candidate_id, payload_hash)] = receipt
+        self._records[_idempotency_key(ex_type, candidate_id, payload_hash)] = receipt
         self._persist()
 
     def _load(self) -> None:
@@ -215,13 +234,13 @@ class SubmitIdempotencyStore:
 
 
 def submit_candidates(
-    candidates: Sequence[AnnouncementFactCandidate],
+    candidates: Sequence[CandidatePayload],
     subsystem: AnnouncementSubsystem,
     *,
     idempotency_store: SubmitIdempotencyStore | None = None,
     max_attempts: int = 3,
 ) -> SubmitBatchResult:
-    """Submit Ex-1 fact candidates in order with retry and idempotency."""
+    """Submit Ex-1/Ex-2 candidates in order with retry and idempotency."""
 
     if max_attempts < 1:
         raise ValueError("max_attempts must be at least 1")
@@ -238,11 +257,16 @@ def submit_candidates(
         try:
             payload = _validated_payload(candidate)
             payload_hash = _payload_hash(payload)
+            candidate_id = candidate_id_for(candidate)
+            ex_type = ex_type_for(candidate)
         except Exception as exc:
             failed += 1
-            fact_id = getattr(candidate, "fact_id", "unknown")
+            candidate_id = _best_effort_candidate_id(candidate)
+            ex_type = _best_effort_ex_type(candidate)
             trace = CandidateSubmitTrace(
-                fact_id=str(fact_id),
+                fact_id=candidate_id,
+                candidate_id=candidate_id,
+                ex_type=ex_type,
                 status="failed",
                 attempts=0,
                 errors=[str(exc)],
@@ -252,11 +276,13 @@ def submit_candidates(
             continue
 
         with store.locked():
-            previous_receipt = store._seen_loaded(candidate.fact_id, payload_hash)
+            previous_receipt = store._seen_loaded(ex_type, candidate_id, payload_hash)
             if previous_receipt is not None:
                 skipped_duplicates += 1
                 trace = CandidateSubmitTrace(
-                    fact_id=candidate.fact_id,
+                    fact_id=candidate_id,
+                    candidate_id=candidate_id,
+                    ex_type=ex_type,
                     status="duplicate",
                     receipt_id=previous_receipt.receipt_id,
                     attempts=0,
@@ -267,7 +293,8 @@ def submit_candidates(
                 continue
 
             receipt, trace = _submit_one(
-                candidate.fact_id,
+                candidate_id,
+                ex_type,
                 payload_hash,
                 payload,
                 subsystem,
@@ -280,8 +307,27 @@ def submit_candidates(
                 continue
 
             submitted += 1
+            try:
+                store._record_loaded(ex_type, candidate_id, payload_hash, receipt)
+            except Exception as exc:
+                message = f"idempotency receipt persistence failed: {exc}"
+                receipt = receipt.model_copy(
+                    update={
+                        "warnings": (*receipt.warnings, message),
+                        "requires_reconciliation": True,
+                    }
+                )
+                trace = trace.model_copy(
+                    update={
+                        "errors": [*trace.errors, message],
+                        "requires_reconciliation": True,
+                    }
+                )
+                store._records[
+                    _idempotency_key(ex_type, candidate_id, payload_hash)
+                ] = receipt
+                traces[-1] = trace
             receipts.append(receipt)
-            store._record_loaded(candidate.fact_id, payload_hash, receipt)
 
     return SubmitBatchResult(
         submitted=submitted,
@@ -294,7 +340,8 @@ def submit_candidates(
 
 
 def _submit_one(
-    fact_id: str,
+    candidate_id: str,
+    ex_type: Literal["Ex-1", "Ex-2"],
     payload_hash: str,
     payload: dict[str, Any],
     subsystem: AnnouncementSubsystem,
@@ -316,16 +363,20 @@ def _submit_one(
                 errors.append("subsystem-sdk accepted payload without receipt_id")
                 continue
             receipt = CandidateSubmitReceipt(
-                fact_id=fact_id,
+                fact_id=candidate_id,
+                candidate_id=candidate_id,
                 payload_hash=payload_hash,
                 receipt_id=last_receipt_id,
+                ex_type=ex_type,
                 attempts=attempt,
                 accepted_at=datetime.now(timezone.utc),
                 warnings=_string_tuple(_result_field(result, "warnings")),
                 errors=_string_tuple(_result_field(result, "errors")),
             )
             trace = CandidateSubmitTrace(
-                fact_id=fact_id,
+                fact_id=candidate_id,
+                candidate_id=candidate_id,
+                ex_type=ex_type,
                 status="accepted",
                 receipt_id=receipt.receipt_id,
                 attempts=attempt,
@@ -344,12 +395,14 @@ def _submit_one(
             if part
         )
         errors.append(
-            "subsystem-sdk rejected Ex-1 payload"
+            f"subsystem-sdk rejected {ex_type} payload"
             + (f": {detail}" if detail else "")
         )
 
     return None, CandidateSubmitTrace(
-        fact_id=fact_id,
+        fact_id=candidate_id,
+        candidate_id=candidate_id,
+        ex_type=ex_type,
         status="failed",
         receipt_id=last_receipt_id,
         attempts=max_attempts,
@@ -357,19 +410,56 @@ def _submit_one(
     )
 
 
-def _validated_payload(candidate: AnnouncementFactCandidate) -> dict[str, Any]:
+def _validated_payload(candidate: CandidatePayload) -> dict[str, Any]:
     payload = candidate.to_ex_payload()
-    if payload.get("ex_type") != "Ex-1":
-        raise ValueError("submit_candidates only accepts Ex-1 payloads")
+    ex_type = payload.get("ex_type")
+    if ex_type not in {"Ex-1", "Ex-2"}:
+        raise ValueError("submit_candidates only accepts Ex-1/Ex-2 payloads")
     if not payload.get("evidence_spans"):
-        raise ValueError("Ex-1 payload requires at least one evidence span")
+        raise ValueError(f"{ex_type} payload requires at least one evidence span")
     source_reference = payload.get("source_reference")
     if not isinstance(source_reference, Mapping):
-        raise ValueError("Ex-1 payload requires source_reference")
+        raise ValueError(f"{ex_type} payload requires source_reference")
     _validate_source_reference(payload, source_reference)
     _reject_forbidden_runtime_keys(payload)
-    validated = AnnouncementFactCandidate.model_validate(payload)
+    if ex_type == "Ex-1":
+        validated = AnnouncementFactCandidate.model_validate(payload)
+    else:
+        validated = AnnouncementSignalCandidate.model_validate(payload)
     return validated.model_dump(mode="json")
+
+
+def candidate_id_for(candidate: CandidatePayload) -> str:
+    """Return the stable candidate id regardless of Ex type."""
+
+    ex_type = ex_type_for(candidate)
+    if ex_type == "Ex-1":
+        return candidate.fact_id
+    return candidate.signal_id
+
+
+def ex_type_for(candidate: CandidatePayload) -> Literal["Ex-1", "Ex-2"]:
+    """Return the candidate Ex type."""
+
+    ex_type = getattr(candidate, "ex_type", None)
+    if ex_type not in {"Ex-1", "Ex-2"}:
+        raise ValueError("candidate must be Ex-1 or Ex-2")
+    return ex_type
+
+
+def _best_effort_candidate_id(candidate: object) -> str:
+    for attribute in ("fact_id", "signal_id"):
+        value = getattr(candidate, attribute, None)
+        if isinstance(value, str) and value:
+            return value
+    return "unknown"
+
+
+def _best_effort_ex_type(candidate: object) -> Literal["Ex-1", "Ex-2"] | None:
+    value = getattr(candidate, "ex_type", None)
+    if value in {"Ex-1", "Ex-2"}:
+        return value
+    return None
 
 
 def _validate_source_reference(
@@ -405,7 +495,7 @@ def _reject_forbidden_runtime_keys(value: Any, path: str = "") -> None:
             key_text = str(key)
             if key_text in _FORBIDDEN_RUNTIME_KEYS:
                 raise ValueError(
-                    f"Ex-1 payload contains forbidden runtime key: {path}{key_text}"
+                    f"candidate payload contains forbidden runtime key: {path}{key_text}"
                 )
             _reject_forbidden_runtime_keys(item, f"{path}{key_text}.")
     elif isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
@@ -429,7 +519,11 @@ def _payload_hash(payload: Mapping[str, Any]) -> str:
     ).hexdigest()
 
 
-def _idempotency_key(candidate_id: str, payload_hash: str) -> str:
+def _idempotency_key(ex_type: str, candidate_id: str, payload_hash: str) -> str:
+    return f"{ex_type}:{candidate_id}:{payload_hash}"
+
+
+def _legacy_idempotency_key(candidate_id: str, payload_hash: str) -> str:
     return f"{candidate_id}:{payload_hash}"
 
 

--- a/src/subsystem_announcement/runtime/trace.py
+++ b/src/subsystem_announcement/runtime/trace.py
@@ -16,15 +16,18 @@ _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
 
 
 class CandidateSubmitTrace(BaseModel):
-    """Per-candidate submit trace for one Ex-1 candidate."""
+    """Per-candidate submit trace for one Ex candidate."""
 
     model_config = ConfigDict(extra="forbid")
 
     fact_id: str = Field(min_length=1)
+    candidate_id: str | None = None
+    ex_type: Literal["Ex-1", "Ex-2"] | None = None
     status: Literal["accepted", "duplicate", "failed"]
     receipt_id: str | None = None
     attempts: int = Field(ge=0)
     errors: list[str] = Field(default_factory=list)
+    requires_reconciliation: bool = False
 
 
 class RunTraceError(BaseModel):

--- a/src/subsystem_announcement/signals/__init__.py
+++ b/src/subsystem_announcement/signals/__init__.py
@@ -1,1 +1,26 @@
-__all__: list[str] = []
+"""Announcement Ex-2 signal generation public API."""
+
+from __future__ import annotations
+
+from .aggregator import SignalFunc, derive_signal_candidates
+from .candidates import (
+    AnnouncementSignalCandidate,
+    SignalDirection,
+    SignalTimeHorizon,
+    make_signal_id,
+)
+from .classifier import SignalDecision, classify_signal_for_fact
+from .templates import SIGNAL_TEMPLATES, SignalTemplate
+
+__all__ = [
+    "AnnouncementSignalCandidate",
+    "SIGNAL_TEMPLATES",
+    "SignalDecision",
+    "SignalDirection",
+    "SignalFunc",
+    "SignalTemplate",
+    "SignalTimeHorizon",
+    "classify_signal_for_fact",
+    "derive_signal_candidates",
+    "make_signal_id",
+]

--- a/src/subsystem_announcement/signals/aggregator.py
+++ b/src/subsystem_announcement/signals/aggregator.py
@@ -1,0 +1,94 @@
+"""Aggregate Ex-1 facts into conservative Ex-2 signal candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+from subsystem_announcement.extract import AnnouncementFactCandidate
+
+from .candidates import AnnouncementSignalCandidate, make_signal_id
+from .classifier import classify_signal_for_fact
+from .templates import SIGNAL_TEMPLATES
+
+
+SignalFunc = Callable[
+    [Sequence[AnnouncementFactCandidate]],
+    Sequence[AnnouncementSignalCandidate] | Awaitable[Sequence[AnnouncementSignalCandidate]],
+]
+
+
+def derive_signal_candidates(
+    facts: Sequence[AnnouncementFactCandidate],
+    *,
+    generated_at: datetime | None = None,
+) -> list[AnnouncementSignalCandidate]:
+    """Derive deterministic Ex-2 signal candidates from Ex-1 facts."""
+
+    if not facts:
+        return []
+
+    timestamp = generated_at or datetime.now(timezone.utc)
+    signals: list[AnnouncementSignalCandidate] = []
+    seen_signal_ids: set[str] = set()
+
+    for fact in facts:
+        template = SIGNAL_TEMPLATES.get(fact.fact_type)
+        if template is None:
+            continue
+        decision = classify_signal_for_fact(fact, template)
+        if decision is None:
+            continue
+        affected_entities = _affected_entities(fact)
+        if not affected_entities:
+            continue
+
+        source_fact_ids = [fact.fact_id]
+        identity_payload: dict[str, Any] = {
+            "direction": decision.direction,
+            "magnitude": decision.magnitude,
+            "affected_entities": affected_entities,
+            "time_horizon": decision.time_horizon,
+            "confidence": decision.confidence,
+        }
+        signal_id = make_signal_id(
+            fact.announcement_id,
+            decision.signal_type,
+            source_fact_ids,
+            fact.evidence_spans,
+            identity_payload,
+        )
+        if signal_id in seen_signal_ids:
+            continue
+
+        signals.append(
+            AnnouncementSignalCandidate(
+                signal_id=signal_id,
+                announcement_id=fact.announcement_id,
+                signal_type=decision.signal_type,
+                direction=decision.direction,
+                magnitude=decision.magnitude,
+                affected_entities=affected_entities,
+                time_horizon=decision.time_horizon,
+                source_fact_ids=source_fact_ids,
+                source_reference=dict(fact.source_reference),
+                evidence_spans=list(fact.evidence_spans),
+                confidence=decision.confidence,
+                generated_at=timestamp,
+            )
+        )
+        seen_signal_ids.add(signal_id)
+
+    return signals
+
+
+def _affected_entities(fact: AnnouncementFactCandidate) -> list[str]:
+    entities: list[str] = []
+    seen: set[str] = set()
+    for entity_id in (fact.primary_entity_id, *fact.related_entity_ids):
+        if not entity_id or entity_id in seen:
+            continue
+        seen.add(entity_id)
+        entities.append(entity_id)
+    return entities

--- a/src/subsystem_announcement/signals/candidates.py
+++ b/src/subsystem_announcement/signals/candidates.py
@@ -1,0 +1,143 @@
+"""Ex-2 signal candidate models and deterministic identity helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from subsystem_announcement.extract.candidates import FORBIDDEN_PAYLOAD_KEYS
+from subsystem_announcement.extract.evidence import EvidenceSpan
+
+
+class SignalDirection(str, Enum):
+    """Directional interpretation of an announcement signal."""
+
+    POSITIVE = "positive"
+    NEGATIVE = "negative"
+    NEUTRAL = "neutral"
+
+
+class SignalTimeHorizon(str, Enum):
+    """Expected signal horizon used by downstream consumers."""
+
+    IMMEDIATE = "immediate"
+    SHORT_TERM = "short_term"
+    MEDIUM_TERM = "medium_term"
+
+
+class AnnouncementSignalCandidate(BaseModel):
+    """Contract-ready Ex-2 announcement signal candidate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ex_type: Literal["Ex-2"] = "Ex-2"
+    signal_id: str = Field(min_length=1)
+    announcement_id: str = Field(min_length=1)
+    signal_type: str = Field(min_length=1)
+    direction: SignalDirection
+    magnitude: float = Field(ge=0.0, le=1.0)
+    affected_entities: list[str] = Field(min_length=1)
+    time_horizon: SignalTimeHorizon
+    source_fact_ids: list[str] = Field(min_length=1)
+    source_reference: dict[str, Any] = Field(default_factory=dict)
+    evidence_spans: list[EvidenceSpan] = Field(min_length=1)
+    confidence: float = Field(ge=0.0, le=1.0)
+    generated_at: datetime
+
+    @field_validator("generated_at")
+    @classmethod
+    def require_timezone(cls, value: datetime) -> datetime:
+        """Reject naive generation timestamps."""
+
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("generated_at must include timezone information")
+        return value
+
+    @field_validator("affected_entities", "source_fact_ids")
+    @classmethod
+    def require_non_empty_items(cls, value: list[str]) -> list[str]:
+        """Reject blank entity and source fact references."""
+
+        if any(not item.strip() for item in value):
+            raise ValueError("references must be non-empty strings")
+        return value
+
+    @model_validator(mode="after")
+    def validate_source_reference(self) -> "AnnouncementSignalCandidate":
+        """Require official source provenance and reject runtime metadata."""
+
+        official_url = self.source_reference.get("official_url")
+        if not isinstance(official_url, str) or not official_url.strip():
+            raise ValueError("source_reference.official_url is required")
+        _reject_forbidden_keys(self.model_dump(mode="python"))
+        return self
+
+    def to_ex_payload(self) -> dict[str, Any]:
+        """Return the Ex-2 payload for subsystem-sdk submission."""
+
+        payload = self.model_dump(mode="json")
+        _reject_forbidden_keys(payload)
+        return payload
+
+
+def make_signal_id(
+    announcement_id: str,
+    signal_type: str,
+    source_fact_ids: Sequence[str],
+    evidence_spans: Sequence[EvidenceSpan],
+    payload: Mapping[str, Any],
+) -> str:
+    """Generate a deterministic signal id for replay/dedupe."""
+
+    evidence_quotes = [
+        " ".join(span.quote.split()) for span in evidence_spans if span.quote.strip()
+    ]
+    identity_payload = {
+        "announcement_id": announcement_id,
+        "signal_type": signal_type,
+        "source_fact_ids": list(source_fact_ids),
+        "evidence_quotes": evidence_quotes,
+        "payload": _stable_jsonable(payload),
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            identity_payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"signal:{announcement_id}:{signal_type}:{digest}"
+
+
+def _stable_jsonable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _stable_jsonable(item)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_stable_jsonable(item) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _reject_forbidden_keys(value: Any, path: str = "") -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            key_text = str(key)
+            if key_text in FORBIDDEN_PAYLOAD_KEYS:
+                raise ValueError(f"Ex-2 payload contains forbidden key: {path}{key_text}")
+            _reject_forbidden_keys(item, f"{path}{key_text}.")
+    elif isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        for index, item in enumerate(value):
+            _reject_forbidden_keys(item, f"{path}{index}.")

--- a/src/subsystem_announcement/signals/classifier.py
+++ b/src/subsystem_announcement/signals/classifier.py
@@ -1,0 +1,137 @@
+"""Rule-based Ex-2 signal decisions from stable Ex-1 facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from subsystem_announcement.extract import AnnouncementFactCandidate, FactType
+
+from .candidates import SignalDirection, SignalTimeHorizon
+from .templates import SignalTemplate
+
+
+@dataclass(frozen=True)
+class SignalDecision:
+    """A classified signal interpretation before candidate materialization."""
+
+    signal_type: str
+    direction: SignalDirection
+    magnitude: float
+    time_horizon: SignalTimeHorizon
+    confidence: float
+
+
+def classify_signal_for_fact(
+    fact: AnnouncementFactCandidate,
+    template: SignalTemplate,
+) -> SignalDecision | None:
+    """Classify one fact into an Ex-2 signal decision, or return ``None``."""
+
+    if fact.fact_type != template.fact_type:
+        return None
+    if not fact.evidence_spans:
+        return None
+    official_url = fact.source_reference.get("official_url")
+    if not isinstance(official_url, str) or not official_url.strip():
+        return None
+    if not fact.primary_entity_id:
+        return None
+    if fact.confidence < template.min_confidence:
+        return None
+    if any(key not in fact.fact_content for key in template.required_content_keys):
+        return None
+
+    direction = _direction_for_fact(fact)
+    if direction is None:
+        return None
+
+    magnitude = template.base_magnitude
+    if direction is SignalDirection.NEUTRAL:
+        magnitude = min(magnitude, 0.5)
+
+    return SignalDecision(
+        signal_type=template.signal_type,
+        direction=direction,
+        magnitude=magnitude,
+        time_horizon=template.time_horizon,
+        confidence=fact.confidence,
+    )
+
+
+def _direction_for_fact(fact: AnnouncementFactCandidate) -> SignalDirection | None:
+    content = fact.fact_content
+    if fact.fact_type is FactType.EARNINGS_PREANNOUNCE:
+        return _map_value(
+            content.get("performance_direction"),
+            {
+                "positive": SignalDirection.POSITIVE,
+                "negative": SignalDirection.NEGATIVE,
+                "uncertain": SignalDirection.NEUTRAL,
+            },
+        )
+    if fact.fact_type is FactType.MAJOR_CONTRACT:
+        return _map_value(
+            content.get("event"),
+            {
+                "major_contract": SignalDirection.POSITIVE,
+            },
+        )
+    if fact.fact_type is FactType.SHAREHOLDER_CHANGE:
+        return _map_value(
+            content.get("shareholder_change_type"),
+            {
+                "increase": SignalDirection.POSITIVE,
+                "decrease": SignalDirection.NEGATIVE,
+                "control_change": SignalDirection.NEUTRAL,
+                "change": SignalDirection.NEUTRAL,
+            },
+        )
+    if fact.fact_type is FactType.EQUITY_PLEDGE:
+        return _map_value(
+            content.get("pledge_action"),
+            {
+                "pledge": SignalDirection.NEGATIVE,
+                "release": SignalDirection.POSITIVE,
+            },
+        )
+    if fact.fact_type is FactType.REGULATORY_ACTION:
+        return _map_value(
+            content.get("regulatory_action_type"),
+            {
+                "administrative_penalty": SignalDirection.NEGATIVE,
+                "investigation": SignalDirection.NEGATIVE,
+                "disciplinary_action": SignalDirection.NEGATIVE,
+                "regulatory_measure": SignalDirection.NEGATIVE,
+                "regulatory_notice": SignalDirection.NEUTRAL,
+                "inquiry_letter": SignalDirection.NEUTRAL,
+            },
+        )
+    if fact.fact_type is FactType.TRADING_HALT_RESUME:
+        return _map_value(
+            content.get("trading_status"),
+            {
+                "resume": SignalDirection.POSITIVE,
+                "halt": SignalDirection.NEGATIVE,
+            },
+        )
+    if fact.fact_type is FactType.FUNDRAISING_CHANGE:
+        return _map_value(
+            content.get("fundraising_change_type"),
+            {
+                "use_or_plan_change": SignalDirection.NEUTRAL,
+                "scale_increase": SignalDirection.POSITIVE,
+                "scale_decrease": SignalDirection.NEGATIVE,
+                "termination": SignalDirection.NEGATIVE,
+            },
+        )
+    return None
+
+
+def _map_value(
+    raw_value: Any,
+    mapping: dict[str, SignalDirection],
+) -> SignalDirection | None:
+    if not isinstance(raw_value, str):
+        return None
+    return mapping.get(raw_value.strip().lower())

--- a/src/subsystem_announcement/signals/templates.py
+++ b/src/subsystem_announcement/signals/templates.py
@@ -1,0 +1,75 @@
+"""Conservative Ex-2 signal templates keyed by Ex-1 fact type."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from subsystem_announcement.extract import FactType
+
+from .candidates import SignalTimeHorizon
+
+
+@dataclass(frozen=True)
+class SignalTemplate:
+    """Configuration for converting one fact type into an Ex-2 signal."""
+
+    fact_type: FactType
+    signal_type: str
+    base_magnitude: float
+    time_horizon: SignalTimeHorizon
+    required_content_keys: tuple[str, ...]
+    min_confidence: float = 0.75
+
+
+SIGNAL_TEMPLATES: Mapping[FactType, SignalTemplate] = {
+    FactType.EARNINGS_PREANNOUNCE: SignalTemplate(
+        fact_type=FactType.EARNINGS_PREANNOUNCE,
+        signal_type="earnings_preannounce_outlook",
+        base_magnitude=0.72,
+        time_horizon=SignalTimeHorizon.SHORT_TERM,
+        required_content_keys=("performance_direction",),
+    ),
+    FactType.MAJOR_CONTRACT: SignalTemplate(
+        fact_type=FactType.MAJOR_CONTRACT,
+        signal_type="major_contract_award",
+        base_magnitude=0.68,
+        time_horizon=SignalTimeHorizon.MEDIUM_TERM,
+        required_content_keys=("event",),
+    ),
+    FactType.SHAREHOLDER_CHANGE: SignalTemplate(
+        fact_type=FactType.SHAREHOLDER_CHANGE,
+        signal_type="shareholder_position_change",
+        base_magnitude=0.62,
+        time_horizon=SignalTimeHorizon.SHORT_TERM,
+        required_content_keys=("shareholder_change_type",),
+    ),
+    FactType.EQUITY_PLEDGE: SignalTemplate(
+        fact_type=FactType.EQUITY_PLEDGE,
+        signal_type="equity_pledge_status",
+        base_magnitude=0.66,
+        time_horizon=SignalTimeHorizon.SHORT_TERM,
+        required_content_keys=("pledge_action",),
+    ),
+    FactType.REGULATORY_ACTION: SignalTemplate(
+        fact_type=FactType.REGULATORY_ACTION,
+        signal_type="regulatory_action_risk",
+        base_magnitude=0.74,
+        time_horizon=SignalTimeHorizon.IMMEDIATE,
+        required_content_keys=("regulatory_action_type",),
+    ),
+    FactType.TRADING_HALT_RESUME: SignalTemplate(
+        fact_type=FactType.TRADING_HALT_RESUME,
+        signal_type="trading_status_change",
+        base_magnitude=0.58,
+        time_horizon=SignalTimeHorizon.IMMEDIATE,
+        required_content_keys=("trading_status",),
+    ),
+    FactType.FUNDRAISING_CHANGE: SignalTemplate(
+        fact_type=FactType.FUNDRAISING_CHANGE,
+        signal_type="fundraising_plan_change",
+        base_magnitude=0.55,
+        time_horizon=SignalTimeHorizon.MEDIUM_TERM,
+        required_content_keys=("fundraising_change_type",),
+    ),
+}

--- a/tests/contracts/test_ex2_contract.py
+++ b/tests/contracts/test_ex2_contract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from subsystem_announcement.extract import extract_fact_candidates
+from subsystem_announcement.signals import AnnouncementSignalCandidate, derive_signal_candidates
+
+from tests.extract_fixtures import make_artifact
+
+
+FORBIDDEN_KEYS = {"submitted_at", "ingest_seq", "layer_b_receipt_id", "local_path"}
+
+
+def test_ex2_payload_shape_and_forbidden_metadata() -> None:
+    fact = _earnings_fact()
+    signal = derive_signal_candidates(
+        [fact],
+        generated_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
+    )[0]
+
+    payload = signal.to_ex_payload()
+
+    assert payload["ex_type"] == "Ex-2"
+    assert payload["signal_id"]
+    assert payload["announcement_id"] == fact.announcement_id
+    assert payload["signal_type"] == "earnings_preannounce_outlook"
+    assert payload["direction"] == "positive"
+    assert payload["affected_entities"] == [fact.primary_entity_id]
+    assert payload["source_fact_ids"] == [fact.fact_id]
+    assert payload["source_reference"] == fact.source_reference
+    assert payload["evidence_spans"] == [span.model_dump(mode="json") for span in fact.evidence_spans]
+    AnnouncementSignalCandidate.model_validate(payload)
+    _assert_no_forbidden_keys(payload)
+
+
+def test_ex2_source_reference_is_not_forged_when_missing() -> None:
+    fact = _earnings_fact().model_copy(update={"source_reference": {}})
+
+    assert derive_signal_candidates([fact]) == []
+
+
+def _earnings_fact():
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n"
+        "公司预计2026年净利润同比增长50%，本公告为业绩预告。",
+        announcement_id="ann-ex2-contract",
+    )
+    return extract_fact_candidates(artifact)[0]
+
+
+def _assert_no_forbidden_keys(value: Any) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            assert key not in FORBIDDEN_KEYS
+            _assert_no_forbidden_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_forbidden_keys(item)

--- a/tests/test_package_layout.py
+++ b/tests/test_package_layout.py
@@ -73,6 +73,14 @@ def test_subpackages_are_importable(subpackage: str) -> None:
             "AnnouncementPipeline",
             "submit_candidates",
         }.issubset(set(module.__all__))
+    elif subpackage == "signals":
+        assert {
+            "AnnouncementSignalCandidate",
+            "SignalDirection",
+            "SignalTemplate",
+            "SignalTimeHorizon",
+            "derive_signal_candidates",
+        }.issubset(set(module.__all__))
     else:
         assert module.__all__ == []
 

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -65,7 +65,10 @@ def test_process_envelope_discovers_parses_extracts_and_submits_ex1(
     assert run.trace_path is not None
     assert run.trace_path.exists()
     assert subsystem.submissions
-    assert all(payload["ex_type"] == "Ex-1" for payload in subsystem.submissions)
+    assert [payload["ex_type"] for payload in subsystem.submissions] == ["Ex-1", "Ex-2"]
+    assert subsystem.submissions[1]["source_fact_ids"] == [
+        subsystem.submissions[0]["fact_id"]
+    ]
     assert all(payload["evidence_spans"] for payload in subsystem.submissions)
     assert all(
         payload["source_reference"]["official_url"].startswith("https://")
@@ -248,11 +251,10 @@ def test_process_envelope_wires_configured_registry_and_reasoner(
     assert reasoner_payloads
     assert reasoner_payloads[0]["endpoint"] == reasoner_endpoint
     assert registry_calls == [
-        ("lookup_alias", "测试股份", registry_endpoint),
         ("lookup_alias", "银河资本", registry_endpoint),
         ("resolve_mentions", ["银河资本"], registry_endpoint),
     ]
-    assert subsystem.submissions[0]["primary_entity_id"] == "entity-primary"
+    assert subsystem.submissions[0]["primary_entity_id"] == "ts_code:600000.SH"
     assert subsystem.submissions[0]["related_entity_ids"] == ["entity-counterparty"]
     assert (
         subsystem.submissions[0]["fact_content"]["reasoner_fact_content"][

--- a/tests/test_runtime_submit.py
+++ b/tests/test_runtime_submit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import threading
+from datetime import datetime, timezone
 from typing import Any
 
 from subsystem_announcement.extract import AnnouncementFactCandidate, extract_fact_candidates
@@ -10,6 +11,7 @@ from subsystem_announcement.runtime.submit import (
     SubmitIdempotencyStore,
     submit_candidates,
 )
+from subsystem_announcement.signals import derive_signal_candidates
 
 from .extract_fixtures import make_artifact
 
@@ -71,6 +73,44 @@ def test_submit_candidates_preserves_order_and_records_receipts() -> None:
     assert [trace.status for trace in result.traces] == ["accepted", "accepted"]
 
 
+def test_submit_candidates_accepts_mixed_ex1_ex2_in_order() -> None:
+    fact = _fact("ann-mixed-submit")
+    signal = derive_signal_candidates(
+        [fact],
+        generated_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
+    )[0]
+    subsystem = RecordingSubsystem([_accepted("receipt-1"), _accepted("receipt-2")])
+
+    result = submit_candidates([fact, signal], subsystem)  # type: ignore[arg-type]
+
+    assert [payload["ex_type"] for payload in subsystem.submissions] == [
+        "Ex-1",
+        "Ex-2",
+    ]
+    assert subsystem.submissions[1]["source_fact_ids"] == [fact.fact_id]
+    assert [receipt.ex_type for receipt in result.receipts] == ["Ex-1", "Ex-2"]
+    assert [trace.ex_type for trace in result.traces] == ["Ex-1", "Ex-2"]
+
+
+def test_submit_candidates_idempotency_separates_ex_type_from_candidate_id() -> None:
+    fact = _fact("ann-idempotency-ex-type")
+    signal = derive_signal_candidates(
+        [fact],
+        generated_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
+    )[0].model_copy(update={"signal_id": fact.fact_id})
+    subsystem = RecordingSubsystem([_accepted("receipt-1"), _accepted("receipt-2")])
+    store = SubmitIdempotencyStore()
+
+    first = submit_candidates([fact, signal], subsystem, idempotency_store=store)  # type: ignore[arg-type]
+    second = submit_candidates([fact, signal], subsystem, idempotency_store=store)  # type: ignore[arg-type]
+
+    assert first.submitted == 2
+    assert first.skipped_duplicates == 0
+    assert second.submitted == 0
+    assert second.skipped_duplicates == 2
+    assert len(subsystem.submissions) == 2
+
+
 def test_submit_candidates_skips_duplicate_fact_id_and_payload_hash() -> None:
     fact = _fact("ann-duplicate")
     subsystem = RecordingSubsystem([_accepted("receipt-original")])
@@ -87,6 +127,29 @@ def test_submit_candidates_skips_duplicate_fact_id_and_payload_hash() -> None:
     assert second.receipts[0].receipt_id == "receipt-original"
     assert second.traces[0].status == "duplicate"
     assert second.traces[0].receipt_id == "receipt-original"
+
+
+def test_submit_candidates_surfaces_accepted_receipt_when_persistence_fails() -> None:
+    class FailingRecordStore(SubmitIdempotencyStore):
+        def _record_loaded(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("disk full")
+
+    fact = _fact("ann-persist-failure")
+    subsystem = RecordingSubsystem([_accepted("receipt-accepted")])
+    store = FailingRecordStore()
+
+    first = submit_candidates([fact], subsystem, idempotency_store=store)  # type: ignore[arg-type]
+    second = submit_candidates([fact], subsystem, idempotency_store=store)  # type: ignore[arg-type]
+
+    assert first.submitted == 1
+    assert first.failed == 0
+    assert first.receipts[0].receipt_id == "receipt-accepted"
+    assert first.receipts[0].requires_reconciliation is True
+    assert first.traces[0].requires_reconciliation is True
+    assert "persistence failed" in first.traces[0].errors[0]
+    assert second.submitted == 0
+    assert second.skipped_duplicates == 1
+    assert len(subsystem.submissions) == 1
 
 
 def test_submit_candidates_serializes_file_backed_idempotency(

--- a/tests/test_signals_candidates.py
+++ b/tests/test_signals_candidates.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from subsystem_announcement.extract import extract_fact_candidates
+from subsystem_announcement.signals import (
+    AnnouncementSignalCandidate,
+    SignalDirection,
+    derive_signal_candidates,
+    make_signal_id,
+)
+
+from .extract_fixtures import make_artifact
+
+
+GENERATED_AT = datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc)
+
+
+def test_signal_candidate_rejects_extra_and_requires_sources() -> None:
+    fact = _earnings_fact()
+    signal = derive_signal_candidates([fact], generated_at=GENERATED_AT)[0]
+
+    with pytest.raises(ValidationError):
+        AnnouncementSignalCandidate.model_validate(
+            {**signal.model_dump(mode="python"), "local_path": "/tmp/cache.pdf"}
+        )
+
+    with pytest.raises(ValidationError):
+        AnnouncementSignalCandidate.model_validate(
+            {**signal.model_dump(mode="python"), "source_fact_ids": []}
+        )
+
+    with pytest.raises(ValidationError):
+        AnnouncementSignalCandidate.model_validate(
+            {**signal.model_dump(mode="python"), "evidence_spans": []}
+        )
+
+
+def test_make_signal_id_is_stable_and_sensitive_to_evidence_and_direction() -> None:
+    fact = _earnings_fact()
+    payload = {
+        "direction": SignalDirection.POSITIVE,
+        "magnitude": 0.72,
+        "affected_entities": [fact.primary_entity_id],
+    }
+
+    first = make_signal_id(
+        fact.announcement_id,
+        "earnings_preannounce_outlook",
+        [fact.fact_id],
+        fact.evidence_spans,
+        payload,
+    )
+    second = make_signal_id(
+        fact.announcement_id,
+        "earnings_preannounce_outlook",
+        [fact.fact_id],
+        fact.evidence_spans,
+        payload,
+    )
+    changed_direction = make_signal_id(
+        fact.announcement_id,
+        "earnings_preannounce_outlook",
+        [fact.fact_id],
+        fact.evidence_spans,
+        {**payload, "direction": SignalDirection.NEGATIVE},
+    )
+    changed_span = fact.evidence_spans[0].model_copy(
+        update={
+            "end_offset": fact.evidence_spans[0].end_offset + 1,
+            "quote": f"{fact.evidence_spans[0].quote}x",
+        }
+    )
+    changed_evidence = make_signal_id(
+        fact.announcement_id,
+        "earnings_preannounce_outlook",
+        [fact.fact_id],
+        [changed_span],
+        payload,
+    )
+
+    assert first == second
+    assert first.startswith(f"signal:{fact.announcement_id}:earnings_preannounce_outlook:")
+    assert changed_direction != first
+    assert changed_evidence != first
+
+
+def test_derive_signal_candidates_preserves_fact_provenance_and_entities() -> None:
+    fact = _earnings_fact().model_copy(
+        update={"related_entity_ids": ["entity-counterparty", "entity-counterparty"]}
+    )
+
+    signal = derive_signal_candidates([fact], generated_at=GENERATED_AT)[0]
+
+    assert signal.source_fact_ids == [fact.fact_id]
+    assert signal.source_reference == fact.source_reference
+    assert signal.evidence_spans == fact.evidence_spans
+    assert signal.affected_entities == [
+        fact.primary_entity_id,
+        "entity-counterparty",
+    ]
+    assert signal.generated_at == GENERATED_AT
+
+
+def test_derive_signal_candidates_returns_empty_for_empty_input() -> None:
+    assert derive_signal_candidates([]) == []
+
+
+def _earnings_fact():
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n"
+        "公司预计2026年净利润同比增长50%，本公告为业绩预告。",
+        announcement_id="ann-signal-candidate",
+    )
+    return extract_fact_candidates(artifact)[0]

--- a/tests/test_signals_pipeline.py
+++ b/tests/test_signals_pipeline.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.discovery import (
+    AnnouncementDiscoveryResult,
+    AnnouncementEnvelope,
+)
+from subsystem_announcement.discovery.document import AnnouncementDocumentArtifact
+from subsystem_announcement.extract import AnnouncementFactCandidate, extract_fact_candidates
+from subsystem_announcement.parse import ParsedAnnouncementArtifact
+from subsystem_announcement.runtime.pipeline import AnnouncementPipeline
+from subsystem_announcement.signals import derive_signal_candidates
+
+from .extract_fixtures import make_artifact
+
+
+GENERATED_AT = datetime(2026, 4, 18, 10, 30, tzinfo=timezone.utc)
+
+
+class RecordingSubsystem:
+    def __init__(self) -> None:
+        self.submissions: list[dict[str, Any]] = []
+
+    def submit(self, candidate: dict[str, Any]) -> dict[str, Any]:
+        self.submissions.append(candidate)
+        return {
+            "accepted": True,
+            "receipt_id": f"receipt-{len(self.submissions)}",
+            "warnings": (),
+            "errors": (),
+        }
+
+
+def test_pipeline_extracts_facts_then_generates_signals_then_submits_in_order(
+    tmp_path: Path,
+) -> None:
+    subsystem = RecordingSubsystem()
+    signal_calls: list[list[str]] = []
+
+    def signal_func(facts: list[AnnouncementFactCandidate]):
+        signal_calls.append([fact.fact_id for fact in facts])
+        return derive_signal_candidates(facts, generated_at=GENERATED_AT)
+
+    pipeline = AnnouncementPipeline(
+        _config(tmp_path),
+        subsystem=subsystem,  # type: ignore[arg-type]
+        discovery_func=_fake_discovery,
+        parse_func=_fake_parse,
+        extract_func=_fake_extract,
+        signal_func=signal_func,
+    )
+
+    run = asyncio.run(pipeline.process_envelope(_envelope()))
+
+    assert run.status == "succeeded"
+    assert run.candidate_count == 2
+    assert signal_calls == [[subsystem.submissions[0]["fact_id"]]]
+    assert [payload["ex_type"] for payload in subsystem.submissions] == [
+        "Ex-1",
+        "Ex-2",
+    ]
+    assert subsystem.submissions[1]["source_fact_ids"] == [
+        subsystem.submissions[0]["fact_id"]
+    ]
+    assert [receipt["ex_type"] for receipt in run.submit_receipts] == [
+        "Ex-1",
+        "Ex-2",
+    ]
+    assert [trace.ex_type for trace in run.candidate_traces] == ["Ex-1", "Ex-2"]
+
+
+def test_pipeline_empty_signals_preserves_ex1_submit_behavior(tmp_path: Path) -> None:
+    subsystem = RecordingSubsystem()
+
+    pipeline = AnnouncementPipeline(
+        _config(tmp_path),
+        subsystem=subsystem,  # type: ignore[arg-type]
+        discovery_func=_fake_discovery,
+        parse_func=_fake_parse,
+        extract_func=_fake_extract,
+        signal_func=lambda facts: [],
+    )
+
+    run = asyncio.run(pipeline.process_envelope(_envelope()))
+
+    assert run.status == "succeeded"
+    assert run.candidate_count == 1
+    assert [payload["ex_type"] for payload in subsystem.submissions] == ["Ex-1"]
+
+
+async def _fake_discovery(
+    envelope: AnnouncementEnvelope,
+    config: AnnouncementConfig,
+) -> AnnouncementDiscoveryResult:
+    path = Path(config.artifact_root) / "documents" / f"{envelope.announcement_id}.pdf"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"%PDF mocked")
+    document = AnnouncementDocumentArtifact(
+        announcement_id=envelope.announcement_id,
+        ts_code=envelope.ts_code,
+        title=envelope.title,
+        publish_time=envelope.publish_time,
+        content_hash="b" * 64,
+        official_url=envelope.official_url,
+        source_exchange=envelope.source_exchange,
+        attachment_type=envelope.attachment_type,
+        local_path=path,
+        content_type="application/pdf",
+        byte_size=path.stat().st_size,
+        fetched_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+    )
+    return AnnouncementDiscoveryResult(status="fetched", document=document)
+
+
+def _fake_parse(
+    document: AnnouncementDocumentArtifact,
+    config: AnnouncementConfig,
+) -> ParsedAnnouncementArtifact:
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n"
+        "公司预计2026年净利润同比增长50%，本公告为业绩预告。",
+        announcement_id=document.announcement_id,
+    )
+    return artifact.model_copy(
+        update={
+            "content_hash": document.content_hash,
+            "source_document": document,
+        }
+    )
+
+
+def _fake_extract(
+    artifact: ParsedAnnouncementArtifact,
+) -> list[AnnouncementFactCandidate]:
+    return extract_fact_candidates(artifact)
+
+
+def _envelope() -> AnnouncementEnvelope:
+    return AnnouncementEnvelope(
+        announcement_id="ann-signal-pipeline",
+        ts_code="600000.SH",
+        title="测试公司业绩预告",
+        publish_time=datetime(2026, 4, 18, 9, 0, tzinfo=timezone.utc),
+        official_url="https://static.sse.com.cn/disclosure/ann-signal-pipeline.pdf",
+        source_exchange="sse",
+        attachment_type="pdf",
+    )
+
+
+def _config(tmp_path: Path) -> AnnouncementConfig:
+    return AnnouncementConfig(
+        artifact_root=tmp_path,
+        docling_version="docling==2.15.1",
+        llama_index_version="llama-index-core==0.10.0",
+    )

--- a/tests/test_signals_templates.py
+++ b/tests/test_signals_templates.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from subsystem_announcement.extract import FactType, extract_fact_candidates
+from subsystem_announcement.signals import (
+    SIGNAL_TEMPLATES,
+    SignalDirection,
+    classify_signal_for_fact,
+)
+
+from .extract_fixtures import make_artifact
+
+
+def test_signal_templates_cover_all_fact_types() -> None:
+    assert set(SIGNAL_TEMPLATES) == set(FactType)
+    assert all(template.fact_type == fact_type for fact_type, template in SIGNAL_TEMPLATES.items())
+
+
+def test_earnings_performance_direction_mapping() -> None:
+    template = SIGNAL_TEMPLATES[FactType.EARNINGS_PREANNOUNCE]
+
+    assert _decision(
+        FactType.EARNINGS_PREANNOUNCE,
+        {"performance_direction": "positive"},
+        template,
+    ).direction is SignalDirection.POSITIVE
+    assert _decision(
+        FactType.EARNINGS_PREANNOUNCE,
+        {"performance_direction": "negative"},
+        template,
+    ).direction is SignalDirection.NEGATIVE
+    assert _decision(
+        FactType.EARNINGS_PREANNOUNCE,
+        {"performance_direction": "uncertain"},
+        template,
+    ).direction is SignalDirection.NEUTRAL
+
+
+def test_equity_pledge_action_mapping() -> None:
+    template = SIGNAL_TEMPLATES[FactType.EQUITY_PLEDGE]
+
+    assert _decision(
+        FactType.EQUITY_PLEDGE,
+        {"pledge_action": "pledge"},
+        template,
+    ).direction is SignalDirection.NEGATIVE
+    assert _decision(
+        FactType.EQUITY_PLEDGE,
+        {"pledge_action": "release"},
+        template,
+    ).direction is SignalDirection.POSITIVE
+
+
+def test_regulatory_action_never_maps_positive() -> None:
+    template = SIGNAL_TEMPLATES[FactType.REGULATORY_ACTION]
+
+    directions = [
+        _decision(
+            FactType.REGULATORY_ACTION,
+            {"regulatory_action_type": action_type},
+            template,
+        ).direction
+        for action_type in (
+            "administrative_penalty",
+            "investigation",
+            "regulatory_notice",
+        )
+    ]
+
+    assert directions == [
+        SignalDirection.NEGATIVE,
+        SignalDirection.NEGATIVE,
+        SignalDirection.NEUTRAL,
+    ]
+    assert SignalDirection.POSITIVE not in directions
+
+
+def test_classifier_returns_none_for_insufficient_fact_inputs() -> None:
+    template = SIGNAL_TEMPLATES[FactType.MAJOR_CONTRACT]
+    fact = _fact(FactType.MAJOR_CONTRACT, {"event": "major_contract"})
+
+    assert classify_signal_for_fact(
+        fact.model_copy(update={"evidence_spans": []}),
+        template,
+    ) is None
+    assert classify_signal_for_fact(
+        fact.model_copy(update={"fact_content": {}}),
+        template,
+    ) is None
+    assert classify_signal_for_fact(
+        fact.model_copy(update={"primary_entity_id": ""}),
+        template,
+    ) is None
+    assert classify_signal_for_fact(
+        fact.model_copy(update={"confidence": template.min_confidence - 0.01}),
+        template,
+    ) is None
+    assert classify_signal_for_fact(
+        fact.model_copy(update={"source_reference": {"official_url": ""}}),
+        template,
+    ) is None
+
+
+def test_unknown_direction_returns_none() -> None:
+    template = SIGNAL_TEMPLATES[FactType.TRADING_HALT_RESUME]
+
+    assert (
+        classify_signal_for_fact(
+            _fact(FactType.TRADING_HALT_RESUME, {"trading_status": "unknown"}),
+            template,
+        )
+        is None
+    )
+
+
+def _decision(fact_type: FactType, content: dict[str, str], template):
+    decision = classify_signal_for_fact(_fact(fact_type, content), template)
+    assert decision is not None
+    return decision
+
+
+def _fact(fact_type: FactType, content: dict[str, str]):
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n"
+        "公司与华东能源签订重大合同，合同金额为1000万元。",
+        announcement_id=f"ann-{fact_type.value}",
+    )
+    fact = extract_fact_candidates(artifact)[0]
+    return fact.model_copy(
+        update={
+            "fact_type": fact_type,
+            "fact_content": content,
+            "confidence": 0.9,
+        }
+    )


### PR DESCRIPTION
Closes #8

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/runtime/submit.py`, `tests/contracts/test_ex1_contract.py`, `tests/test_parse_docling_client.py`, `tests/test_runtime_sdk.py`


---
### 1. 背景与目标
项目文档 §11.4、§13.2 和 §21 阶段 2 要求在 Ex-1 事实稳定后，只在事实和证据充分时生成 Ex-2 公告信号。当前代码已经有 `subsystem_announcement.extract.candidates.AnnouncementFactCandidate`、`FactType`、`EvidenceSpan`、`extract_fact_candidates(parsed_artifact, *, entity_registry=None, reasoner=None)`，并由 `subsystem_announcement.runtime.pipeline.AnnouncementPipeline.process_envelope(...)` 串起 discovery -> parse -> extract -> submit。当前仓库还没有 `src/subsystem_announcement/signals/` 的实际实现，本 issue 的目标是在不改 Ex-1 抽取规则的前提下，基于真实 `AnnouncementFactCandidate[]` 生成可提交、可审计、可去重的 `AnnouncementSignalCandidate`。事实不足、证据缺失或实体无法锚定时必须保持 Ex-1-only，不得为了信号覆盖率硬凑 Ex-2。

### 2. 所属模块
Primary writable paths:
- `src/subsystem_announcement/signals/__init__.py`（不存在时创建，导出公开 API）
- `src/subsystem_announcement/signals/candidates.py`
- `src/subsystem_announcement/signals/templates.py`
- `src/subsystem_announcement/signals/classifier.py`
- `src/subsystem_announcement/signals/aggregator.py`
- `src/subsystem_announcement/runtime/pipeline.py`（仅做 Ex-2 pipeline 接入与依赖注入扩展）
- `src/subsystem_announcement/runtime/submit.py`（仅把提交入口从 Ex-1 扩展到 Ex-1/Ex-2 混合候选）
- `src/subsystem_announcement/runtime/trace.py`（仅在提交 trace 需要记录 `ex_type` / candidate id 时修改）
- `tests/test_signals_candidates.py`
- `tests/test_signals_templates.py`
- `tests/test_signals_pipeline.py`
- `tests/contracts/test_ex2_contract.py`

Adjacent read-only / integration paths:
- `src/subsystem_announcement/extract/candidates.py`：复用 `AnnouncementFactCandidate`、`FactType`、`build_source_reference(...)` 当前语义，不修改 Ex-1 schema
- `src/subsystem_announcement/extract/evidence.py`：复用 `EvidenceSpan`，不重算 offset
- `src/subsystem_announcement/extract/entity_anchor.py`：复用 #7 后已经稳定的实体锚点结果，不在 signals 内调用 registry
- `tests/test_extract_fact_candidates.py`、`tests/test_runtime_submit.py`、`tests/test_pipeline_e2e.py`：作为回归验证入口

### 3. 实现范围
- 创建 signals package 并在 `signals/__init__.py` 导出 `AnnouncementSignalCandidate`、`SignalDirection`、`SignalTimeHorizon`、`SignalTemplate`、`derive_signal_candidates`。
- 在 `signals/candid