### PR TITLE
feat(#9): 高门槛 Ex-3 图谱变更候选

### DIFF
--- a/src/subsystem_announcement/graph/__init__.py
+++ b/src/subsystem_announcement/graph/__init__.py
@@ -1,1 +1,27 @@
-__all__: list[str] = []
+"""Announcement Ex-3 graph delta generation public API."""
+
+from __future__ import annotations
+
+from .candidates import (
+    AnnouncementGraphDeltaCandidate,
+    GraphDeltaType,
+    GraphRelationType,
+    make_delta_id,
+)
+from .deltas import GraphFunc, derive_graph_delta_candidates
+from .guard import GraphDeltaGuard, GraphDeltaGuardResult, is_resolved_entity_id
+from .rules import GraphDeltaIntent, classify_graph_delta_intent
+
+__all__ = [
+    "AnnouncementGraphDeltaCandidate",
+    "GraphDeltaGuard",
+    "GraphDeltaGuardResult",
+    "GraphDeltaIntent",
+    "GraphDeltaType",
+    "GraphFunc",
+    "GraphRelationType",
+    "classify_graph_delta_intent",
+    "derive_graph_delta_candidates",
+    "is_resolved_entity_id",
+    "make_delta_id",
+]

--- a/src/subsystem_announcement/graph/candidates.py
+++ b/src/subsystem_announcement/graph/candidates.py
@@ -1,0 +1,156 @@
+"""Ex-3 graph delta candidate models and deterministic identity helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from subsystem_announcement.extract.candidates import FORBIDDEN_PAYLOAD_KEYS
+from subsystem_announcement.extract.evidence import EvidenceSpan
+
+
+class GraphDeltaType(str, Enum):
+    """Allowed graph delta operations."""
+
+    ADD_EDGE = "add_edge"
+    UPDATE_EDGE = "update_edge"
+
+
+class GraphRelationType(str, Enum):
+    """Allowed announcement-derived graph relations."""
+
+    CONTROL = "control"
+    SHAREHOLDING = "shareholding"
+    SUPPLY_CONTRACT = "supply_contract"
+    COOPERATION = "cooperation"
+
+
+class AnnouncementGraphDeltaCandidate(BaseModel):
+    """Contract-ready Ex-3 graph delta candidate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ex_type: Literal["Ex-3"] = "Ex-3"
+    delta_id: str = Field(min_length=1)
+    announcement_id: str = Field(min_length=1)
+    delta_type: GraphDeltaType
+    source_node: str = Field(min_length=1)
+    target_node: str = Field(min_length=1)
+    relation_type: GraphRelationType
+    properties: dict[str, Any] = Field(default_factory=dict)
+    source_fact_ids: list[str] = Field(min_length=1)
+    source_reference: dict[str, Any]
+    evidence_spans: list[EvidenceSpan] = Field(min_length=2)
+    confidence: float = Field(ge=0.0, le=1.0)
+    generated_at: datetime
+
+    @field_validator("generated_at")
+    @classmethod
+    def require_timezone(cls, value: datetime) -> datetime:
+        """Reject naive generation timestamps."""
+
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("generated_at must include timezone information")
+        return value
+
+    @field_validator("source_node", "target_node")
+    @classmethod
+    def require_non_blank_node(cls, value: str) -> str:
+        """Reject blank graph endpoints."""
+
+        if not value.strip():
+            raise ValueError("graph node references must be non-empty strings")
+        return value
+
+    @field_validator("source_fact_ids")
+    @classmethod
+    def require_non_empty_fact_ids(cls, value: list[str]) -> list[str]:
+        """Reject blank source fact references."""
+
+        if any(not item.strip() for item in value):
+            raise ValueError("source_fact_ids must contain non-empty strings")
+        return value
+
+    @model_validator(mode="after")
+    def validate_source_reference(self) -> "AnnouncementGraphDeltaCandidate":
+        """Require official source provenance and reject runtime metadata."""
+
+        official_url = self.source_reference.get("official_url")
+        if not isinstance(official_url, str) or not official_url.strip():
+            raise ValueError("source_reference.official_url is required")
+        _reject_forbidden_keys(self.model_dump(mode="python"))
+        return self
+
+    def to_ex_payload(self) -> dict[str, Any]:
+        """Return the Ex-3 payload for subsystem-sdk submission."""
+
+        payload = self.model_dump(mode="json")
+        _reject_forbidden_keys(payload)
+        return payload
+
+
+def make_delta_id(
+    announcement_id: str,
+    relation_type: GraphRelationType,
+    source_node: str,
+    target_node: str,
+    source_fact_ids: Sequence[str],
+    evidence_spans: Sequence[EvidenceSpan],
+    properties: Mapping[str, Any],
+) -> str:
+    """Generate a deterministic graph delta id for dedupe/replay."""
+
+    identity_payload = {
+        "announcement_id": announcement_id,
+        "relation_type": relation_type.value,
+        "source_node": source_node,
+        "target_node": target_node,
+        "source_fact_ids": list(source_fact_ids),
+        "evidence_spans": [
+            _stable_jsonable(span.model_dump(mode="python"))
+            for span in evidence_spans
+        ],
+        "properties": _stable_jsonable(properties),
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            identity_payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"graph_delta:{announcement_id}:{relation_type.value}:{digest}"
+
+
+def _stable_jsonable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _stable_jsonable(item)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_stable_jsonable(item) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _reject_forbidden_keys(value: Any, path: str = "") -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            key_text = str(key)
+            if key_text in FORBIDDEN_PAYLOAD_KEYS:
+                raise ValueError(f"Ex-3 payload contains forbidden key: {path}{key_text}")
+            _reject_forbidden_keys(item, f"{path}{key_text}.")
+    elif isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        for index, item in enumerate(value):
+            _reject_forbidden_keys(item, f"{path}{index}.")

--- a/src/subsystem_announcement/graph/deltas.py
+++ b/src/subsystem_announcement/graph/deltas.py
@@ -1,0 +1,78 @@
+"""Materialize conservative Ex-3 graph delta candidates from Ex-1 facts."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import datetime, timezone
+
+from subsystem_announcement.extract import AnnouncementFactCandidate
+
+from .candidates import AnnouncementGraphDeltaCandidate, make_delta_id
+from .guard import GraphDeltaGuard
+from .rules import classify_graph_delta_intent
+
+
+GraphFunc = Callable[
+    [Sequence[AnnouncementFactCandidate]],
+    Sequence[AnnouncementGraphDeltaCandidate]
+    | Awaitable[Sequence[AnnouncementGraphDeltaCandidate]],
+]
+
+
+def derive_graph_delta_candidates(
+    facts: Sequence[AnnouncementFactCandidate],
+    *,
+    generated_at: datetime | None = None,
+    guard: GraphDeltaGuard | None = None,
+) -> list[AnnouncementGraphDeltaCandidate]:
+    """Derive deterministic high-threshold Ex-3 candidates from Ex-1 facts."""
+
+    if not facts:
+        return []
+
+    timestamp = generated_at or datetime.now(timezone.utc)
+    active_guard = guard or GraphDeltaGuard()
+    graph_deltas: list[AnnouncementGraphDeltaCandidate] = []
+    seen_delta_ids: set[str] = set()
+
+    for fact in facts:
+        intent = classify_graph_delta_intent(fact)
+        if intent is None:
+            continue
+        guard_result = active_guard.check(fact, intent)
+        if not guard_result.allow:
+            continue
+
+        source_fact_ids = [fact.fact_id]
+        properties = dict(intent.properties)
+        delta_id = make_delta_id(
+            fact.announcement_id,
+            intent.relation_type,
+            intent.source_node,
+            intent.target_node,
+            source_fact_ids,
+            fact.evidence_spans,
+            properties,
+        )
+        if delta_id in seen_delta_ids:
+            continue
+
+        graph_deltas.append(
+            AnnouncementGraphDeltaCandidate(
+                delta_id=delta_id,
+                announcement_id=fact.announcement_id,
+                delta_type=intent.delta_type,
+                source_node=intent.source_node,
+                target_node=intent.target_node,
+                relation_type=intent.relation_type,
+                properties=properties,
+                source_fact_ids=source_fact_ids,
+                source_reference=dict(fact.source_reference),
+                evidence_spans=list(fact.evidence_spans),
+                confidence=fact.confidence,
+                generated_at=timestamp,
+            )
+        )
+        seen_delta_ids.add(delta_id)
+
+    return graph_deltas

--- a/src/subsystem_announcement/graph/guard.py
+++ b/src/subsystem_announcement/graph/guard.py
@@ -1,0 +1,85 @@
+"""High-threshold guardrails for Ex-3 graph delta generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from subsystem_announcement.extract import AnnouncementFactCandidate
+
+if TYPE_CHECKING:
+    from .rules import GraphDeltaIntent
+
+
+AMBIGUOUS_GRAPH_TERMS = (
+    "战略合作意向",
+    "框架协议",
+    "意向",
+    "拟",
+    "可能",
+)
+
+
+@dataclass(frozen=True)
+class GraphDeltaGuardResult:
+    """Decision returned by graph delta guard checks."""
+
+    allow: bool
+    reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class GraphDeltaGuard:
+    """Conservative threshold checks before materializing Ex-3 candidates."""
+
+    min_evidence_spans: int = 2
+    min_fact_confidence: float = 0.90
+    require_resolved_entity_ids: bool = True
+
+    def check(
+        self,
+        fact: AnnouncementFactCandidate,
+        intent: "GraphDeltaIntent",
+    ) -> GraphDeltaGuardResult:
+        """Return whether a fact and classified intent may produce Ex-3."""
+
+        reasons: list[str] = []
+        if len(fact.evidence_spans) < self.min_evidence_spans:
+            reasons.append("insufficient_evidence_spans")
+        if fact.confidence < self.min_fact_confidence:
+            reasons.append("low_fact_confidence")
+        if self.require_resolved_entity_ids:
+            if not is_resolved_entity_id(intent.source_node):
+                reasons.append("unresolved_source_node")
+            if not is_resolved_entity_id(intent.target_node):
+                reasons.append("unresolved_target_node")
+        official_url = fact.source_reference.get("official_url")
+        if not isinstance(official_url, str) or not official_url.strip():
+            reasons.append("missing_source_reference")
+        if _contains_ambiguous_language(fact):
+            reasons.append("ambiguous_language")
+        return GraphDeltaGuardResult(allow=not reasons, reasons=tuple(reasons))
+
+
+def is_resolved_entity_id(value: str) -> bool:
+    """Return whether a reference is safe to use as a graph node id."""
+
+    text = value.strip()
+    if not text:
+        return False
+    lowered = text.lower()
+    if lowered == "unresolved" or lowered.startswith("unresolved:"):
+        return False
+    if lowered.startswith("mention:"):
+        return False
+    return not lowered.startswith("unresolved")
+
+
+def has_ambiguous_graph_language(text: str) -> bool:
+    """Return whether text contains terms too weak for Ex-3 graph updates."""
+
+    return any(term in text for term in AMBIGUOUS_GRAPH_TERMS)
+
+
+def _contains_ambiguous_language(fact: AnnouncementFactCandidate) -> bool:
+    return any(has_ambiguous_graph_language(span.quote) for span in fact.evidence_spans)

--- a/src/subsystem_announcement/graph/rules.py
+++ b/src/subsystem_announcement/graph/rules.py
@@ -1,0 +1,166 @@
+"""Conservative Ex-3 graph delta intent rules from Ex-1 facts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from subsystem_announcement.extract import AnnouncementFactCandidate, FactType
+
+from .candidates import GraphDeltaType, GraphRelationType
+from .guard import has_ambiguous_graph_language, is_resolved_entity_id
+
+
+@dataclass(frozen=True)
+class GraphDeltaIntent:
+    """A classified graph delta before threshold checks and materialization."""
+
+    delta_type: GraphDeltaType
+    relation_type: GraphRelationType
+    source_node: str
+    target_node: str
+    properties: dict[str, Any] = field(default_factory=dict)
+    reason: str = ""
+
+
+_PERCENT = r"\d+(?:\.\d+)?%"
+_RATIO_CHANGE_RE = re.compile(
+    rf"持股比例(?:由|从)?\s*(?P<before>{_PERCENT})"
+    rf"[^。；;，,]{{0,24}}(?:增至|增加至|升至|上升至|降至|下降至|减至|减少至|变更为|变为|至|到)"
+    rf"\s*(?P<after>{_PERCENT})"
+)
+_AFTER_RATIO_RE = re.compile(
+    rf"(?:变动后|权益变动后|本次权益变动后|完成后|减持后|增持后)"
+    rf"[^。；;，,]{{0,30}}(?:持股比例)?(?:为|至|达到|降至|增至)?\s*(?P<after>{_PERCENT})"
+)
+_HOLDING_RATIO_RE = re.compile(
+    rf"持股比例(?:为|至|达到|降至|增至)\s*(?P<after>{_PERCENT})"
+)
+_CHANGE_RATIO_RE = re.compile(
+    rf"(?P<direction>增持|减持)比例(?:为|达到)?\s*(?P<change>{_PERCENT})"
+)
+
+_MAJOR_CONTRACT_ACTION_RE = re.compile(
+    r"签订|签署|订立|签约|中标|合作协议|终止合同|解除合同|合同终止"
+)
+_COOPERATION_RE = re.compile(r"合作协议|战略合作协议")
+_TERMINATION_RE = re.compile(r"终止合同|解除合同|合同终止")
+
+
+def classify_graph_delta_intent(
+    fact: AnnouncementFactCandidate,
+) -> GraphDeltaIntent | None:
+    """Classify one Ex-1 fact into an Ex-3 graph intent, when safe."""
+
+    if fact.fact_type is FactType.SHAREHOLDER_CHANGE:
+        return _shareholder_change_intent(fact)
+    if fact.fact_type is FactType.MAJOR_CONTRACT:
+        return _major_contract_intent(fact)
+    return None
+
+
+def _shareholder_change_intent(
+    fact: AnnouncementFactCandidate,
+) -> GraphDeltaIntent | None:
+    if _evidence_has_ambiguous_language(fact):
+        return None
+    source_node = _first_resolved_related_entity(fact)
+    if source_node is None or not is_resolved_entity_id(fact.primary_entity_id):
+        return None
+
+    if fact.fact_content.get("shareholder_change_type") == "control_change":
+        return GraphDeltaIntent(
+            delta_type=GraphDeltaType.UPDATE_EDGE,
+            relation_type=GraphRelationType.CONTROL,
+            source_node=source_node,
+            target_node=fact.primary_entity_id,
+            properties={"change_type": "control_change"},
+            reason="explicit_control_change",
+        )
+
+    ratio_properties = _shareholding_ratio_properties(fact)
+    if not ratio_properties:
+        return None
+    return GraphDeltaIntent(
+        delta_type=GraphDeltaType.UPDATE_EDGE,
+        relation_type=GraphRelationType.SHAREHOLDING,
+        source_node=source_node,
+        target_node=fact.primary_entity_id,
+        properties=ratio_properties,
+        reason="explicit_shareholding_ratio",
+    )
+
+
+def _major_contract_intent(
+    fact: AnnouncementFactCandidate,
+) -> GraphDeltaIntent | None:
+    if _evidence_has_ambiguous_language(fact):
+        return None
+    evidence_text = _evidence_text(fact)
+    if _MAJOR_CONTRACT_ACTION_RE.search(evidence_text) is None:
+        return None
+    target_node = _first_resolved_related_entity(fact)
+    if target_node is None or not is_resolved_entity_id(fact.primary_entity_id):
+        return None
+
+    relation_type = (
+        GraphRelationType.COOPERATION
+        if _COOPERATION_RE.search(evidence_text)
+        else GraphRelationType.SUPPLY_CONTRACT
+    )
+    properties: dict[str, Any] = {"event": fact.fact_content.get("event", "major_contract")}
+    if _TERMINATION_RE.search(evidence_text):
+        properties["contract_status"] = "terminated"
+
+    return GraphDeltaIntent(
+        delta_type=GraphDeltaType.ADD_EDGE,
+        relation_type=relation_type,
+        source_node=fact.primary_entity_id,
+        target_node=target_node,
+        properties=properties,
+        reason="explicit_major_contract_action",
+    )
+
+
+def _first_resolved_related_entity(fact: AnnouncementFactCandidate) -> str | None:
+    for entity_id in fact.related_entity_ids:
+        if is_resolved_entity_id(entity_id):
+            return entity_id
+    return None
+
+
+def _shareholding_ratio_properties(
+    fact: AnnouncementFactCandidate,
+) -> dict[str, Any]:
+    text = _evidence_text(fact).replace("％", "%")
+    properties: dict[str, Any] = {}
+
+    change_match = _RATIO_CHANGE_RE.search(text)
+    if change_match is not None:
+        properties["before_ratio"] = change_match.group("before")
+        properties["after_ratio"] = change_match.group("after")
+        return properties
+
+    after_match = _AFTER_RATIO_RE.search(text) or _HOLDING_RATIO_RE.search(text)
+    if after_match is not None:
+        properties["after_ratio"] = after_match.group("after")
+
+    change_ratio_match = _CHANGE_RATIO_RE.search(text)
+    if change_ratio_match is not None:
+        properties["direction"] = (
+            "increase"
+            if change_ratio_match.group("direction") == "增持"
+            else "decrease"
+        )
+        properties["change_ratio"] = change_ratio_match.group("change")
+
+    return properties
+
+
+def _evidence_has_ambiguous_language(fact: AnnouncementFactCandidate) -> bool:
+    return any(has_ambiguous_graph_language(span.quote) for span in fact.evidence_spans)
+
+
+def _evidence_text(fact: AnnouncementFactCandidate) -> str:
+    return "\n".join(span.quote for span in fact.evidence_spans)

--- a/src/subsystem_announcement/runtime/pipeline.py
+++ b/src/subsystem_announcement/runtime/pipeline.py
@@ -26,6 +26,11 @@ from subsystem_announcement.extract import (
     StructuredReasoner,
     extract_fact_candidates,
 )
+from subsystem_announcement.graph import (
+    AnnouncementGraphDeltaCandidate,
+    GraphFunc,
+    derive_graph_delta_candidates,
+)
 from subsystem_announcement.parse import ParsedAnnouncementArtifact, parse_announcement
 from subsystem_announcement.parse.artifact import write_parsed_artifact
 from subsystem_announcement.signals import (
@@ -59,7 +64,7 @@ ExtractFunc = Callable[
 
 
 class AnnouncementPipeline:
-    """Process one announcement envelope through Ex-1/Ex-2 submission."""
+    """Process one announcement envelope through Ex candidate submission."""
 
     def __init__(
         self,
@@ -70,6 +75,7 @@ class AnnouncementPipeline:
         parse_func: ParseFunc = parse_announcement,
         extract_func: ExtractFunc = extract_fact_candidates,
         signal_func: SignalFunc = derive_signal_candidates,
+        graph_func: GraphFunc = derive_graph_delta_candidates,
         idempotency_store: SubmitIdempotencyStore | None = None,
         trace_store: TraceStore | None = None,
     ) -> None:
@@ -79,6 +85,7 @@ class AnnouncementPipeline:
         self._parse_func = parse_func
         self._extract_func = extract_func
         self._signal_func = signal_func
+        self._graph_func = graph_func
         self._entity_registry = _build_entity_registry(config)
         self._reasoner = _build_reasoner(config)
         self._idempotency_store = idempotency_store or SubmitIdempotencyStore(
@@ -90,7 +97,7 @@ class AnnouncementPipeline:
         self,
         envelope: AnnouncementEnvelope,
     ) -> AnnouncementExtractionRun:
-        """Run discovery, parse, Ex-1 extraction, Ex-2 signals, submit, and trace."""
+        """Run discovery, parse, Ex extraction, submit, and trace."""
 
         run = AnnouncementExtractionRun(
             run_id=str(uuid4()),
@@ -109,7 +116,8 @@ class AnnouncementPipeline:
 
             facts = list(await self._call_extract(parsed_artifact))
             signals = list(await self._call_signals(facts))
-            candidates: list[CandidatePayload] = [*facts, *signals]
+            graph_deltas = list(await self._call_graph(facts))
+            candidates: list[CandidatePayload] = [*facts, *signals, *graph_deltas]
             run.candidate_count = len(candidates)
 
             if candidates:
@@ -165,6 +173,12 @@ class AnnouncementPipeline:
         facts: Sequence[AnnouncementFactCandidate],
     ) -> Sequence[AnnouncementSignalCandidate]:
         return await _maybe_await(self._signal_func(facts))
+
+    async def _call_graph(
+        self,
+        facts: Sequence[AnnouncementFactCandidate],
+    ) -> Sequence[AnnouncementGraphDeltaCandidate]:
+        return await _maybe_await(self._graph_func(facts))
 
     def _get_subsystem(self) -> AnnouncementSubsystem:
         if self._subsystem is None:

--- a/src/subsystem_announcement/runtime/submit.py
+++ b/src/subsystem_announcement/runtime/submit.py
@@ -18,6 +18,7 @@ from subsystem_announcement.discovery.errors import NonOfficialSourceError
 from subsystem_announcement.discovery.fetcher import _validate_official_url_text
 from subsystem_announcement.extract import AnnouncementFactCandidate
 from subsystem_announcement.extract.candidates import FORBIDDEN_PAYLOAD_KEYS
+from subsystem_announcement.graph import AnnouncementGraphDeltaCandidate
 from subsystem_announcement.signals import AnnouncementSignalCandidate
 
 from .sdk_adapter import AnnouncementSubsystem
@@ -39,7 +40,12 @@ _FORBIDDEN_RUNTIME_KEYS = FORBIDDEN_PAYLOAD_KEYS | {
 }
 _VOLATILE_IDEMPOTENCY_PAYLOAD_KEYS = {"extracted_at", "generated_at"}
 
-CandidatePayload: TypeAlias = AnnouncementFactCandidate | AnnouncementSignalCandidate
+CandidatePayload: TypeAlias = (
+    AnnouncementFactCandidate
+    | AnnouncementSignalCandidate
+    | AnnouncementGraphDeltaCandidate
+)
+ExType: TypeAlias = Literal["Ex-1", "Ex-2", "Ex-3"]
 
 
 class CandidateSubmitReceipt(BaseModel):
@@ -51,7 +57,7 @@ class CandidateSubmitReceipt(BaseModel):
     candidate_id: str | None = None
     payload_hash: str = Field(min_length=64, max_length=64)
     receipt_id: str = Field(min_length=1)
-    ex_type: Literal["Ex-1", "Ex-2"] = "Ex-1"
+    ex_type: ExType = "Ex-1"
     attempts: int = Field(ge=1)
     accepted_at: datetime
     warnings: tuple[str, ...] = Field(default_factory=tuple)
@@ -240,7 +246,7 @@ def submit_candidates(
     idempotency_store: SubmitIdempotencyStore | None = None,
     max_attempts: int = 3,
 ) -> SubmitBatchResult:
-    """Submit Ex-1/Ex-2 candidates in order with retry and idempotency."""
+    """Submit Ex candidates in order with retry and idempotency."""
 
     if max_attempts < 1:
         raise ValueError("max_attempts must be at least 1")
@@ -341,7 +347,7 @@ def submit_candidates(
 
 def _submit_one(
     candidate_id: str,
-    ex_type: Literal["Ex-1", "Ex-2"],
+    ex_type: ExType,
     payload_hash: str,
     payload: dict[str, Any],
     subsystem: AnnouncementSubsystem,
@@ -413,8 +419,8 @@ def _submit_one(
 def _validated_payload(candidate: CandidatePayload) -> dict[str, Any]:
     payload = candidate.to_ex_payload()
     ex_type = payload.get("ex_type")
-    if ex_type not in {"Ex-1", "Ex-2"}:
-        raise ValueError("submit_candidates only accepts Ex-1/Ex-2 payloads")
+    if ex_type not in {"Ex-1", "Ex-2", "Ex-3"}:
+        raise ValueError("submit_candidates only accepts Ex-1/Ex-2/Ex-3 payloads")
     if not payload.get("evidence_spans"):
         raise ValueError(f"{ex_type} payload requires at least one evidence span")
     source_reference = payload.get("source_reference")
@@ -424,8 +430,10 @@ def _validated_payload(candidate: CandidatePayload) -> dict[str, Any]:
     _reject_forbidden_runtime_keys(payload)
     if ex_type == "Ex-1":
         validated = AnnouncementFactCandidate.model_validate(payload)
-    else:
+    elif ex_type == "Ex-2":
         validated = AnnouncementSignalCandidate.model_validate(payload)
+    else:
+        validated = AnnouncementGraphDeltaCandidate.model_validate(payload)
     return validated.model_dump(mode="json")
 
 
@@ -435,29 +443,31 @@ def candidate_id_for(candidate: CandidatePayload) -> str:
     ex_type = ex_type_for(candidate)
     if ex_type == "Ex-1":
         return candidate.fact_id
-    return candidate.signal_id
+    if ex_type == "Ex-2":
+        return candidate.signal_id
+    return candidate.delta_id
 
 
-def ex_type_for(candidate: CandidatePayload) -> Literal["Ex-1", "Ex-2"]:
+def ex_type_for(candidate: CandidatePayload) -> ExType:
     """Return the candidate Ex type."""
 
     ex_type = getattr(candidate, "ex_type", None)
-    if ex_type not in {"Ex-1", "Ex-2"}:
-        raise ValueError("candidate must be Ex-1 or Ex-2")
+    if ex_type not in {"Ex-1", "Ex-2", "Ex-3"}:
+        raise ValueError("candidate must be Ex-1, Ex-2, or Ex-3")
     return ex_type
 
 
 def _best_effort_candidate_id(candidate: object) -> str:
-    for attribute in ("fact_id", "signal_id"):
+    for attribute in ("fact_id", "signal_id", "delta_id"):
         value = getattr(candidate, attribute, None)
         if isinstance(value, str) and value:
             return value
     return "unknown"
 
 
-def _best_effort_ex_type(candidate: object) -> Literal["Ex-1", "Ex-2"] | None:
+def _best_effort_ex_type(candidate: object) -> ExType | None:
     value = getattr(candidate, "ex_type", None)
-    if value in {"Ex-1", "Ex-2"}:
+    if value in {"Ex-1", "Ex-2", "Ex-3"}:
         return value
     return None
 

--- a/src/subsystem_announcement/runtime/trace.py
+++ b/src/subsystem_announcement/runtime/trace.py
@@ -22,7 +22,7 @@ class CandidateSubmitTrace(BaseModel):
 
     fact_id: str = Field(min_length=1)
     candidate_id: str | None = None
-    ex_type: Literal["Ex-1", "Ex-2"] | None = None
+    ex_type: Literal["Ex-1", "Ex-2", "Ex-3"] | None = None
     status: Literal["accepted", "duplicate", "failed"]
     receipt_id: str | None = None
     attempts: int = Field(ge=0)

--- a/tests/contracts/test_ex3_contract.py
+++ b/tests/contracts/test_ex3_contract.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from subsystem_announcement.extract import AnnouncementFactCandidate, EvidenceSpan, FactType
+from subsystem_announcement.graph import (
+    AnnouncementGraphDeltaCandidate,
+    derive_graph_delta_candidates,
+)
+from subsystem_announcement.runtime.submit import submit_candidates
+
+
+FORBIDDEN_KEYS = {"submitted_at", "ingest_seq", "layer_b_receipt_id", "local_path"}
+GENERATED_AT = datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc)
+
+
+class RecordingSubsystem:
+    def __init__(self) -> None:
+        self.submissions: list[dict[str, Any]] = []
+
+    def submit(self, candidate: dict[str, Any]) -> dict[str, Any]:
+        self.submissions.append(candidate)
+        return {
+            "accepted": True,
+            "receipt_id": f"receipt-{len(self.submissions)}",
+            "warnings": (),
+            "errors": (),
+        }
+
+
+def test_ex3_payload_shape_and_forbidden_metadata() -> None:
+    fact = _major_contract_fact()
+    delta = derive_graph_delta_candidates([fact], generated_at=GENERATED_AT)[0]
+
+    payload = delta.to_ex_payload()
+
+    assert payload["ex_type"] == "Ex-3"
+    assert payload["delta_id"]
+    assert payload["announcement_id"] == fact.announcement_id
+    assert payload["delta_type"] == "add_edge"
+    assert payload["relation_type"] == "supply_contract"
+    assert payload["source_node"] == fact.primary_entity_id
+    assert payload["target_node"] == fact.related_entity_ids[0]
+    assert payload["source_fact_ids"] == [fact.fact_id]
+    assert payload["source_reference"] == fact.source_reference
+    assert payload["evidence_spans"] == [
+        span.model_dump(mode="json") for span in fact.evidence_spans
+    ]
+    AnnouncementGraphDeltaCandidate.model_validate(payload)
+    _assert_no_forbidden_keys(payload)
+
+
+def test_ex3_submit_path_validates_contract_payload_without_runtime_metadata() -> None:
+    fact = _major_contract_fact("ann-ex3-submit-contract")
+    delta = derive_graph_delta_candidates([fact], generated_at=GENERATED_AT)[0]
+    subsystem = RecordingSubsystem()
+
+    result = submit_candidates([delta], subsystem)  # type: ignore[arg-type]
+
+    assert result.submitted == 1
+    assert result.failed == 0
+    assert subsystem.submissions == [delta.to_ex_payload()]
+    _assert_no_forbidden_keys(subsystem.submissions[0])
+
+
+def test_ex3_source_reference_is_not_forged_when_missing() -> None:
+    fact = _major_contract_fact("ann-ex3-missing-source").model_copy(
+        update={"source_reference": {}}
+    )
+
+    assert derive_graph_delta_candidates([fact], generated_at=GENERATED_AT) == []
+
+
+def _major_contract_fact(announcement_id: str = "ann-ex3-contract") -> AnnouncementFactCandidate:
+    return AnnouncementFactCandidate(
+        fact_id=f"fact:{announcement_id}:major_contract:1",
+        announcement_id=announcement_id,
+        fact_type=FactType.MAJOR_CONTRACT,
+        primary_entity_id="ts_code:600000.SH",
+        related_entity_ids=["entity:huadong-energy"],
+        fact_content={"event": "major_contract"},
+        confidence=0.93,
+        source_reference={
+            "announcement_id": announcement_id,
+            "official_url": f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf",
+            "source_exchange": "sse",
+            "attachment_type": "pdf",
+        },
+        evidence_spans=[
+            _span("公司与华东能源签订重大合同。", "sec-1"),
+            _span("双方合同金额为1000万元。", "sec-2"),
+        ],
+        extracted_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+    )
+
+
+def _span(quote: str, section_id: str) -> EvidenceSpan:
+    return EvidenceSpan(
+        section_id=section_id,
+        start_offset=0,
+        end_offset=len(quote),
+        quote=quote,
+    )
+
+
+def _assert_no_forbidden_keys(value: Any) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            assert key not in FORBIDDEN_KEYS
+            _assert_no_forbidden_keys(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_forbidden_keys(item)

--- a/tests/test_graph_delta_candidates.py
+++ b/tests/test_graph_delta_candidates.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from subsystem_announcement.extract import EvidenceSpan
+from subsystem_announcement.graph import (
+    AnnouncementGraphDeltaCandidate,
+    GraphDeltaType,
+    GraphRelationType,
+    make_delta_id,
+)
+
+
+GENERATED_AT = datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc)
+
+
+def test_graph_delta_candidate_payload_shape_and_validation() -> None:
+    candidate = _candidate()
+
+    payload = candidate.to_ex_payload()
+
+    assert payload["ex_type"] == "Ex-3"
+    assert payload["delta_id"] == candidate.delta_id
+    assert payload["delta_type"] == "add_edge"
+    assert payload["relation_type"] == "supply_contract"
+    assert payload["source_fact_ids"] == ["fact:ann-graph-schema:major_contract:1"]
+    assert payload["source_reference"]["official_url"].startswith("https://")
+    assert len(payload["evidence_spans"]) == 2
+    AnnouncementGraphDeltaCandidate.model_validate(payload)
+
+
+def test_graph_delta_candidate_rejects_extra_fields_and_missing_required_fields() -> None:
+    payload = _candidate().model_dump(mode="python")
+
+    with pytest.raises(ValidationError):
+        AnnouncementGraphDeltaCandidate.model_validate({**payload, "local_path": "/tmp/a.pdf"})
+
+    for field_name in ("source_fact_ids", "source_reference"):
+        invalid = dict(payload)
+        invalid.pop(field_name)
+        with pytest.raises(ValidationError):
+            AnnouncementGraphDeltaCandidate.model_validate(invalid)
+
+
+def test_graph_delta_candidate_requires_two_evidence_spans_and_source_fact() -> None:
+    payload = _candidate().model_dump(mode="python")
+
+    with pytest.raises(ValidationError):
+        AnnouncementGraphDeltaCandidate.model_validate({**payload, "evidence_spans": payload["evidence_spans"][:1]})
+
+    with pytest.raises(ValidationError):
+        AnnouncementGraphDeltaCandidate.model_validate({**payload, "source_fact_ids": []})
+
+
+def test_graph_delta_type_and_relation_type_are_whitelisted() -> None:
+    payload = _candidate().model_dump(mode="python")
+
+    with pytest.raises(ValidationError):
+        AnnouncementGraphDeltaCandidate.model_validate({**payload, "delta_type": "delete_edge"})
+
+    with pytest.raises(ValidationError):
+        AnnouncementGraphDeltaCandidate.model_validate({**payload, "relation_type": "rumor"})
+
+
+def test_make_delta_id_is_stable_and_sensitive_to_core_fields() -> None:
+    spans = [_span("公司与华东能源签订重大合同。"), _span("双方合同金额为1000万元。", "sec-2")]
+    source_fact_ids = ["fact:ann-delta-id:major_contract:1"]
+    properties = {"event": "major_contract"}
+
+    first = make_delta_id(
+        "ann-delta-id",
+        GraphRelationType.SUPPLY_CONTRACT,
+        "ts_code:600000.SH",
+        "entity:huadong-energy",
+        source_fact_ids,
+        spans,
+        properties,
+    )
+    second = make_delta_id(
+        "ann-delta-id",
+        GraphRelationType.SUPPLY_CONTRACT,
+        "ts_code:600000.SH",
+        "entity:huadong-energy",
+        source_fact_ids,
+        spans,
+        properties,
+    )
+    changed_target = make_delta_id(
+        "ann-delta-id",
+        GraphRelationType.SUPPLY_CONTRACT,
+        "ts_code:600000.SH",
+        "entity:other",
+        source_fact_ids,
+        spans,
+        properties,
+    )
+    changed_properties = make_delta_id(
+        "ann-delta-id",
+        GraphRelationType.SUPPLY_CONTRACT,
+        "ts_code:600000.SH",
+        "entity:huadong-energy",
+        source_fact_ids,
+        spans,
+        {"event": "major_contract", "contract_status": "terminated"},
+    )
+    changed_evidence = make_delta_id(
+        "ann-delta-id",
+        GraphRelationType.SUPPLY_CONTRACT,
+        "ts_code:600000.SH",
+        "entity:huadong-energy",
+        source_fact_ids,
+        [spans[0], _span("双方合同金额为2000万元。", "sec-2")],
+        properties,
+    )
+
+    assert first == second
+    assert first.startswith("graph_delta:ann-delta-id:supply_contract:")
+    assert changed_target != first
+    assert changed_properties != first
+    assert changed_evidence != first
+
+
+def _candidate() -> AnnouncementGraphDeltaCandidate:
+    spans = [_span("公司与华东能源签订重大合同。"), _span("双方合同金额为1000万元。", "sec-2")]
+    properties = {"event": "major_contract"}
+    source_fact_ids = ["fact:ann-graph-schema:major_contract:1"]
+    delta_id = make_delta_id(
+        "ann-graph-schema",
+        GraphRelationType.SUPPLY_CONTRACT,
+        "ts_code:600000.SH",
+        "entity:huadong-energy",
+        source_fact_ids,
+        spans,
+        properties,
+    )
+    return AnnouncementGraphDeltaCandidate(
+        delta_id=delta_id,
+        announcement_id="ann-graph-schema",
+        delta_type=GraphDeltaType.ADD_EDGE,
+        source_node="ts_code:600000.SH",
+        target_node="entity:huadong-energy",
+        relation_type=GraphRelationType.SUPPLY_CONTRACT,
+        properties=properties,
+        source_fact_ids=source_fact_ids,
+        source_reference=_source_reference("ann-graph-schema"),
+        evidence_spans=spans,
+        confidence=0.93,
+        generated_at=GENERATED_AT,
+    )
+
+
+def _source_reference(announcement_id: str) -> dict[str, str]:
+    return {
+        "announcement_id": announcement_id,
+        "official_url": f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf",
+        "source_exchange": "sse",
+        "attachment_type": "pdf",
+    }
+
+
+def _span(quote: str, section_id: str = "sec-1") -> EvidenceSpan:
+    return EvidenceSpan(
+        section_id=section_id,
+        start_offset=0,
+        end_offset=len(quote),
+        quote=quote,
+    )

--- a/tests/test_graph_delta_guard.py
+++ b/tests/test_graph_delta_guard.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from subsystem_announcement.extract import AnnouncementFactCandidate, EvidenceSpan, FactType
+from subsystem_announcement.graph import (
+    GraphDeltaGuard,
+    GraphDeltaIntent,
+    GraphDeltaType,
+    GraphRelationType,
+    is_resolved_entity_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("ts_code:600000.SH", True),
+        ("entity:shareholder", True),
+        ("", False),
+        ("   ", False),
+        ("unresolved", False),
+        ("unresolved:abc", False),
+        ("unresolved_related:abc", False),
+        ("mention:华东能源", False),
+    ],
+)
+def test_is_resolved_entity_id(value: str, expected: bool) -> None:
+    assert is_resolved_entity_id(value) is expected
+
+
+def test_graph_delta_guard_allows_resolved_fact_with_two_evidence_spans() -> None:
+    result = GraphDeltaGuard().check(_fact(), _intent())
+
+    assert result.allow is True
+    assert result.reasons == ()
+
+
+def test_graph_delta_guard_rejects_single_evidence_span() -> None:
+    fact = _fact(quotes=["公司与华东能源签订重大合同。"])
+
+    result = GraphDeltaGuard().check(fact, _intent())
+
+    assert result.allow is False
+    assert "insufficient_evidence_spans" in result.reasons
+
+
+def test_graph_delta_guard_rejects_unresolved_endpoints() -> None:
+    fact = _fact()
+    intent = _intent(source_node="unresolved:shareholder", target_node="mention:测试公司")
+
+    result = GraphDeltaGuard().check(fact, intent)
+
+    assert result.allow is False
+    assert "unresolved_source_node" in result.reasons
+    assert "unresolved_target_node" in result.reasons
+
+
+def test_graph_delta_guard_rejects_low_confidence_fact() -> None:
+    fact = _fact(confidence=0.89)
+
+    result = GraphDeltaGuard().check(fact, _intent())
+
+    assert result.allow is False
+    assert "low_fact_confidence" in result.reasons
+
+
+def test_graph_delta_guard_rejects_ambiguous_wording() -> None:
+    fact = _fact(
+        quotes=[
+            "公司拟与华东能源签订重大合同。",
+            "双方可能后续签署正式协议。",
+        ]
+    )
+
+    result = GraphDeltaGuard().check(fact, _intent())
+
+    assert result.allow is False
+    assert "ambiguous_language" in result.reasons
+
+
+def _intent(
+    *,
+    source_node: str = "ts_code:600000.SH",
+    target_node: str = "entity:huadong-energy",
+) -> GraphDeltaIntent:
+    return GraphDeltaIntent(
+        delta_type=GraphDeltaType.ADD_EDGE,
+        relation_type=GraphRelationType.SUPPLY_CONTRACT,
+        source_node=source_node,
+        target_node=target_node,
+        properties={"event": "major_contract"},
+        reason="test",
+    )
+
+
+def _fact(
+    *,
+    confidence: float = 0.93,
+    quotes: list[str] | None = None,
+) -> AnnouncementFactCandidate:
+    spans = [
+        _span(quote, f"sec-{index}")
+        for index, quote in enumerate(
+            quotes
+            or ["公司与华东能源签订重大合同。", "双方合同金额为1000万元。"],
+            start=1,
+        )
+    ]
+    return AnnouncementFactCandidate(
+        fact_id="fact:ann-guard:major_contract:1",
+        announcement_id="ann-guard",
+        fact_type=FactType.MAJOR_CONTRACT,
+        primary_entity_id="ts_code:600000.SH",
+        related_entity_ids=["entity:huadong-energy"],
+        fact_content={"event": "major_contract"},
+        confidence=confidence,
+        source_reference=_source_reference("ann-guard"),
+        evidence_spans=spans,
+        extracted_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+    )
+
+
+def _source_reference(announcement_id: str) -> dict[str, str]:
+    return {
+        "announcement_id": announcement_id,
+        "official_url": f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf",
+        "source_exchange": "sse",
+        "attachment_type": "pdf",
+    }
+
+
+def _span(quote: str, section_id: str) -> EvidenceSpan:
+    return EvidenceSpan(
+        section_id=section_id,
+        start_offset=0,
+        end_offset=len(quote),
+        quote=quote,
+    )

--- a/tests/test_graph_delta_pipeline.py
+++ b/tests/test_graph_delta_pipeline.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.discovery import (
+    AnnouncementDiscoveryResult,
+    AnnouncementEnvelope,
+)
+from subsystem_announcement.discovery.document import AnnouncementDocumentArtifact
+from subsystem_announcement.extract import AnnouncementFactCandidate, EvidenceSpan, FactType
+from subsystem_announcement.graph import derive_graph_delta_candidates
+from subsystem_announcement.parse import ParsedAnnouncementArtifact
+from subsystem_announcement.runtime.pipeline import AnnouncementPipeline
+from subsystem_announcement.runtime.submit import SubmitIdempotencyStore, submit_candidates
+from subsystem_announcement.signals import derive_signal_candidates
+
+from .extract_fixtures import make_artifact
+
+
+GENERATED_AT = datetime(2026, 4, 18, 10, 30, tzinfo=timezone.utc)
+
+
+class RecordingSubsystem:
+    def __init__(self) -> None:
+        self.submissions: list[dict[str, Any]] = []
+
+    def submit(self, candidate: dict[str, Any]) -> dict[str, Any]:
+        self.submissions.append(candidate)
+        return {
+            "accepted": True,
+            "receipt_id": f"receipt-{len(self.submissions)}",
+            "warnings": (),
+            "errors": (),
+        }
+
+
+def test_pipeline_generates_graph_after_signals_and_submits_ex3_last(
+    tmp_path: Path,
+) -> None:
+    subsystem = RecordingSubsystem()
+    calls: list[str] = []
+
+    def extract_func(artifact: ParsedAnnouncementArtifact) -> list[AnnouncementFactCandidate]:
+        calls.append("extract")
+        return [_major_contract_fact(artifact.announcement_id)]
+
+    def signal_func(facts: list[AnnouncementFactCandidate]):
+        assert calls == ["extract"]
+        calls.append("signals")
+        return derive_signal_candidates(facts, generated_at=GENERATED_AT)
+
+    def graph_func(facts: list[AnnouncementFactCandidate]):
+        assert calls == ["extract", "signals"]
+        calls.append("graph")
+        return derive_graph_delta_candidates(facts, generated_at=GENERATED_AT)
+
+    pipeline = AnnouncementPipeline(
+        _config(tmp_path),
+        subsystem=subsystem,  # type: ignore[arg-type]
+        discovery_func=_fake_discovery,
+        parse_func=_fake_parse,
+        extract_func=extract_func,
+        signal_func=signal_func,
+        graph_func=graph_func,
+    )
+
+    run = asyncio.run(pipeline.process_envelope(_envelope()))
+
+    assert calls == ["extract", "signals", "graph"]
+    assert run.status == "succeeded"
+    assert run.candidate_count == 3
+    assert [payload["ex_type"] for payload in subsystem.submissions] == [
+        "Ex-1",
+        "Ex-2",
+        "Ex-3",
+    ]
+    assert subsystem.submissions[1]["source_fact_ids"] == [
+        subsystem.submissions[0]["fact_id"]
+    ]
+    assert subsystem.submissions[2]["source_fact_ids"] == [
+        subsystem.submissions[0]["fact_id"]
+    ]
+    assert [receipt["ex_type"] for receipt in run.submit_receipts] == [
+        "Ex-1",
+        "Ex-2",
+        "Ex-3",
+    ]
+    assert [trace.ex_type for trace in run.candidate_traces] == [
+        "Ex-1",
+        "Ex-2",
+        "Ex-3",
+    ]
+
+
+def test_ex3_idempotency_is_isolated_from_ex1_and_ex2_candidate_ids() -> None:
+    fact = _major_contract_fact("ann-graph-idempotency")
+    signal = derive_signal_candidates([fact], generated_at=GENERATED_AT)[0].model_copy(
+        update={"signal_id": fact.fact_id}
+    )
+    delta = derive_graph_delta_candidates([fact], generated_at=GENERATED_AT)[0].model_copy(
+        update={"delta_id": fact.fact_id}
+    )
+    subsystem = RecordingSubsystem()
+    store = SubmitIdempotencyStore()
+
+    first = submit_candidates([fact, signal, delta], subsystem, idempotency_store=store)  # type: ignore[arg-type]
+    second = submit_candidates([fact, signal, delta], subsystem, idempotency_store=store)  # type: ignore[arg-type]
+
+    assert first.submitted == 3
+    assert first.skipped_duplicates == 0
+    assert second.submitted == 0
+    assert second.skipped_duplicates == 3
+    assert len(subsystem.submissions) == 3
+    assert [trace.ex_type for trace in second.traces] == ["Ex-1", "Ex-2", "Ex-3"]
+    assert all(trace.status == "duplicate" for trace in second.traces)
+
+
+async def _fake_discovery(
+    envelope: AnnouncementEnvelope,
+    config: AnnouncementConfig,
+) -> AnnouncementDiscoveryResult:
+    path = Path(config.artifact_root) / "documents" / f"{envelope.announcement_id}.pdf"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"%PDF mocked")
+    document = AnnouncementDocumentArtifact(
+        announcement_id=envelope.announcement_id,
+        ts_code=envelope.ts_code,
+        title=envelope.title,
+        publish_time=envelope.publish_time,
+        content_hash="b" * 64,
+        official_url=envelope.official_url,
+        source_exchange=envelope.source_exchange,
+        attachment_type=envelope.attachment_type,
+        local_path=path,
+        content_type="application/pdf",
+        byte_size=path.stat().st_size,
+        fetched_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+    )
+    return AnnouncementDiscoveryResult(status="fetched", document=document)
+
+
+def _fake_parse(
+    document: AnnouncementDocumentArtifact,
+    config: AnnouncementConfig,
+) -> ParsedAnnouncementArtifact:
+    artifact = make_artifact(
+        "证券代码：600000\n证券简称：测试公司\n"
+        "公司与华东能源签订重大合同，合同金额为1000万元。",
+        announcement_id=document.announcement_id,
+    )
+    return artifact.model_copy(
+        update={
+            "content_hash": document.content_hash,
+            "source_document": document,
+        }
+    )
+
+
+def _major_contract_fact(announcement_id: str) -> AnnouncementFactCandidate:
+    return AnnouncementFactCandidate(
+        fact_id=f"fact:{announcement_id}:major_contract:1",
+        announcement_id=announcement_id,
+        fact_type=FactType.MAJOR_CONTRACT,
+        primary_entity_id="ts_code:600000.SH",
+        related_entity_ids=["entity:huadong-energy"],
+        fact_content={"event": "major_contract"},
+        confidence=0.93,
+        source_reference={
+            "announcement_id": announcement_id,
+            "official_url": f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf",
+            "source_exchange": "sse",
+            "attachment_type": "pdf",
+        },
+        evidence_spans=[
+            _span("公司与华东能源签订重大合同。", "sec-1"),
+            _span("双方合同金额为1000万元。", "sec-2"),
+        ],
+        extracted_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+    )
+
+
+def _span(quote: str, section_id: str) -> EvidenceSpan:
+    return EvidenceSpan(
+        section_id=section_id,
+        start_offset=0,
+        end_offset=len(quote),
+        quote=quote,
+    )
+
+
+def _envelope() -> AnnouncementEnvelope:
+    return AnnouncementEnvelope(
+        announcement_id="ann-graph-pipeline",
+        ts_code="600000.SH",
+        title="测试公司重大合同公告",
+        publish_time=datetime(2026, 4, 18, 9, 0, tzinfo=timezone.utc),
+        official_url="https://static.sse.com.cn/disclosure/ann-graph-pipeline.pdf",
+        source_exchange="sse",
+        attachment_type="pdf",
+    )
+
+
+def _config(tmp_path: Path) -> AnnouncementConfig:
+    return AnnouncementConfig(
+        artifact_root=tmp_path,
+        docling_version="docling==2.15.1",
+        llama_index_version="llama-index-core==0.10.0",
+    )

--- a/tests/test_graph_delta_rules.py
+++ b/tests/test_graph_delta_rules.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from subsystem_announcement.extract import AnnouncementFactCandidate, EvidenceSpan, FactType
+from subsystem_announcement.graph import (
+    GraphDeltaType,
+    GraphRelationType,
+    classify_graph_delta_intent,
+    derive_graph_delta_candidates,
+)
+
+
+GENERATED_AT = datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc)
+
+
+def test_unsupported_fact_type_does_not_produce_graph_intent() -> None:
+    fact = _fact(
+        fact_type=FactType.EARNINGS_PREANNOUNCE,
+        fact_content={"performance_direction": "positive"},
+        quotes=["公司预计2026年净利润同比增长50%。", "本公告为业绩预告。"],
+    )
+
+    assert classify_graph_delta_intent(fact) is None
+    assert derive_graph_delta_candidates([fact]) == []
+
+
+def test_shareholder_control_change_intent_requires_resolved_related_entity() -> None:
+    fact = _fact(
+        fact_type=FactType.SHAREHOLDER_CHANGE,
+        related_entity_ids=["entity:new-controller"],
+        fact_content={"shareholder_change_type": "control_change"},
+        quotes=[
+            "本次权益变动将导致公司控股股东变更为明德投资。",
+            "公司实际控制人将发生变更。",
+        ],
+    )
+
+    intent = classify_graph_delta_intent(fact)
+
+    assert intent is not None
+    assert intent.delta_type is GraphDeltaType.UPDATE_EDGE
+    assert intent.relation_type is GraphRelationType.CONTROL
+    assert intent.source_node == "entity:new-controller"
+    assert intent.target_node == "ts_code:600000.SH"
+    assert intent.properties == {"change_type": "control_change"}
+
+
+def test_shareholder_ratio_intent_records_explicit_ratio_fields() -> None:
+    fact = _fact(
+        fact_type=FactType.SHAREHOLDER_CHANGE,
+        related_entity_ids=["entity:shareholder"],
+        fact_content={"shareholder_change_type": "decrease"},
+        quotes=[
+            "股东明德投资减持后持股比例降至5%。",
+            "本次权益变动后明德投资持股比例为5%。",
+        ],
+    )
+
+    delta = derive_graph_delta_candidates([fact], generated_at=GENERATED_AT)[0]
+
+    assert delta.relation_type is GraphRelationType.SHAREHOLDING
+    assert delta.properties["after_ratio"] == "5%"
+    assert delta.source_fact_ids == [fact.fact_id]
+    assert delta.source_reference == fact.source_reference
+    assert delta.evidence_spans == fact.evidence_spans
+
+
+def test_shareholder_change_without_ratio_does_not_produce_shareholding_delta() -> None:
+    fact = _fact(
+        fact_type=FactType.SHAREHOLDER_CHANGE,
+        related_entity_ids=["entity:shareholder"],
+        fact_content={"shareholder_change_type": "decrease"},
+        quotes=["股东明德投资减持公司股份。", "本次权益变动不会导致控制权变化。"],
+    )
+
+    assert classify_graph_delta_intent(fact) is None
+    assert derive_graph_delta_candidates([fact]) == []
+
+
+def test_major_contract_strong_action_produces_supply_contract_delta() -> None:
+    fact = _fact(
+        fact_type=FactType.MAJOR_CONTRACT,
+        related_entity_ids=["entity:huadong-energy"],
+        fact_content={"event": "major_contract"},
+        quotes=["公司与华东能源签订重大合同。", "双方合同金额为1000万元。"],
+    )
+
+    delta = derive_graph_delta_candidates([fact], generated_at=GENERATED_AT)[0]
+
+    assert delta.relation_type is GraphRelationType.SUPPLY_CONTRACT
+    assert delta.delta_type is GraphDeltaType.ADD_EDGE
+    assert delta.source_node == "ts_code:600000.SH"
+    assert delta.target_node == "entity:huadong-energy"
+    assert delta.confidence == fact.confidence
+
+
+def test_major_contract_cooperation_action_produces_cooperation_delta() -> None:
+    fact = _fact(
+        fact_type=FactType.MAJOR_CONTRACT,
+        related_entity_ids=["entity:research-partner"],
+        fact_content={"event": "major_contract"},
+        quotes=[
+            "公司与研究院签署战略合作协议。",
+            "双方将在新能源材料领域开展合作。",
+        ],
+    )
+
+    intent = classify_graph_delta_intent(fact)
+
+    assert intent is not None
+    assert intent.relation_type is GraphRelationType.COOPERATION
+
+
+def test_major_contract_ambiguous_wording_does_not_produce_graph_delta() -> None:
+    fact = _fact(
+        fact_type=FactType.MAJOR_CONTRACT,
+        related_entity_ids=["entity:potential-partner"],
+        fact_content={"event": "major_contract"},
+        quotes=[
+            "公司拟与潜在合作方签署战略合作意向。",
+            "双方目前仅签订框架协议，后续存在不确定性。",
+        ],
+    )
+
+    assert classify_graph_delta_intent(fact) is None
+    assert derive_graph_delta_candidates([fact]) == []
+
+
+def test_major_contract_requires_resolved_related_entity_and_two_evidence_spans() -> None:
+    unresolved = _fact(
+        fact_type=FactType.MAJOR_CONTRACT,
+        related_entity_ids=["unresolved:counterparty"],
+        fact_content={"event": "major_contract"},
+        quotes=["公司与华东能源签订重大合同。", "双方合同金额为1000万元。"],
+    )
+    single_span = _fact(
+        fact_type=FactType.MAJOR_CONTRACT,
+        related_entity_ids=["entity:huadong-energy"],
+        fact_content={"event": "major_contract"},
+        quotes=["公司与华东能源签订重大合同。"],
+    )
+
+    assert classify_graph_delta_intent(unresolved) is None
+    assert derive_graph_delta_candidates([unresolved]) == []
+    assert classify_graph_delta_intent(single_span) is not None
+    assert derive_graph_delta_candidates([single_span]) == []
+
+
+def test_low_confidence_fact_does_not_materialize_graph_delta() -> None:
+    fact = _fact(
+        fact_type=FactType.MAJOR_CONTRACT,
+        related_entity_ids=["entity:huadong-energy"],
+        fact_content={"event": "major_contract"},
+        confidence=0.89,
+        quotes=["公司与华东能源签订重大合同。", "双方合同金额为1000万元。"],
+    )
+
+    assert classify_graph_delta_intent(fact) is not None
+    assert derive_graph_delta_candidates([fact]) == []
+
+
+def test_duplicate_graph_delta_ids_are_deduped_in_input_order() -> None:
+    fact = _fact(
+        fact_type=FactType.MAJOR_CONTRACT,
+        related_entity_ids=["entity:huadong-energy"],
+        fact_content={"event": "major_contract"},
+        quotes=["公司与华东能源签订重大合同。", "双方合同金额为1000万元。"],
+    )
+
+    deltas = derive_graph_delta_candidates([fact, fact], generated_at=GENERATED_AT)
+
+    assert len(deltas) == 1
+    assert deltas[0].source_fact_ids == [fact.fact_id]
+
+
+def _fact(
+    *,
+    fact_type: FactType,
+    fact_content: dict[str, object],
+    quotes: list[str],
+    related_entity_ids: list[str] | None = None,
+    confidence: float = 0.93,
+) -> AnnouncementFactCandidate:
+    announcement_id = "ann-graph-rules"
+    return AnnouncementFactCandidate(
+        fact_id=f"fact:{announcement_id}:{fact_type.value}:1",
+        announcement_id=announcement_id,
+        fact_type=fact_type,
+        primary_entity_id="ts_code:600000.SH",
+        related_entity_ids=related_entity_ids or [],
+        fact_content=fact_content,
+        confidence=confidence,
+        source_reference=_source_reference(announcement_id),
+        evidence_spans=[
+            _span(quote, f"sec-{index}")
+            for index, quote in enumerate(quotes, start=1)
+        ],
+        extracted_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+    )
+
+
+def _source_reference(announcement_id: str) -> dict[str, str]:
+    return {
+        "announcement_id": announcement_id,
+        "official_url": f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf",
+        "source_exchange": "sse",
+        "attachment_type": "pdf",
+    }
+
+
+def _span(quote: str, section_id: str) -> EvidenceSpan:
+    return EvidenceSpan(
+        section_id=section_id,
+        start_offset=0,
+        end_offset=len(quote),
+        quote=quote,
+    )

--- a/tests/test_package_layout.py
+++ b/tests/test_package_layout.py
@@ -81,6 +81,14 @@ def test_subpackages_are_importable(subpackage: str) -> None:
             "SignalTimeHorizon",
             "derive_signal_candidates",
         }.issubset(set(module.__all__))
+    elif subpackage == "graph":
+        assert {
+            "AnnouncementGraphDeltaCandidate",
+            "GraphDeltaGuard",
+            "GraphDeltaType",
+            "GraphRelationType",
+            "derive_graph_delta_candidates",
+        }.issubset(set(module.__all__))
     else:
         assert module.__all__ == []
 


### PR DESCRIPTION
Closes #9

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/signals/classifier.py`, `tests/contracts/test_ex1_contract.py`, `tests/test_parse_docling_client.py`, `tests/test_runtime_sdk.py`


---
### 1. 背景与目标
项目文档 §11.5、§13.3 和 §21 阶段 2 要求 Ex-3 只在控股股东/实控人变更、明确持股比例变化、明确重大合同或合作关系建立/终止等强证据场景中少量产出。当前代码的可靠输入是 `subsystem_announcement.extract.candidates.AnnouncementFactCandidate`，其中已有 `fact_type`、`primary_entity_id`、`related_entity_ids`、`fact_content`、`source_reference` 和 `evidence_spans`；#8 会先补齐 Ex-2 与 Ex-1/Ex-2 mixed submit/pipeline 扩展点。当前仓库还没有 `src/subsystem_announcement/graph/` 的实际实现，本 issue 只在事实层已经明确、证据足够、实体双端可锚定时生成 `AnnouncementGraphDeltaCandidate`。默认策略必须保守：缺少强证据时宁可没有 Ex-3，也不能污染图谱候选。

### 2. 所属模块
Primary writable paths:
- `src/subsystem_announcement/graph/__init__.py`（不存在时创建，导出公开 API）
- `src/subsystem_announcement/graph/candidates.py`
- `src/subsystem_announcement/graph/guard.py`
- `src/subsystem_announcement/graph/rules.py`
- `src/subsystem_announcement/graph/deltas.py`
- `src/subsystem_announcement/runtime/pipeline.py`（仅在 #8 的 pipeline 扩展点后追加 Ex-3 generation）
- `src/subsystem_announcement/runtime/submit.py`（仅把 #8 的 mixed submit ex_type 白名单扩展到 `Ex-3`）
- `src/subsystem_announcement/runtime/trace.py`（仅在 trace/receipt 类型需要识别 `Ex-3` 时修改）
- `tests/test_graph_delta_candidates.py`
- `tests/test_graph_delta_guard.py`
- `tests/test_graph_delta_rules.py`
- `tests/test_graph_delta_pipeline.py`
- `tests/contracts/test_ex3_contract.py`

Adjacent read-only / integration paths:
- `src/subsystem_announcement/extract/candidates.py`：只读消费 `AnnouncementFactCandidate` 与 `FactType`，不扩展 Ex-1 schema
- `src/subsystem_announcement/extract/evidence.py`：只读消费 `EvidenceSpan`，不重新计算 parse offsets
- `src/subsystem_announcement/signals/`：只复用 #8 的 pipeline/submission 扩展，不修改 signal 规则
- `src/subsystem_announcement/extract/entity_anchor.py`：不调用 registry，不修改锚点策略

### 3. 实现范围
- 创建 graph package 并在 `graph/__init__.py` 导出 `AnnouncementGraphDeltaCandidate`、`GraphDeltaType`、`GraphRelationType`、`derive_graph_delta_candidates`、`GraphDeltaGuard`。
- 在 `graph/candidates.py` 定义 `AnnouncementGraphDeltaCandidate` pydantic 模型，字段包含 `ex_type: Literal["Ex-3"] = "Ex-3"`、`delta_id`、`announcement_id`、`delta_type`、`