### PR TITLE
feat(#26): [milestone-2 review] P0: Dependent Ex-2/Ex-3 candidates can submit without accepted Ex-1 facts

### DIFF
--- a/src/subsystem_announcement/runtime/pipeline.py
+++ b/src/subsystem_announcement/runtime/pipeline.py
@@ -44,9 +44,16 @@ from .submit import (
     CandidatePayload,
     SubmitBatchResult,
     SubmitIdempotencyStore,
+    candidate_id_for,
+    ex_type_for,
     submit_candidates,
 )
-from .trace import AnnouncementExtractionRun, RunTraceError, TraceStore
+from .trace import (
+    AnnouncementExtractionRun,
+    CandidateSubmitTrace,
+    RunTraceError,
+    TraceStore,
+)
 
 
 DiscoveryFunc = Callable[
@@ -117,12 +124,13 @@ class AnnouncementPipeline:
             facts = list(await self._call_extract(parsed_artifact))
             signals = list(await self._call_signals(facts))
             graph_deltas = list(await self._call_graph(facts))
-            candidates: list[CandidatePayload] = [*facts, *signals, *graph_deltas]
-            run.candidate_count = len(candidates)
+            downstream_candidates: list[CandidatePayload] = [*signals, *graph_deltas]
+            run.candidate_count = len(facts) + len(downstream_candidates)
 
-            if candidates:
-                submit_result = submit_candidates(
-                    candidates,
+            if run.candidate_count:
+                submit_result = _submit_candidate_phases(
+                    facts,
+                    downstream_candidates,
                     self._get_subsystem(),
                     idempotency_store=self._idempotency_store,
                 )
@@ -133,7 +141,10 @@ class AnnouncementPipeline:
                     failed=0,
                 )
             _apply_submit_result(run, submit_result)
-            run.status = _status_from_submit_result(submit_result, len(candidates))
+            run.status = _status_from_submit_result(
+                submit_result,
+                run.candidate_count,
+            )
         except Exception as exc:
             run.status = "failed"
             run.errors.append(
@@ -279,6 +290,114 @@ def _accepts_keyword(func: Callable[..., Any], name: str) -> bool:
         inspect.Parameter.KEYWORD_ONLY,
         inspect.Parameter.POSITIONAL_OR_KEYWORD,
     }
+
+
+def _submit_candidate_phases(
+    facts: Sequence[AnnouncementFactCandidate],
+    downstream_candidates: Sequence[CandidatePayload],
+    subsystem: AnnouncementSubsystem,
+    *,
+    idempotency_store: SubmitIdempotencyStore,
+) -> SubmitBatchResult:
+    """Submit Ex-1 first, then gate Ex-2/Ex-3 on accepted Ex-1 ids."""
+
+    results: list[SubmitBatchResult] = []
+    if facts:
+        fact_result = submit_candidates(
+            facts,
+            subsystem,
+            idempotency_store=idempotency_store,
+        )
+        results.append(fact_result)
+    else:
+        fact_result = SubmitBatchResult(submitted=0, skipped_duplicates=0, failed=0)
+
+    accepted_fact_ids = _accepted_fact_ids(fact_result)
+    for candidate in downstream_candidates:
+        missing_fact_ids = _missing_source_fact_ids(candidate, accepted_fact_ids)
+        if missing_fact_ids:
+            results.append(_failed_dependency_result(candidate, missing_fact_ids))
+            continue
+        results.append(
+            submit_candidates(
+                [candidate],
+                subsystem,
+                idempotency_store=idempotency_store,
+            )
+        )
+
+    return _merge_submit_results(results)
+
+
+def _accepted_fact_ids(result: SubmitBatchResult) -> set[str]:
+    return {
+        trace.candidate_id or trace.fact_id
+        for trace in result.traces
+        if trace.ex_type == "Ex-1" and trace.status in {"accepted", "duplicate"}
+    }
+
+
+def _missing_source_fact_ids(
+    candidate: CandidatePayload,
+    accepted_fact_ids: set[str],
+) -> tuple[str, ...]:
+    source_fact_ids = getattr(candidate, "source_fact_ids", ())
+    return tuple(
+        fact_id
+        for fact_id in source_fact_ids
+        if fact_id not in accepted_fact_ids
+    )
+
+
+def _failed_dependency_result(
+    candidate: CandidatePayload,
+    missing_fact_ids: Sequence[str],
+) -> SubmitBatchResult:
+    candidate_id = candidate_id_for(candidate)
+    ex_type = ex_type_for(candidate)
+    trace = CandidateSubmitTrace(
+        fact_id=candidate_id,
+        candidate_id=candidate_id,
+        ex_type=ex_type,
+        status="failed",
+        attempts=0,
+        errors=[
+            f"skipped {ex_type} candidate because source_fact_ids are not "
+            f"accepted Ex-1 facts: {', '.join(missing_fact_ids)}"
+        ],
+    )
+    return SubmitBatchResult(
+        submitted=0,
+        skipped_duplicates=0,
+        failed=1,
+        failures=[trace],
+        traces=[trace],
+    )
+
+
+def _merge_submit_results(
+    results: Sequence[SubmitBatchResult],
+) -> SubmitBatchResult:
+    return SubmitBatchResult(
+        submitted=sum(result.submitted for result in results),
+        skipped_duplicates=sum(result.skipped_duplicates for result in results),
+        failed=sum(result.failed for result in results),
+        receipts=[
+            receipt
+            for result in results
+            for receipt in result.receipts
+        ],
+        failures=[
+            failure
+            for result in results
+            for failure in result.failures
+        ],
+        traces=[
+            trace
+            for result in results
+            for trace in result.traces
+        ],
+    )
 
 
 def _apply_submit_result(

--- a/src/subsystem_announcement/runtime/submit.py
+++ b/src/subsystem_announcement/runtime/submit.py
@@ -246,12 +246,15 @@ def submit_candidates(
     idempotency_store: SubmitIdempotencyStore | None = None,
     max_attempts: int = 3,
 ) -> SubmitBatchResult:
-    """Submit Ex candidates in order with retry and idempotency."""
+    """Submit Ex candidates with retry, idempotency, and same-batch Ex gating."""
 
     if max_attempts < 1:
         raise ValueError("max_attempts must be at least 1")
 
     store = idempotency_store or SubmitIdempotencyStore()
+    fact_candidates, downstream_candidates = _partition_candidate_phases(candidates)
+    batch_fact_ids = _batch_fact_ids(fact_candidates)
+    accepted_fact_ids: set[str] = set()
     submitted = 0
     skipped_duplicates = 0
     failed = 0
@@ -259,7 +262,9 @@ def submit_candidates(
     failures: list[CandidateSubmitTrace] = []
     traces: list[CandidateSubmitTrace] = []
 
-    for candidate in candidates:
+    def process_candidate(candidate: CandidatePayload) -> CandidateSubmitTrace:
+        nonlocal failed, skipped_duplicates, submitted
+
         try:
             payload = _validated_payload(candidate)
             payload_hash = _payload_hash(payload)
@@ -279,7 +284,23 @@ def submit_candidates(
             )
             failures.append(trace)
             traces.append(trace)
-            continue
+            return trace
+
+        missing_fact_ids = _missing_unaccepted_batch_fact_ids(
+            payload,
+            accepted_fact_ids=accepted_fact_ids,
+            batch_fact_ids=batch_fact_ids,
+        )
+        if ex_type in {"Ex-2", "Ex-3"} and missing_fact_ids:
+            failed += 1
+            trace = _dependency_failure_trace(
+                candidate_id,
+                ex_type,
+                missing_fact_ids,
+            )
+            failures.append(trace)
+            traces.append(trace)
+            return trace
 
         with store.locked():
             previous_receipt = store._seen_loaded(ex_type, candidate_id, payload_hash)
@@ -296,7 +317,7 @@ def submit_candidates(
                 )
                 receipts.append(previous_receipt)
                 traces.append(trace)
-                continue
+                return trace
 
             receipt, trace = _submit_one(
                 candidate_id,
@@ -310,7 +331,7 @@ def submit_candidates(
             if receipt is None:
                 failed += 1
                 failures.append(trace)
-                continue
+                return trace
 
             submitted += 1
             try:
@@ -334,6 +355,15 @@ def submit_candidates(
                 ] = receipt
                 traces[-1] = trace
             receipts.append(receipt)
+            return trace
+
+    for candidate in fact_candidates:
+        trace = process_candidate(candidate)
+        if trace.ex_type == "Ex-1" and trace.status in {"accepted", "duplicate"}:
+            accepted_fact_ids.add(trace.candidate_id or trace.fact_id)
+
+    for candidate in downstream_candidates:
+        process_candidate(candidate)
 
     return SubmitBatchResult(
         submitted=submitted,
@@ -342,6 +372,69 @@ def submit_candidates(
         receipts=receipts,
         failures=failures,
         traces=traces,
+    )
+
+
+def _partition_candidate_phases(
+    candidates: Sequence[CandidatePayload],
+) -> tuple[list[CandidatePayload], list[CandidatePayload]]:
+    fact_candidates: list[CandidatePayload] = []
+    downstream_candidates: list[CandidatePayload] = []
+    for candidate in candidates:
+        if _best_effort_ex_type(candidate) == "Ex-1":
+            fact_candidates.append(candidate)
+        else:
+            downstream_candidates.append(candidate)
+    return fact_candidates, downstream_candidates
+
+
+def _batch_fact_ids(candidates: Sequence[CandidatePayload]) -> set[str]:
+    fact_ids: set[str] = set()
+    for candidate in candidates:
+        fact_id = getattr(candidate, "fact_id", None)
+        if isinstance(fact_id, str) and fact_id:
+            fact_ids.add(fact_id)
+    return fact_ids
+
+
+def _missing_unaccepted_batch_fact_ids(
+    payload: Mapping[str, Any],
+    *,
+    accepted_fact_ids: set[str],
+    batch_fact_ids: set[str],
+) -> tuple[str, ...]:
+    source_fact_ids = payload.get("source_fact_ids")
+    if not isinstance(source_fact_ids, Sequence) or isinstance(
+        source_fact_ids,
+        str | bytes | bytearray,
+    ):
+        return ()
+    return tuple(
+        fact_id
+        for fact_id in source_fact_ids
+        if (
+            isinstance(fact_id, str)
+            and fact_id in batch_fact_ids
+            and fact_id not in accepted_fact_ids
+        )
+    )
+
+
+def _dependency_failure_trace(
+    candidate_id: str,
+    ex_type: ExType,
+    missing_fact_ids: Sequence[str],
+) -> CandidateSubmitTrace:
+    return CandidateSubmitTrace(
+        fact_id=candidate_id,
+        candidate_id=candidate_id,
+        ex_type=ex_type,
+        status="failed",
+        attempts=0,
+        errors=[
+            f"skipped {ex_type} candidate because source_fact_ids are not "
+            f"accepted Ex-1 facts in this submission: {', '.join(missing_fact_ids)}"
+        ],
     )
 
 

--- a/tests/test_graph_delta_pipeline.py
+++ b/tests/test_graph_delta_pipeline.py
@@ -38,13 +38,36 @@ class RecordingSubsystem:
         }
 
 
+class RejectFactsAcceptDependentsSubsystem:
+    def __init__(self) -> None:
+        self.submissions: list[dict[str, Any]] = []
+
+    def submit(self, candidate: dict[str, Any]) -> dict[str, Any]:
+        self.submissions.append(candidate)
+        if candidate["ex_type"] == "Ex-1":
+            return {
+                "accepted": False,
+                "receipt_id": f"rejected-{len(self.submissions)}",
+                "warnings": (),
+                "errors": ("fact rejected",),
+            }
+        return {
+            "accepted": True,
+            "receipt_id": f"accepted-{len(self.submissions)}",
+            "warnings": (),
+            "errors": (),
+        }
+
+
 def test_pipeline_generates_graph_after_signals_and_submits_ex3_last(
     tmp_path: Path,
 ) -> None:
     subsystem = RecordingSubsystem()
     calls: list[str] = []
 
-    def extract_func(artifact: ParsedAnnouncementArtifact) -> list[AnnouncementFactCandidate]:
+    def extract_func(
+        artifact: ParsedAnnouncementArtifact,
+    ) -> list[AnnouncementFactCandidate]:
         calls.append("extract")
         return [_major_contract_fact(artifact.announcement_id)]
 
@@ -94,6 +117,64 @@ def test_pipeline_generates_graph_after_signals_and_submits_ex3_last(
         "Ex-2",
         "Ex-3",
     ]
+
+
+def test_pipeline_skips_ex2_ex3_when_source_ex1_is_rejected(
+    tmp_path: Path,
+) -> None:
+    subsystem = RejectFactsAcceptDependentsSubsystem()
+
+    def extract_func(
+        artifact: ParsedAnnouncementArtifact,
+    ) -> list[AnnouncementFactCandidate]:
+        return [_major_contract_fact(artifact.announcement_id)]
+
+    def signal_func(facts: list[AnnouncementFactCandidate]):
+        return derive_signal_candidates(facts, generated_at=GENERATED_AT)
+
+    def graph_func(facts: list[AnnouncementFactCandidate]):
+        return derive_graph_delta_candidates(facts, generated_at=GENERATED_AT)
+
+    pipeline = AnnouncementPipeline(
+        _config(tmp_path),
+        subsystem=subsystem,  # type: ignore[arg-type]
+        discovery_func=_fake_discovery,
+        parse_func=_fake_parse,
+        extract_func=extract_func,
+        signal_func=signal_func,
+        graph_func=graph_func,
+    )
+
+    run = asyncio.run(pipeline.process_envelope(_envelope()))
+
+    assert run.status == "failed"
+    assert run.candidate_count == 3
+    assert run.submit_success_count == 0
+    assert run.submit_failure_count == 3
+    assert [payload["ex_type"] for payload in subsystem.submissions] == [
+        "Ex-1",
+        "Ex-1",
+        "Ex-1",
+    ]
+    assert [trace.ex_type for trace in run.candidate_traces] == [
+        "Ex-1",
+        "Ex-2",
+        "Ex-3",
+    ]
+    assert [trace.status for trace in run.candidate_traces] == [
+        "failed",
+        "failed",
+        "failed",
+    ]
+    assert run.candidate_traces[0].attempts == 3
+    assert run.candidate_traces[1].attempts == 0
+    assert run.candidate_traces[2].attempts == 0
+    assert "source_fact_ids are not accepted Ex-1 facts" in (
+        run.candidate_traces[1].errors[0]
+    )
+    assert "source_fact_ids are not accepted Ex-1 facts" in (
+        run.candidate_traces[2].errors[0]
+    )
 
 
 def test_ex3_idempotency_is_isolated_from_ex1_and_ex2_candidate_ids() -> None:

--- a/tests/test_runtime_submit.py
+++ b/tests/test_runtime_submit.py
@@ -5,7 +5,13 @@ import threading
 from datetime import datetime, timezone
 from typing import Any
 
-from subsystem_announcement.extract import AnnouncementFactCandidate, extract_fact_candidates
+from subsystem_announcement.extract import (
+    AnnouncementFactCandidate,
+    EvidenceSpan,
+    FactType,
+    extract_fact_candidates,
+)
+from subsystem_announcement.graph import derive_graph_delta_candidates
 from subsystem_announcement.runtime import submit as submit_module
 from subsystem_announcement.runtime.submit import (
     SubmitIdempotencyStore,
@@ -228,6 +234,44 @@ def test_submit_candidates_records_rejected_result_as_failure() -> None:
     assert "contract still rejected" in result.failures[0].errors[-1]
 
 
+def test_submit_candidates_skips_same_batch_dependents_when_ex1_rejected() -> None:
+    fact = _graph_fact("ann-direct-submit-rejected-dependency")
+    generated_at = datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc)
+    signal = derive_signal_candidates([fact], generated_at=generated_at)[0]
+    delta = derive_graph_delta_candidates([fact], generated_at=generated_at)[0]
+    subsystem = RecordingSubsystem(
+        [
+            _rejected("receipt-rejected", "fact rejected"),
+            _accepted("signal-should-not-submit"),
+            _accepted("delta-should-not-submit"),
+        ]
+    )
+
+    result = submit_candidates(
+        [fact, signal, delta],
+        subsystem,  # type: ignore[arg-type]
+        max_attempts=1,
+    )
+
+    assert result.submitted == 0
+    assert result.failed == 3
+    assert [payload["ex_type"] for payload in subsystem.submissions] == ["Ex-1"]
+    assert [trace.ex_type for trace in result.traces] == ["Ex-1", "Ex-2", "Ex-3"]
+    assert [trace.status for trace in result.traces] == [
+        "failed",
+        "failed",
+        "failed",
+    ]
+    assert result.traces[1].attempts == 0
+    assert result.traces[2].attempts == 0
+    assert "source_fact_ids are not accepted Ex-1 facts" in (
+        result.traces[1].errors[0]
+    )
+    assert "source_fact_ids are not accepted Ex-1 facts" in (
+        result.traces[2].errors[0]
+    )
+
+
 def test_submit_candidates_rejects_invalid_payload_before_sdk_call() -> None:
     fact = _fact("ann-invalid")
     invalid = fact.model_copy(update={"evidence_spans": []})
@@ -295,6 +339,40 @@ def _fact(announcement_id: str) -> AnnouncementFactCandidate:
         announcement_id=announcement_id,
     )
     return extract_fact_candidates(artifact)[0]
+
+
+def _graph_fact(announcement_id: str) -> AnnouncementFactCandidate:
+    return AnnouncementFactCandidate(
+        fact_id=f"fact:{announcement_id}:major_contract:1",
+        announcement_id=announcement_id,
+        fact_type=FactType.MAJOR_CONTRACT,
+        primary_entity_id="ts_code:600000.SH",
+        related_entity_ids=["entity:huadong-energy"],
+        fact_content={"event": "major_contract"},
+        confidence=0.93,
+        source_reference={
+            "announcement_id": announcement_id,
+            "official_url": (
+                f"https://static.sse.com.cn/disclosure/{announcement_id}.pdf"
+            ),
+            "source_exchange": "sse",
+            "attachment_type": "pdf",
+        },
+        evidence_spans=[
+            _span("公司与华东能源签订重大合同。", "sec-1"),
+            _span("双方合同金额为1000万元。", "sec-2"),
+        ],
+        extracted_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+    )
+
+
+def _span(quote: str, section_id: str) -> EvidenceSpan:
+    return EvidenceSpan(
+        section_id=section_id,
+        start_offset=0,
+        end_offset=len(quote),
+        quote=quote,
+    )
 
 
 def _accepted(receipt_id: str) -> dict[str, Any]:


### PR DESCRIPTION
Closes #26

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/graph/candidates.py`, `src/subsystem_announcement/graph/deltas.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/signals/classifier.py`, `tests/contracts/test_ex1_contract.py`, `tests/contracts/test_ex2_contract.py`, `tests/test_parse_docling_client.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The pipeline derives facts, signals, and graph deltas up front, concatenates them into one ordered batch, and submit_candidates continues processing later candidates even if an earlier Ex-1 candidate fails validation or SDK submission. That means an Ex-2 signal or Ex-3 graph delta can be accepted while its source_fact_ids reference a fact that was rejected in the same run. This breaks the milestone data contract that Ex-2/Ex-3 are downstream of stable Ex-1 facts and can leave downstream systems with orphaned references.

## 实现范围
- 修改文件: `src/subsystem_announcement/runtime/pipeline.py`
- Submit Ex-1 facts as a first phase, collect accepted or duplicate fact_ids, and only then submit Ex-2/Ex-3 candidates whose source_fact_ids are all present in that accepted set. Add a regression test where the SDK rejects the Ex-1 payload but would accept the derived Ex-2/Ex-3 payload, and assert the dependent candidates are skipped or marked failed.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/subsystem-announcement/.venv/bin/python -m pytest
```
