### PR TITLE
feat(#10): 公告域 chunk / index 与 retrieval artifact

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "docling==2.15.1",
+    "llama-index-core==0.10.0",
+    "llama-index-node-parser-docling==0.1.0",
     "pydantic>=2.6",
     "typer>=0.12",
     "structlog>=24.1",

--- a/src/subsystem_announcement/index/__init__.py
+++ b/src/subsystem_announcement/index/__init__.py
@@ -1,1 +1,26 @@
-__all__: list[str] = []
+"""Announcement retrieval index public API."""
+
+from __future__ import annotations
+
+from .chunker import chunk_parsed_artifact, make_chunk_id
+from .retrieval_artifact import (
+    AnnouncementChunk,
+    AnnouncementRetrievalArtifact,
+    AnnouncementRetrievalHit,
+    build_retrieval_artifact,
+    load_retrieval_artifact,
+    write_retrieval_artifact,
+)
+from .sample_query import query
+
+__all__ = [
+    "AnnouncementChunk",
+    "AnnouncementRetrievalArtifact",
+    "AnnouncementRetrievalHit",
+    "build_retrieval_artifact",
+    "chunk_parsed_artifact",
+    "load_retrieval_artifact",
+    "make_chunk_id",
+    "query",
+    "write_retrieval_artifact",
+]

--- a/src/subsystem_announcement/index/__main__.py
+++ b/src/subsystem_announcement/index/__main__.py
@@ -1,0 +1,122 @@
+"""Offline CLI for announcement retrieval indexes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+from subsystem_announcement.config import AnnouncementConfig, load_config
+from subsystem_announcement.parse.artifact import load_parsed_artifact
+
+from .retrieval_artifact import (
+    build_retrieval_artifact,
+    load_retrieval_artifact,
+    write_retrieval_artifact,
+)
+from .sample_query import query
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the offline index CLI."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    try:
+        if args.command == "build":
+            return _build_command(args)
+        if args.command == "query":
+            return _query_command(args)
+    except Exception as exc:
+        print(f"index {args.command} failed: {exc}", file=sys.stderr)
+        return 1
+    return 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m subsystem_announcement.index",
+        description="Build and query offline announcement retrieval indexes.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    build_parser = subparsers.add_parser("build", help="Build a retrieval index.")
+    build_parser.add_argument("--parsed-artifact", type=Path, required=True)
+    build_parser.add_argument("--output", type=Path, required=True)
+    build_parser.add_argument("--config", type=Path, default=None)
+
+    query_parser = subparsers.add_parser("query", help="Query a retrieval artifact.")
+    query_parser.add_argument("--artifact", type=Path, required=True)
+    query_parser.add_argument("--text", required=True)
+    query_parser.add_argument("--top-k", type=int, default=5)
+    return parser
+
+
+def _build_command(args: argparse.Namespace) -> int:
+    config = _load_cli_config(args.config)
+    parsed_artifact = load_parsed_artifact(args.parsed_artifact)
+    artifact = build_retrieval_artifact(
+        parsed_artifact,
+        config=config,
+        parsed_artifact_path=args.parsed_artifact,
+        output_root=args.output,
+    )
+    artifact_path = write_retrieval_artifact(artifact, args.output)
+    print(f"ok artifact={artifact_path}")
+    return 0
+
+
+def _query_command(args: argparse.Namespace) -> int:
+    artifact = load_retrieval_artifact(args.artifact)
+    hits = query(args.text, artifact, top_k=args.top_k)
+    print(
+        json.dumps(
+            [hit.model_dump(mode="json") for hit in hits],
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def _load_cli_config(config_path: Path | None) -> AnnouncementConfig:
+    config = load_config(config_path)
+    if config.llama_index_version != "not-configured":
+        return config
+    pin = _pyproject_llama_index_pin(Path.cwd())
+    if pin is None:
+        return config
+    return config.model_copy(update={"llama_index_version": pin})
+
+
+def _pyproject_llama_index_pin(cwd: Path) -> str | None:
+    for root in [cwd, *cwd.parents]:
+        pyproject_path = root / "pyproject.toml"
+        if not pyproject_path.exists():
+            continue
+        try:
+            pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            return None
+        dependencies = pyproject.get("project", {}).get("dependencies", [])
+        exact_pins = [
+            dependency
+            for dependency in dependencies
+            if isinstance(dependency, str)
+            and (
+                dependency.startswith("llama-index-core==")
+                or dependency.startswith("llama-index==")
+            )
+        ]
+        return exact_pins[0] if exact_pins else None
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/subsystem_announcement/index/chunker.py
+++ b/src/subsystem_announcement/index/chunker.py
@@ -1,0 +1,354 @@
+"""Chunk parsed announcement artifacts for offline retrieval."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterator, Mapping, Sequence
+from datetime import datetime
+from enum import Enum
+from typing import Any, Literal
+
+from subsystem_announcement.extract.evidence import render_table_text
+from subsystem_announcement.parse.artifact import (
+    AnnouncementSection,
+    AnnouncementTable,
+    ParsedAnnouncementArtifact,
+)
+
+from .retrieval_artifact import AnnouncementChunk
+
+
+ChunkType = Literal["section", "table", "clause"]
+
+
+def chunk_parsed_artifact(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    *,
+    max_chars: int = 1800,
+    overlap_chars: int = 120,
+) -> list[AnnouncementChunk]:
+    """Build stable section/table retrieval chunks from a parse artifact."""
+
+    if max_chars <= 0:
+        raise ValueError("max_chars must be greater than 0")
+    if overlap_chars < 0:
+        raise ValueError("overlap_chars must be greater than or equal to 0")
+    if overlap_chars >= max_chars:
+        raise ValueError("overlap_chars must be smaller than max_chars")
+
+    source_reference = build_source_reference(parsed_artifact)
+    sections_by_id = {section.section_id: section for section in parsed_artifact.sections}
+    chunks: list[AnnouncementChunk] = []
+
+    for section in parsed_artifact.sections:
+        chunks.extend(
+            _chunk_section(
+                parsed_artifact,
+                section,
+                sections_by_id,
+                source_reference=source_reference,
+                max_chars=max_chars,
+                overlap_chars=overlap_chars,
+            )
+        )
+
+    for table in parsed_artifact.tables:
+        chunks.extend(
+            _chunk_table(
+                parsed_artifact,
+                table,
+                sections_by_id,
+                source_reference=source_reference,
+                max_chars=max_chars,
+                overlap_chars=overlap_chars,
+            )
+        )
+
+    return chunks
+
+
+def make_chunk_id(
+    announcement_id: str,
+    section_id: str,
+    chunk_type: ChunkType,
+    start_offset: int,
+    end_offset: int,
+    text: str,
+) -> str:
+    """Generate a deterministic chunk id for replay and index rebuilds."""
+
+    payload = {
+        "announcement_id": announcement_id,
+        "section_id": section_id,
+        "chunk_type": chunk_type,
+        "start_offset": start_offset,
+        "end_offset": end_offset,
+        "text": text,
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            _stable_jsonable(payload),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    return f"chunk:{announcement_id}:{section_id}:{chunk_type}:{digest}"
+
+
+def build_source_reference(
+    parsed_artifact: ParsedAnnouncementArtifact,
+) -> dict[str, Any]:
+    """Build official-source provenance for retrieval chunks."""
+
+    source_document = parsed_artifact.source_document
+    official_url = str(source_document.official_url).strip()
+    if not official_url:
+        raise ValueError("official source reference is required")
+
+    source_reference: dict[str, Any] = {
+        "announcement_id": parsed_artifact.announcement_id,
+        "official_url": official_url,
+        "source_exchange": source_document.source_exchange,
+        "attachment_type": source_document.attachment_type,
+        "content_hash": parsed_artifact.content_hash,
+        "parser_version": parsed_artifact.parser_version,
+    }
+    if source_document.ts_code is not None:
+        source_reference["ts_code"] = source_document.ts_code
+    if source_document.title is not None:
+        source_reference["title"] = source_document.title
+    if source_document.publish_time is not None:
+        source_reference["publish_time"] = source_document.publish_time.isoformat()
+    return source_reference
+
+
+def _chunk_section(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    section: AnnouncementSection,
+    sections_by_id: Mapping[str, AnnouncementSection],
+    *,
+    source_reference: Mapping[str, Any],
+    max_chars: int,
+    overlap_chars: int,
+) -> list[AnnouncementChunk]:
+    title_path = _title_path_for_section(parsed_artifact, section, sections_by_id)
+    if len(section.text) <= max_chars:
+        return [
+            _make_chunk(
+                parsed_artifact.announcement_id,
+                chunk_type="section",
+                section_id=section.section_id,
+                table_ref=None,
+                text=section.text,
+                start_offset=section.start_offset,
+                end_offset=section.end_offset,
+                title_path=title_path,
+                source_reference=source_reference,
+            )
+        ]
+
+    chunks: list[AnnouncementChunk] = []
+    for local_start, local_end in _split_text_ranges(
+        section.text,
+        max_chars=max_chars,
+        overlap_chars=overlap_chars,
+    ):
+        text = section.text[local_start:local_end]
+        chunks.append(
+            _make_chunk(
+                parsed_artifact.announcement_id,
+                chunk_type="clause",
+                section_id=section.section_id,
+                table_ref=None,
+                text=text,
+                start_offset=section.start_offset + local_start,
+                end_offset=section.start_offset + local_end,
+                title_path=title_path,
+                source_reference=source_reference,
+            )
+        )
+    return chunks
+
+
+def _chunk_table(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    table: AnnouncementTable,
+    sections_by_id: Mapping[str, AnnouncementSection],
+    *,
+    source_reference: Mapping[str, Any],
+    max_chars: int,
+    overlap_chars: int,
+) -> list[AnnouncementChunk]:
+    text = render_table_text(table)
+    if not text.strip():
+        return []
+
+    section = sections_by_id.get(table.section_id)
+    title_path = (
+        _title_path_for_section(parsed_artifact, section, sections_by_id)
+        if section is not None
+        else list(parsed_artifact.title_hierarchy)
+    )
+    if table.caption and table.caption not in title_path:
+        title_path = [*title_path, table.caption]
+
+    if len(text) <= max_chars:
+        return [
+            _make_chunk(
+                parsed_artifact.announcement_id,
+                chunk_type="table",
+                section_id=table.section_id,
+                table_ref=table.table_id,
+                text=text,
+                start_offset=table.start_offset,
+                end_offset=table.end_offset,
+                title_path=title_path,
+                source_reference=source_reference,
+            )
+        ]
+
+    chunks: list[AnnouncementChunk] = []
+    for local_start, local_end in _split_text_ranges(
+        text,
+        max_chars=max_chars,
+        overlap_chars=overlap_chars,
+    ):
+        chunks.append(
+            _make_chunk(
+                parsed_artifact.announcement_id,
+                chunk_type="table",
+                section_id=table.section_id,
+                table_ref=table.table_id,
+                text=text[local_start:local_end],
+                start_offset=table.start_offset + local_start,
+                end_offset=table.start_offset + local_end,
+                title_path=title_path,
+                source_reference=source_reference,
+            )
+        )
+    return chunks
+
+
+def _make_chunk(
+    announcement_id: str,
+    *,
+    chunk_type: ChunkType,
+    section_id: str,
+    table_ref: str | None,
+    text: str,
+    start_offset: int,
+    end_offset: int,
+    title_path: Sequence[str],
+    source_reference: Mapping[str, Any],
+) -> AnnouncementChunk:
+    chunk_id = make_chunk_id(
+        announcement_id,
+        section_id,
+        chunk_type,
+        start_offset,
+        end_offset,
+        text,
+    )
+    return AnnouncementChunk(
+        chunk_id=chunk_id,
+        announcement_id=announcement_id,
+        chunk_type=chunk_type,
+        section_id=section_id,
+        table_ref=table_ref,
+        text=text,
+        start_offset=start_offset,
+        end_offset=end_offset,
+        title_path=list(title_path),
+        source_reference=dict(source_reference),
+    )
+
+
+def _split_text_ranges(
+    text: str,
+    *,
+    max_chars: int,
+    overlap_chars: int,
+) -> Iterator[tuple[int, int]]:
+    start = 0
+    text_length = len(text)
+    while start < text_length:
+        end = min(text_length, start + max_chars)
+        if end < text_length:
+            end = _choose_split_end(text, start, end, max_chars=max_chars)
+        trimmed_start, trimmed_end = _trim_range(text, start, end)
+        if trimmed_end > trimmed_start:
+            yield trimmed_start, trimmed_end
+        if end >= text_length:
+            break
+        next_start = max(0, end - overlap_chars)
+        if next_start <= start:
+            next_start = end
+        start = next_start
+
+
+def _choose_split_end(text: str, start: int, end: int, *, max_chars: int) -> int:
+    minimum = start + max(1, max_chars // 2)
+    candidates = [
+        text.rfind(marker, minimum, end)
+        for marker in ("。", "！", "？", "\n", "；", ";", " ")
+    ]
+    split_at = max(candidates)
+    if split_at == -1:
+        return end
+    return split_at + 1
+
+
+def _trim_range(text: str, start: int, end: int) -> tuple[int, int]:
+    while start < end and text[start].isspace():
+        start += 1
+    while end > start and text[end - 1].isspace():
+        end -= 1
+    return start, end
+
+
+def _title_path_for_section(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    section: AnnouncementSection,
+    sections_by_id: Mapping[str, AnnouncementSection],
+) -> list[str]:
+    titles = [title for title in parsed_artifact.title_hierarchy if title.strip()]
+    ancestors: list[AnnouncementSection] = []
+    current = section
+    seen = {current.section_id}
+    while current.parent_id and current.parent_id in sections_by_id:
+        parent = sections_by_id[current.parent_id]
+        if parent.section_id in seen:
+            break
+        ancestors.append(parent)
+        seen.add(parent.section_id)
+        current = parent
+
+    for ancestor in reversed(ancestors):
+        _append_title(titles, ancestor.title)
+    _append_title(titles, section.title)
+    return titles
+
+
+def _append_title(titles: list[str], title: str | None) -> None:
+    if title is None:
+        return
+    stripped = title.strip()
+    if stripped and (not titles or titles[-1] != stripped):
+        titles.append(stripped)
+
+
+def _stable_jsonable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _stable_jsonable(item)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_stable_jsonable(item) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    return value

--- a/src/subsystem_announcement/index/retrieval_artifact.py
+++ b/src/subsystem_announcement/index/retrieval_artifact.py
@@ -119,15 +119,19 @@ def build_retrieval_artifact(
     from .chunker import chunk_parsed_artifact
     from .vector_store import build_vector_index
 
-    root = (
-        Path(output_root)
-        if output_root is not None
-        else Path(config.artifact_root) / "index" / parsed_artifact.announcement_id
-    )
+    if output_root is None:
+        root, vector_store_dir = _prepare_default_output_paths(
+            config,
+            parsed_artifact.announcement_id,
+        )
+    else:
+        root = Path(output_root)
+        vector_store_dir = root / "vector_store"
+
     chunks = chunk_parsed_artifact(parsed_artifact)
     vector_ref = build_vector_index(
         chunks,
-        persist_dir=root / "vector_store",
+        persist_dir=vector_store_dir,
         config=config,
     )
     return AnnouncementRetrievalArtifact(
@@ -170,4 +174,100 @@ def load_retrieval_artifact(path: Path) -> AnnouncementRetrievalArtifact:
     except (OSError, ValueError) as exc:
         raise RuntimeError(
             f"Unable to load retrieval artifact: path={artifact_path}"
+        ) from exc
+
+
+def _prepare_default_output_paths(
+    config: AnnouncementConfig,
+    announcement_id: str,
+) -> tuple[Path, Path]:
+    safe_announcement_id = _safe_path_component(
+        announcement_id,
+        field_name="announcement_id",
+    )
+    index_root = Path(config.artifact_root) / "index"
+    output_root = index_root / safe_announcement_id
+    output_root, resolved_index_root = _prepare_directory_under_root(
+        index_root,
+        output_root,
+        description="retrieval announcement directory",
+        announcement_id=safe_announcement_id,
+    )
+    vector_store_dir = output_root / "vector_store"
+    vector_store_dir, _ = _prepare_directory_under_root(
+        index_root,
+        vector_store_dir,
+        description="retrieval vector store directory",
+        announcement_id=safe_announcement_id,
+        resolved_root=resolved_index_root,
+    )
+    return output_root, vector_store_dir
+
+
+def _safe_path_component(value: str, *, field_name: str) -> str:
+    if (
+        not isinstance(value, str)
+        or value in {"", ".", ".."}
+        or "/" in value
+        or "\\" in value
+        or "\x00" in value
+        or Path(value).is_absolute()
+    ):
+        raise ValueError(f"Unsafe {field_name} for retrieval index path: {value!r}")
+    return value
+
+
+def _prepare_directory_under_root(
+    root: Path,
+    path: Path,
+    *,
+    description: str,
+    announcement_id: str,
+    resolved_root: Path | None = None,
+) -> tuple[Path, Path]:
+    if root.is_symlink():
+        raise ValueError(
+            "Retrieval index root is a symlink: "
+            f"announcement_id={announcement_id} path={root}"
+        )
+    root.mkdir(parents=True, exist_ok=True)
+    if root.is_symlink():
+        raise ValueError(
+            "Retrieval index root is a symlink: "
+            f"announcement_id={announcement_id} path={root}"
+        )
+    if not root.is_dir():
+        raise ValueError(
+            "Retrieval index root is not a directory: "
+            f"announcement_id={announcement_id} path={root}"
+        )
+
+    resolved_root = resolved_root or root.resolve()
+    if path.is_symlink():
+        raise ValueError(
+            f"{description.title()} is a symlink: "
+            f"announcement_id={announcement_id} path={path}"
+        )
+    path.mkdir(exist_ok=True)
+    if path.is_symlink():
+        raise ValueError(
+            f"{description.title()} is a symlink: "
+            f"announcement_id={announcement_id} path={path}"
+        )
+    if not path.is_dir():
+        raise ValueError(
+            f"{description.title()} is not a directory: "
+            f"announcement_id={announcement_id} path={path}"
+        )
+    _ensure_under_resolved_root(path, resolved_root)
+    return path, resolved_root
+
+
+def _ensure_under_resolved_root(path: Path, resolved_root: Path) -> None:
+    try:
+        path.resolve().relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(
+            "Retrieval index path escaped retrieval index root: "
+            f"path={path} root={resolved_root}"
         ) from exc

--- a/src/subsystem_announcement/index/retrieval_artifact.py
+++ b/src/subsystem_announcement/index/retrieval_artifact.py
@@ -1,0 +1,173 @@
+"""Retrieval artifact models and persistence helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
+
+
+class AnnouncementChunk(BaseModel):
+    """One searchable retrieval unit derived from a parsed announcement."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    chunk_id: str = Field(min_length=1)
+    announcement_id: str = Field(min_length=1)
+    chunk_type: Literal["section", "table", "clause"]
+    section_id: str = Field(min_length=1)
+    table_ref: str | None = None
+    text: str = Field(min_length=1)
+    start_offset: int = Field(ge=0)
+    end_offset: int = Field(ge=0)
+    title_path: list[str] = Field(default_factory=list)
+    source_reference: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_chunk(self) -> "AnnouncementChunk":
+        """Keep chunk spans and source provenance usable for replay."""
+
+        if self.end_offset <= self.start_offset:
+            raise ValueError("end_offset must be greater than start_offset")
+        if self.chunk_type == "table" and self.table_ref is None:
+            raise ValueError("table chunks must include table_ref")
+        official_url = self.source_reference.get("official_url")
+        if not isinstance(official_url, str) or not official_url.strip():
+            raise ValueError("source_reference.official_url is required")
+        return self
+
+
+class AnnouncementRetrievalArtifact(BaseModel):
+    """Local retrieval index reference for one parsed announcement."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    announcement_id: str = Field(min_length=1)
+    chunk_refs: list[str] = Field(min_length=1)
+    index_ref: str = Field(min_length=1)
+    parser_version: str = Field(min_length=1)
+    llama_index_version: str = Field(min_length=1)
+    chunk_count: int = Field(ge=1)
+    built_at: datetime
+    source_parsed_artifact_path: Path | None = None
+    chunks: list[AnnouncementChunk] = Field(default_factory=list)
+
+    @field_validator("built_at")
+    @classmethod
+    def require_timezone(cls, value: datetime) -> datetime:
+        """Reject naive build timestamps."""
+
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("built_at must include timezone information")
+        return value
+
+    @field_validator("llama_index_version")
+    @classmethod
+    def reject_unconfigured_llama_index(cls, value: str) -> str:
+        """Retrieval artifacts must preserve a concrete LlamaIndex pin."""
+
+        if value == "not-configured":
+            raise ValueError("llama_index_version must not be not-configured")
+        return value
+
+    @model_validator(mode="after")
+    def validate_chunk_refs(self) -> "AnnouncementRetrievalArtifact":
+        """Keep chunk metadata internally consistent with artifact refs."""
+
+        if self.chunk_count != len(self.chunk_refs):
+            raise ValueError("chunk_count must match chunk_refs length")
+        if not self.chunks:
+            return self
+        if self.chunk_count != len(self.chunks):
+            raise ValueError("chunk_count must match chunks length")
+        chunk_ids = [chunk.chunk_id for chunk in self.chunks]
+        if self.chunk_refs != chunk_ids:
+            raise ValueError("chunk_refs must match chunk ids in order")
+        if any(chunk.announcement_id != self.announcement_id for chunk in self.chunks):
+            raise ValueError("chunk announcement_id must match artifact")
+        return self
+
+
+class AnnouncementRetrievalHit(BaseModel):
+    """One retrieval result returned for an announcement query."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    chunk_id: str = Field(min_length=1)
+    announcement_id: str = Field(min_length=1)
+    section_id: str = Field(min_length=1)
+    table_ref: str | None = None
+    score: float = Field(ge=0.0)
+    quote: str = Field(min_length=1)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+def build_retrieval_artifact(
+    parsed_artifact: ParsedAnnouncementArtifact,
+    *,
+    config: AnnouncementConfig,
+    parsed_artifact_path: Path | None = None,
+    output_root: Path | None = None,
+) -> AnnouncementRetrievalArtifact:
+    """Build chunks, a local vector index, and the retrieval artifact object."""
+
+    from .chunker import chunk_parsed_artifact
+    from .vector_store import build_vector_index
+
+    root = (
+        Path(output_root)
+        if output_root is not None
+        else Path(config.artifact_root) / "index" / parsed_artifact.announcement_id
+    )
+    chunks = chunk_parsed_artifact(parsed_artifact)
+    vector_ref = build_vector_index(
+        chunks,
+        persist_dir=root / "vector_store",
+        config=config,
+    )
+    return AnnouncementRetrievalArtifact(
+        announcement_id=parsed_artifact.announcement_id,
+        chunk_refs=[chunk.chunk_id for chunk in chunks],
+        index_ref=vector_ref.index_ref,
+        parser_version=parsed_artifact.parser_version,
+        llama_index_version=vector_ref.llama_index_version,
+        chunk_count=len(chunks),
+        built_at=vector_ref.built_at,
+        source_parsed_artifact_path=parsed_artifact_path,
+        chunks=chunks,
+    )
+
+
+def write_retrieval_artifact(
+    artifact: AnnouncementRetrievalArtifact,
+    root: Path,
+) -> Path:
+    """Persist a retrieval artifact as ``root/retrieval_artifact.json``."""
+
+    output_root = Path(root)
+    path = output_root / "retrieval_artifact.json"
+    try:
+        output_root.mkdir(parents=True, exist_ok=True)
+        path.write_text(artifact.model_dump_json(indent=2), encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Unable to write retrieval artifact: path={path}") from exc
+    return path
+
+
+def load_retrieval_artifact(path: Path) -> AnnouncementRetrievalArtifact:
+    """Load a retrieval artifact JSON file."""
+
+    artifact_path = Path(path)
+    try:
+        return AnnouncementRetrievalArtifact.model_validate_json(
+            artifact_path.read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(
+            f"Unable to load retrieval artifact: path={artifact_path}"
+        ) from exc

--- a/src/subsystem_announcement/index/sample_query.py
+++ b/src/subsystem_announcement/index/sample_query.py
@@ -1,0 +1,147 @@
+"""Sample retrieval query helper for offline announcement indexes."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .retrieval_artifact import (
+    AnnouncementChunk,
+    AnnouncementRetrievalArtifact,
+    AnnouncementRetrievalHit,
+)
+from .vector_store import load_vector_index
+
+
+def query(
+    text: str,
+    artifact: AnnouncementRetrievalArtifact,
+    *,
+    top_k: int = 5,
+    embed_model: Any | None = None,
+) -> list[AnnouncementRetrievalHit]:
+    """Query a retrieval artifact and return chunk-level hits only."""
+
+    query_text = text.strip()
+    if not query_text:
+        raise ValueError("query text must not be empty")
+    if top_k <= 0:
+        raise ValueError("top_k must be greater than 0")
+    if not artifact.chunks:
+        raise ValueError("retrieval artifact must include chunk metadata for query")
+
+    index = load_vector_index(
+        persist_dir=Path(artifact.index_ref),
+        llama_index_version=artifact.llama_index_version,
+        embed_model=embed_model,
+    )
+    vector_scores = _vector_scores(index, query_text, top_k=top_k)
+    lexical_scores = {
+        chunk.chunk_id: score
+        for chunk in artifact.chunks
+        if (score := _lexical_score(query_text, _chunk_search_text(chunk))) > 0.0
+    }
+
+    chunks_by_id = {chunk.chunk_id: chunk for chunk in artifact.chunks}
+    candidate_ids = [
+        chunk.chunk_id
+        for chunk in artifact.chunks
+        if chunk.chunk_id in lexical_scores or chunk.chunk_id in vector_scores
+    ]
+    ranked_ids = sorted(
+        candidate_ids,
+        key=lambda chunk_id: (
+            max(lexical_scores.get(chunk_id, 0.0), vector_scores.get(chunk_id, 0.0)),
+            -artifact.chunk_refs.index(chunk_id),
+        ),
+        reverse=True,
+    )
+
+    hits: list[AnnouncementRetrievalHit] = []
+    for chunk_id in ranked_ids[:top_k]:
+        chunk = chunks_by_id[chunk_id]
+        score = max(lexical_scores.get(chunk_id, 0.0), vector_scores.get(chunk_id, 0.0))
+        hits.append(_hit_from_chunk(chunk, query_text=query_text, score=score))
+    return hits
+
+
+def _vector_scores(index: Any, query_text: str, *, top_k: int) -> dict[str, float]:
+    retriever = index.as_retriever(similarity_top_k=top_k)
+    results = retriever.retrieve(query_text)
+    scores: dict[str, float] = {}
+    for result in results:
+        node = getattr(result, "node", result)
+        metadata = getattr(node, "metadata", {}) or {}
+        chunk_id = metadata.get("chunk_id") if isinstance(metadata, Mapping) else None
+        if not isinstance(chunk_id, str) or not chunk_id:
+            continue
+        raw_score = getattr(result, "score", 0.0)
+        score = 0.0 if raw_score is None else max(float(raw_score), 0.0)
+        scores[chunk_id] = max(scores.get(chunk_id, 0.0), score)
+    return scores
+
+
+def _lexical_score(query_text: str, chunk_text: str) -> float:
+    terms = _query_terms(query_text)
+    if not terms:
+        return 0.0
+    score = 0.0
+    lowered_chunk = chunk_text.lower()
+    for term in terms:
+        lowered_term = term.lower()
+        count = lowered_chunk.count(lowered_term)
+        if count:
+            score += count * max(len(term), 1)
+    if score == 0.0:
+        return 0.0
+    return 1.0 + score / max(len(chunk_text), 1)
+
+
+def _chunk_search_text(chunk: AnnouncementChunk) -> str:
+    return "\n".join([chunk.text, *chunk.title_path])
+
+
+def _query_terms(query_text: str) -> list[str]:
+    terms = [query_text]
+    terms.extend(term for term in re.split(r"\s+", query_text) if term)
+    seen: set[str] = set()
+    unique_terms: list[str] = []
+    for term in terms:
+        if term not in seen:
+            seen.add(term)
+            unique_terms.append(term)
+    return unique_terms
+
+
+def _hit_from_chunk(
+    chunk: AnnouncementChunk,
+    *,
+    query_text: str,
+    score: float,
+) -> AnnouncementRetrievalHit:
+    return AnnouncementRetrievalHit(
+        chunk_id=chunk.chunk_id,
+        announcement_id=chunk.announcement_id,
+        section_id=chunk.section_id,
+        table_ref=chunk.table_ref,
+        score=score,
+        quote=_quote(chunk.text, query_text),
+        metadata={
+            "chunk_type": chunk.chunk_type,
+            "start_offset": chunk.start_offset,
+            "end_offset": chunk.end_offset,
+            "title_path": chunk.title_path,
+            "source_reference": chunk.source_reference,
+        },
+    )
+
+
+def _quote(chunk_text: str, query_text: str) -> str:
+    index = chunk_text.lower().find(query_text.lower())
+    if index == -1:
+        return chunk_text[:320].strip() or chunk_text
+    start = max(0, index - 80)
+    end = min(len(chunk_text), index + len(query_text) + 160)
+    return chunk_text[start:end].strip() or chunk_text[index:end]

--- a/src/subsystem_announcement/index/vector_store.py
+++ b/src/subsystem_announcement/index/vector_store.py
@@ -1,0 +1,275 @@
+"""LlamaIndex vector store integration for announcement chunks."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from subsystem_announcement.config import AnnouncementConfig
+
+from .retrieval_artifact import AnnouncementChunk
+
+
+class AnnouncementVectorIndexRef(BaseModel):
+    """Local reference to a persisted vector index."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    index_ref: str = Field(min_length=1)
+    llama_index_version: str = Field(min_length=1)
+    chunk_ids: list[str] = Field(default_factory=list)
+    built_at: datetime
+
+    @field_validator("built_at")
+    @classmethod
+    def require_timezone(cls, value: datetime) -> datetime:
+        """Reject naive index build timestamps."""
+
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("built_at must include timezone information")
+        return value
+
+
+@dataclass(frozen=True)
+class _LlamaIndexApi:
+    Document: Any
+    StorageContext: Any
+    VectorStoreIndex: Any
+    SimpleVectorStore: Any
+    DoclingNodeParser: Any
+    load_index_from_storage: Any
+
+
+def build_vector_index(
+    chunks: Sequence[AnnouncementChunk],
+    *,
+    persist_dir: Path,
+    config: AnnouncementConfig,
+    embed_model: Any | None = None,
+) -> AnnouncementVectorIndexRef:
+    """Build and persist a LlamaIndex SimpleVectorStore for retrieval chunks."""
+
+    if not chunks:
+        raise ValueError("chunks must contain at least one retrieval chunk")
+
+    llama_index_version = resolve_llama_index_version(config.llama_index_version)
+    api = _load_llama_index_api()
+    embedding = embed_model if embed_model is not None else _default_embed_model()
+    documents = [_document_from_chunk(api.Document, chunk) for chunk in chunks]
+    vector_store = api.SimpleVectorStore()
+    storage_context = api.StorageContext.from_defaults(vector_store=vector_store)
+    node_parser = api.DoclingNodeParser()
+
+    index = _index_from_documents(
+        api,
+        documents,
+        storage_context=storage_context,
+        node_parser=node_parser,
+        embed_model=embedding,
+    )
+
+    output_dir = Path(persist_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    index_storage_context = getattr(index, "storage_context", storage_context)
+    index_storage_context.persist(persist_dir=str(output_dir))
+    return AnnouncementVectorIndexRef(
+        index_ref=str(output_dir),
+        llama_index_version=llama_index_version,
+        chunk_ids=[chunk.chunk_id for chunk in chunks],
+        built_at=datetime.now(timezone.utc),
+    )
+
+
+def load_vector_index(
+    *,
+    persist_dir: Path,
+    llama_index_version: str,
+    embed_model: Any | None = None,
+) -> Any:
+    """Load a persisted LlamaIndex vector index for retrieval."""
+
+    resolve_llama_index_version(llama_index_version)
+    api = _load_llama_index_api()
+    embedding = embed_model if embed_model is not None else _default_embed_model()
+    storage_context = api.StorageContext.from_defaults(persist_dir=str(persist_dir))
+    try:
+        return api.load_index_from_storage(
+            storage_context,
+            embed_model=embedding,
+        )
+    except TypeError:
+        settings = _try_load_settings()
+        if settings is None:
+            return api.load_index_from_storage(storage_context)
+        previous_embed_model = getattr(settings, "embed_model", None)
+        settings.embed_model = embedding
+        try:
+            return api.load_index_from_storage(storage_context)
+        finally:
+            settings.embed_model = previous_embed_model
+
+
+def resolve_llama_index_version(version_pin: str) -> str:
+    """Validate and resolve the exact installed LlamaIndex core version."""
+
+    configured = version_pin.strip()
+    if configured == "not-configured":
+        raise RuntimeError(
+            "LlamaIndex version is not configured. Set "
+            "AnnouncementConfig.llama_index_version to an exact pin such as "
+            "llama-index-core==0.10.0 before building retrieval indexes."
+        )
+    if "==" not in configured:
+        raise RuntimeError(
+            "LlamaIndex version must be an exact package pin, got "
+            f"{configured!r}."
+        )
+    package_name, expected_version = configured.split("==", 1)
+    try:
+        installed_version = metadata.version(package_name)
+    except metadata.PackageNotFoundError as exc:
+        raise RuntimeError(
+            "LlamaIndex dependency is not installed for the configured exact "
+            f"pin {configured!r}. Install the locked LlamaIndex and "
+            "DoclingNodeParser dependencies before building retrieval indexes."
+        ) from exc
+    if installed_version != expected_version:
+        raise RuntimeError(
+            "LlamaIndex version mismatch: configured "
+            f"{configured!r}, installed {package_name}=={installed_version!r}."
+        )
+    return f"{package_name}=={installed_version}"
+
+
+def _document_from_chunk(Document: Any, chunk: AnnouncementChunk) -> Any:
+    metadata_payload = {
+        "chunk_id": chunk.chunk_id,
+        "announcement_id": chunk.announcement_id,
+        "chunk_type": chunk.chunk_type,
+        "section_id": chunk.section_id,
+        "table_ref": chunk.table_ref,
+        "start_offset": chunk.start_offset,
+        "end_offset": chunk.end_offset,
+        "title_path": chunk.title_path,
+        "source_reference": chunk.source_reference,
+    }
+    return Document(text=chunk.text, metadata=metadata_payload)
+
+
+def _index_from_documents(
+    api: _LlamaIndexApi,
+    documents: Sequence[Any],
+    *,
+    storage_context: Any,
+    node_parser: Any,
+    embed_model: Any,
+) -> Any:
+    try:
+        return api.VectorStoreIndex.from_documents(
+            documents,
+            storage_context=storage_context,
+            transformations=[node_parser],
+            embed_model=embed_model,
+        )
+    except TypeError:
+        settings = _try_load_settings()
+        if settings is None:
+            return api.VectorStoreIndex.from_documents(
+                documents,
+                storage_context=storage_context,
+                transformations=[node_parser],
+            )
+        previous_embed_model = getattr(settings, "embed_model", None)
+        settings.embed_model = embed_model
+        try:
+            return api.VectorStoreIndex.from_documents(
+                documents,
+                storage_context=storage_context,
+                transformations=[node_parser],
+            )
+        finally:
+            settings.embed_model = previous_embed_model
+
+
+def _load_llama_index_api() -> _LlamaIndexApi:
+    try:
+        from llama_index.core import (  # type: ignore[import-not-found]
+            Document,
+            StorageContext,
+            VectorStoreIndex,
+            load_index_from_storage,
+        )
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise RuntimeError(
+            "LlamaIndex core is required for announcement retrieval indexes. "
+            "Install the exact llama-index-core pin."
+        ) from exc
+
+    try:
+        from llama_index.core.vector_stores import (  # type: ignore[import-not-found]
+            SimpleVectorStore,
+        )
+    except (ImportError, ModuleNotFoundError):
+        try:
+            from llama_index.core.vector_stores.simple import (  # type: ignore[import-not-found]
+                SimpleVectorStore,
+            )
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise RuntimeError(
+                "LlamaIndex SimpleVectorStore is required for announcement "
+                "retrieval indexes. Install the exact llama-index-core pin."
+            ) from exc
+
+    try:
+        from llama_index.node_parser.docling import (  # type: ignore[import-not-found]
+            DoclingNodeParser,
+        )
+    except (ImportError, ModuleNotFoundError):
+        try:
+            from llama_index.node_parser.docling.base import (  # type: ignore[import-not-found]
+                DoclingNodeParser,
+            )
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise RuntimeError(
+                "LlamaIndex DoclingNodeParser is required for announcement "
+                "retrieval indexes. Install the exact "
+                "llama-index-node-parser-docling pin."
+            ) from exc
+    return _LlamaIndexApi(
+        Document=Document,
+        StorageContext=StorageContext,
+        VectorStoreIndex=VectorStoreIndex,
+        SimpleVectorStore=SimpleVectorStore,
+        DoclingNodeParser=DoclingNodeParser,
+        load_index_from_storage=load_index_from_storage,
+    )
+
+
+def _default_embed_model() -> Any:
+    try:
+        from llama_index.core.embeddings.mock_embed_model import (  # type: ignore[import-not-found]
+            MockEmbedding,
+        )
+    except (ImportError, ModuleNotFoundError):
+        try:
+            from llama_index.core.embeddings import MockEmbedding  # type: ignore[import-not-found]
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise RuntimeError(
+                "LlamaIndex MockEmbedding is required for offline retrieval index "
+                "builds when no embed_model is explicitly provided."
+            ) from exc
+    return MockEmbedding(embed_dim=384)
+
+
+def _try_load_settings() -> Any | None:
+    try:
+        from llama_index.core import Settings  # type: ignore[import-not-found]
+    except (ImportError, ModuleNotFoundError):
+        return None
+    return Settings

--- a/tests/fixtures/announcements/sample_parsed.json
+++ b/tests/fixtures/announcements/sample_parsed.json
@@ -1,0 +1,63 @@
+{
+  "announcement_id": "sample-ann-index",
+  "content_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "parser_version": "docling==2.15.1",
+  "title_hierarchy": [
+    "重大合同公告"
+  ],
+  "sections": [
+    {
+      "section_id": "sec-0001",
+      "title": "重大合同",
+      "level": 1,
+      "text": "公司与客户签署重大合同。合同金额1000万元。",
+      "start_offset": 0,
+      "end_offset": 23,
+      "parent_id": null
+    },
+    {
+      "section_id": "sec-0002",
+      "title": "风险提示",
+      "level": 1,
+      "text": "本合同履行存在不确定性。",
+      "start_offset": 44,
+      "end_offset": 56,
+      "parent_id": null
+    }
+  ],
+  "tables": [
+    {
+      "table_id": "tbl-0001",
+      "section_id": "sec-0001",
+      "caption": null,
+      "headers": [
+        "项目",
+        "金额"
+      ],
+      "rows": [
+        [
+          "重大合同",
+          "1000万元"
+        ]
+      ],
+      "start_offset": 25,
+      "end_offset": 42
+    }
+  ],
+  "extracted_text": "公司与客户签署重大合同。合同金额1000万元。\n\n项目\t金额\n重大合同\t1000万元\n\n本合同履行存在不确定性。",
+  "parsed_at": "2026-04-18T09:31:00+00:00",
+  "source_document": {
+    "announcement_id": "sample-ann-index",
+    "ts_code": "600000.SH",
+    "title": "重大合同公告",
+    "publish_time": "2026-04-18T09:00:00+00:00",
+    "content_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "official_url": "https://static.sse.com.cn/disclosure/sample-ann-index.pdf",
+    "source_exchange": "sse",
+    "attachment_type": "pdf",
+    "local_path": "tests/fixtures/announcements/sse-major-contract.pdf",
+    "content_type": "application/pdf",
+    "byte_size": 100,
+    "fetched_at": "2026-04-18T09:30:00+00:00"
+  }
+}

--- a/tests/test_index_chunker.py
+++ b/tests/test_index_chunker.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from subsystem_announcement.discovery.document import AnnouncementDocumentArtifact
+from subsystem_announcement.index import chunk_parsed_artifact
+from subsystem_announcement.index.chunker import make_chunk_id
+from subsystem_announcement.parse.artifact import (
+    AnnouncementSection,
+    AnnouncementTable,
+    ParsedAnnouncementArtifact,
+)
+
+
+def make_index_artifact(tmp_path: Path) -> ParsedAnnouncementArtifact:
+    section_1 = "公司与客户签署重大合同。合同金额1000万元。"
+    table_text = "项目\t金额\n重大合同\t1000万元"
+    section_2 = "本合同履行存在不确定性。"
+    extracted_text = f"{section_1}\n\n{table_text}\n\n{section_2}"
+    table_start = len(section_1) + 2
+    section_2_start = table_start + len(table_text) + 2
+    return ParsedAnnouncementArtifact(
+        announcement_id="ann-index-1",
+        content_hash="b" * 64,
+        parser_version="docling==2.15.1",
+        title_hierarchy=["重大合同公告"],
+        sections=[
+            AnnouncementSection(
+                section_id="sec-0001",
+                title="重大合同",
+                level=1,
+                text=section_1,
+                start_offset=0,
+                end_offset=len(section_1),
+                parent_id=None,
+            ),
+            AnnouncementSection(
+                section_id="sec-0002",
+                title="风险提示",
+                level=1,
+                text=section_2,
+                start_offset=section_2_start,
+                end_offset=section_2_start + len(section_2),
+                parent_id=None,
+            ),
+        ],
+        tables=[
+            AnnouncementTable(
+                table_id="tbl-0001",
+                section_id="sec-0001",
+                caption=None,
+                headers=["项目", "金额"],
+                rows=[["重大合同", "1000万元"]],
+                start_offset=table_start,
+                end_offset=table_start + len(table_text),
+            )
+        ],
+        extracted_text=extracted_text,
+        parsed_at=datetime(2026, 4, 18, 9, 31, tzinfo=timezone.utc),
+        source_document=AnnouncementDocumentArtifact(
+            announcement_id="ann-index-1",
+            ts_code="600000.SH",
+            title="重大合同公告",
+            publish_time=datetime(2026, 4, 18, 9, 0, tzinfo=timezone.utc),
+            content_hash="b" * 64,
+            official_url="https://static.sse.com.cn/disclosure/ann-index-1.pdf",
+            source_exchange="sse",
+            attachment_type="pdf",
+            local_path=tmp_path / "ann-index-1.pdf",
+            content_type="application/pdf",
+            byte_size=100,
+            fetched_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+        ),
+    )
+
+
+def test_chunk_parsed_artifact_builds_section_and_table_chunks(
+    tmp_path: Path,
+) -> None:
+    artifact = make_index_artifact(tmp_path)
+
+    chunks = chunk_parsed_artifact(artifact)
+
+    assert len(chunks) == 3
+    assert [chunk.chunk_type for chunk in chunks] == ["section", "section", "table"]
+    assert all(chunk.source_reference for chunk in chunks)
+    assert all("local_path" not in chunk.source_reference for chunk in chunks)
+    assert chunks[0].start_offset == artifact.sections[0].start_offset
+    assert chunks[0].end_offset == artifact.sections[0].end_offset
+    assert chunks[1].start_offset == artifact.sections[1].start_offset
+    assert chunks[1].end_offset == artifact.sections[1].end_offset
+    assert chunks[2].table_ref == artifact.tables[0].table_id
+    assert chunks[2].source_reference["official_url"].startswith("https://")
+
+
+def test_chunk_ids_and_order_are_stable(tmp_path: Path) -> None:
+    artifact = make_index_artifact(tmp_path)
+
+    first = chunk_parsed_artifact(artifact)
+    second = chunk_parsed_artifact(artifact)
+
+    assert [chunk.chunk_id for chunk in first] == [chunk.chunk_id for chunk in second]
+    assert first == second
+    assert make_chunk_id(
+        first[0].announcement_id,
+        first[0].section_id,
+        first[0].chunk_type,
+        first[0].start_offset,
+        first[0].end_offset,
+        first[0].text,
+    ) == first[0].chunk_id
+
+
+def test_long_section_is_split_into_clause_chunks(tmp_path: Path) -> None:
+    artifact = make_index_artifact(tmp_path)
+    long_text = "。".join([f"第{index}项合同安排" for index in range(20)]) + "。"
+    artifact = artifact.model_copy(
+        update={
+            "sections": [
+                artifact.sections[0].model_copy(
+                    update={
+                        "text": long_text,
+                        "start_offset": 0,
+                        "end_offset": len(long_text),
+                    }
+                )
+            ],
+            "tables": [],
+            "extracted_text": long_text,
+        }
+    )
+
+    chunks = chunk_parsed_artifact(artifact, max_chars=30, overlap_chars=5)
+
+    assert len(chunks) > 1
+    assert {chunk.chunk_type for chunk in chunks} == {"clause"}
+    assert chunks[0].start_offset == 0
+    assert all(chunk.end_offset > chunk.start_offset for chunk in chunks)
+
+
+@pytest.mark.parametrize(
+    ("max_chars", "overlap_chars", "message"),
+    [
+        (0, 0, "max_chars"),
+        (10, -1, "overlap_chars"),
+        (10, 10, "overlap_chars"),
+    ],
+)
+def test_chunker_rejects_invalid_split_settings(
+    tmp_path: Path,
+    max_chars: int,
+    overlap_chars: int,
+    message: str,
+) -> None:
+    artifact = make_index_artifact(tmp_path)
+
+    with pytest.raises(ValueError, match=message):
+        chunk_parsed_artifact(
+            artifact,
+            max_chars=max_chars,
+            overlap_chars=overlap_chars,
+        )

--- a/tests/test_index_retrieval_artifact.py
+++ b/tests/test_index_retrieval_artifact.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timezone
+from pathlib import Path
+
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.index.retrieval_artifact import (
+    AnnouncementRetrievalArtifact,
+    build_retrieval_artifact,
+    load_retrieval_artifact,
+    write_retrieval_artifact,
+)
+from subsystem_announcement.index.vector_store import AnnouncementVectorIndexRef
+from subsystem_announcement.runtime.pipeline import AnnouncementPipeline
+
+from .test_index_chunker import make_index_artifact
+
+
+def test_retrieval_artifact_builds_and_round_trips(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    parsed_artifact = make_index_artifact(tmp_path)
+
+    def fake_build_vector_index(chunks, *, persist_dir, config, embed_model=None):
+        persist_dir.mkdir(parents=True, exist_ok=True)
+        return AnnouncementVectorIndexRef(
+            index_ref=str(persist_dir),
+            llama_index_version=config.llama_index_version,
+            chunk_ids=[chunk.chunk_id for chunk in chunks],
+            built_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
+        )
+
+    monkeypatch.setattr(
+        "subsystem_announcement.index.vector_store.build_vector_index",
+        fake_build_vector_index,
+    )
+    config = AnnouncementConfig(
+        artifact_root=tmp_path / "artifacts",
+        llama_index_version="llama-index-core==0.10.0",
+    )
+
+    artifact = build_retrieval_artifact(
+        parsed_artifact,
+        config=config,
+        parsed_artifact_path=tmp_path / "parsed.json",
+        output_root=tmp_path / "index-output",
+    )
+    path = write_retrieval_artifact(artifact, tmp_path / "index-output")
+    loaded = load_retrieval_artifact(path)
+
+    assert path == tmp_path / "index-output" / "retrieval_artifact.json"
+    assert loaded == artifact
+    assert loaded.chunk_count == 3
+    assert loaded.chunk_refs == [chunk.chunk_id for chunk in loaded.chunks]
+    assert loaded.index_ref == str(tmp_path / "index-output" / "vector_store")
+
+
+def test_retrieval_artifact_rejects_inconsistent_chunk_refs(
+    tmp_path: Path,
+) -> None:
+    parsed_artifact = make_index_artifact(tmp_path)
+    from subsystem_announcement.index import chunk_parsed_artifact
+
+    chunks = chunk_parsed_artifact(parsed_artifact)
+
+    try:
+        AnnouncementRetrievalArtifact(
+            announcement_id=parsed_artifact.announcement_id,
+            chunk_refs=["wrong"],
+            index_ref=str(tmp_path / "index"),
+            parser_version=parsed_artifact.parser_version,
+            llama_index_version="llama-index-core==0.10.0",
+            chunk_count=1,
+            built_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
+            source_parsed_artifact_path=None,
+            chunks=chunks,
+        )
+    except ValueError as exc:
+        assert "chunk_count" in str(exc) or "chunk_refs" in str(exc)
+    else:
+        raise AssertionError("inconsistent chunk refs were accepted")
+
+
+def test_retrieval_artifact_accepts_external_chunk_refs_without_inline_chunks(
+    tmp_path: Path,
+) -> None:
+    artifact = AnnouncementRetrievalArtifact(
+        announcement_id="ann-index-1",
+        chunk_refs=["chunk:ann-index-1:sec-0001:section:abc"],
+        index_ref=str(tmp_path / "index"),
+        parser_version="docling==2.15.1",
+        llama_index_version="llama-index-core==0.10.0",
+        chunk_count=1,
+        built_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
+        source_parsed_artifact_path=None,
+    )
+
+    assert artifact.chunks == []
+
+
+def test_pipeline_process_envelope_does_not_build_retrieval_index() -> None:
+    source = inspect.getsource(AnnouncementPipeline.process_envelope)
+
+    assert "build_retrieval_artifact" not in source

--- a/tests/test_index_retrieval_artifact.py
+++ b/tests/test_index_retrieval_artifact.py
@@ -4,6 +4,8 @@ import inspect
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from subsystem_announcement.config import AnnouncementConfig
 from subsystem_announcement.index.retrieval_artifact import (
     AnnouncementRetrievalArtifact,
@@ -55,6 +57,74 @@ def test_retrieval_artifact_builds_and_round_trips(
     assert loaded.chunk_count == 3
     assert loaded.chunk_refs == [chunk.chunk_id for chunk in loaded.chunks]
     assert loaded.index_ref == str(tmp_path / "index-output" / "vector_store")
+
+
+@pytest.mark.parametrize(
+    "announcement_id",
+    ["../x", "/abs/path", "a/b", ".", "..", "ann\x00index"],
+)
+def test_retrieval_artifact_rejects_unsafe_default_announcement_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    announcement_id: str,
+) -> None:
+    parsed_artifact = make_index_artifact(tmp_path)
+    unsafe_artifact = parsed_artifact.model_copy(
+        update={
+            "announcement_id": announcement_id,
+            "source_document": parsed_artifact.source_document.model_copy(
+                update={"announcement_id": announcement_id}
+            ),
+        }
+    )
+    config = AnnouncementConfig(
+        artifact_root=tmp_path / "artifacts",
+        llama_index_version="llama-index-core==0.10.0",
+    )
+
+    def fail_build_vector_index(*args, **kwargs):
+        raise AssertionError("unsafe announcement_id reached vector index build")
+
+    monkeypatch.setattr(
+        "subsystem_announcement.index.vector_store.build_vector_index",
+        fail_build_vector_index,
+    )
+
+    with pytest.raises(ValueError, match="Unsafe announcement_id"):
+        build_retrieval_artifact(unsafe_artifact, config=config)
+
+
+def test_retrieval_artifact_rejects_default_vector_store_symlink_escape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parsed_artifact = make_index_artifact(tmp_path)
+    config = AnnouncementConfig(
+        artifact_root=tmp_path / "artifacts",
+        llama_index_version="llama-index-core==0.10.0",
+    )
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    vector_store_dir = (
+        tmp_path
+        / "artifacts"
+        / "index"
+        / parsed_artifact.announcement_id
+        / "vector_store"
+    )
+    vector_store_dir.parent.mkdir(parents=True)
+    vector_store_dir.symlink_to(outside, target_is_directory=True)
+
+    def fail_build_vector_index(*args, **kwargs):
+        raise AssertionError("unsafe vector_store path reached vector index build")
+
+    monkeypatch.setattr(
+        "subsystem_announcement.index.vector_store.build_vector_index",
+        fail_build_vector_index,
+    )
+
+    with pytest.raises(ValueError, match="Vector Store Directory is a symlink"):
+        build_retrieval_artifact(parsed_artifact, config=config)
 
 
 def test_retrieval_artifact_rejects_inconsistent_chunk_refs(

--- a/tests/test_index_vector_store.py
+++ b/tests/test_index_vector_store.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import subsystem_announcement.index.vector_store as vector_store
+from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.index import chunk_parsed_artifact
+from subsystem_announcement.index.retrieval_artifact import AnnouncementRetrievalArtifact
+from subsystem_announcement.index.sample_query import query
+from subsystem_announcement.index.vector_store import build_vector_index
+
+from .test_index_chunker import make_index_artifact
+
+
+def test_build_vector_index_persists_simple_vector_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installed = _install_fake_llama_index(monkeypatch)
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+
+    ref = build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+    )
+
+    assert ref.index_ref == str(tmp_path / "vector-store")
+    assert ref.llama_index_version == "llama-index-core==0.10.0"
+    assert ref.chunk_ids == [chunk.chunk_id for chunk in chunks]
+    assert (tmp_path / "vector-store" / "fake_vector_index.json").exists()
+    assert installed["docling_parser_calls"] == 1
+
+
+def test_query_returns_section_and_table_keyword_hits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_llama_index(monkeypatch)
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+    index_ref = build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+    )
+    artifact = AnnouncementRetrievalArtifact(
+        announcement_id="ann-index-1",
+        chunk_refs=[chunk.chunk_id for chunk in chunks],
+        index_ref=index_ref.index_ref,
+        parser_version="docling==2.15.1",
+        llama_index_version=index_ref.llama_index_version,
+        chunk_count=len(chunks),
+        built_at=index_ref.built_at,
+        source_parsed_artifact_path=None,
+        chunks=chunks,
+    )
+
+    section_hits = query("风险提示", artifact, top_k=1)
+    table_hits = query("1000万元", artifact, top_k=1)
+
+    assert section_hits[0].section_id == "sec-0002"
+    assert section_hits[0].table_ref is None
+    assert table_hits[0].table_ref == "tbl-0001"
+    assert table_hits[0].metadata["chunk_type"] == "table"
+
+
+def test_build_vector_index_rejects_unconfigured_llama_index(
+    tmp_path: Path,
+) -> None:
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+
+    with pytest.raises(RuntimeError, match="LlamaIndex version is not configured"):
+        build_vector_index(
+            chunks,
+            persist_dir=tmp_path / "vector-store",
+            config=AnnouncementConfig(),
+        )
+
+
+def test_build_vector_index_reports_missing_llama_index_dependency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+    monkeypatch.setattr(
+        vector_store.metadata,
+        "version",
+        lambda package_name: "0.10.0",
+    )
+    monkeypatch.setitem(sys.modules, "llama_index", None)
+
+    with pytest.raises(RuntimeError, match="LlamaIndex core"):
+        build_vector_index(
+            chunks,
+            persist_dir=tmp_path / "vector-store",
+            config=config,
+        )
+
+
+def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    calls = {"docling_parser_calls": 0}
+
+    class FakeDocument:
+        def __init__(self, *, text: str, metadata: dict[str, Any]) -> None:
+            self.text = text
+            self.metadata = metadata
+
+        def get_content(self) -> str:
+            return self.text
+
+    class FakeSimpleVectorStore:
+        pass
+
+    class FakeStorageContext:
+        def __init__(
+            self,
+            *,
+            vector_store: Any | None = None,
+            persist_dir: str | None = None,
+        ) -> None:
+            self.vector_store = vector_store
+            self.persist_dir = persist_dir
+            self.documents: list[FakeDocument] = []
+            if persist_dir is not None:
+                index_path = Path(persist_dir) / "fake_vector_index.json"
+                data = json.loads(index_path.read_text(encoding="utf-8"))
+                self.documents = [
+                    FakeDocument(text=item["text"], metadata=item["metadata"])
+                    for item in data["documents"]
+                ]
+
+        @classmethod
+        def from_defaults(cls, **kwargs):
+            return cls(**kwargs)
+
+        def persist(self, *, persist_dir: str) -> None:
+            output_dir = Path(persist_dir)
+            output_dir.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "documents": [
+                    {"text": document.text, "metadata": document.metadata}
+                    for document in self.documents
+                ]
+            }
+            (output_dir / "fake_vector_index.json").write_text(
+                json.dumps(payload, ensure_ascii=False),
+                encoding="utf-8",
+            )
+
+    class FakeDoclingNodeParser:
+        def __init__(self) -> None:
+            calls["docling_parser_calls"] += 1
+
+    class FakeVectorStoreIndex:
+        def __init__(
+            self,
+            documents: list[FakeDocument],
+            storage_context: FakeStorageContext,
+        ) -> None:
+            self.documents = documents
+            self.storage_context = storage_context
+            self.storage_context.documents = documents
+
+        @classmethod
+        def from_documents(
+            cls,
+            documents,
+            *,
+            storage_context,
+            transformations,
+            embed_model=None,
+        ):
+            assert transformations
+            assert isinstance(transformations[0], FakeDoclingNodeParser)
+            assert embed_model is not None
+            return cls(list(documents), storage_context)
+
+        def as_retriever(self, *, similarity_top_k: int):
+            return FakeRetriever(self.documents, similarity_top_k)
+
+    class FakeRetriever:
+        def __init__(self, documents, top_k: int) -> None:
+            self.documents = documents
+            self.top_k = top_k
+
+        def retrieve(self, text: str):
+            ranked = sorted(
+                self.documents,
+                key=lambda document: text in document.text,
+                reverse=True,
+            )
+            return [
+                types.SimpleNamespace(
+                    node=document,
+                    score=1.0 if text in document.text else 0.01,
+                )
+                for document in ranked[: self.top_k]
+            ]
+
+    class FakeMockEmbedding:
+        def __init__(self, *, embed_dim: int) -> None:
+            self.embed_dim = embed_dim
+
+    def fake_load_index_from_storage(storage_context, embed_model=None):
+        assert embed_model is not None
+        return FakeVectorStoreIndex(storage_context.documents, storage_context)
+
+    llama_index_module = types.ModuleType("llama_index")
+    llama_index_module.__path__ = []
+    core_module = types.ModuleType("llama_index.core")
+    core_module.Document = FakeDocument
+    core_module.StorageContext = FakeStorageContext
+    core_module.VectorStoreIndex = FakeVectorStoreIndex
+    core_module.load_index_from_storage = fake_load_index_from_storage
+    vector_stores_module = types.ModuleType("llama_index.core.vector_stores")
+    vector_stores_module.SimpleVectorStore = FakeSimpleVectorStore
+    node_parser_module = types.ModuleType("llama_index.node_parser")
+    node_parser_module.__path__ = []
+    docling_module = types.ModuleType("llama_index.node_parser.docling")
+    docling_module.DoclingNodeParser = FakeDoclingNodeParser
+    embeddings_module = types.ModuleType("llama_index.core.embeddings")
+    embeddings_module.__path__ = []
+    mock_embedding_module = types.ModuleType(
+        "llama_index.core.embeddings.mock_embed_model"
+    )
+    mock_embedding_module.MockEmbedding = FakeMockEmbedding
+
+    monkeypatch.setitem(sys.modules, "llama_index", llama_index_module)
+    monkeypatch.setitem(sys.modules, "llama_index.core", core_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "llama_index.core.vector_stores",
+        vector_stores_module,
+    )
+    monkeypatch.setitem(sys.modules, "llama_index.node_parser", node_parser_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "llama_index.node_parser.docling",
+        docling_module,
+    )
+    monkeypatch.setitem(sys.modules, "llama_index.core.embeddings", embeddings_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "llama_index.core.embeddings.mock_embed_model",
+        mock_embedding_module,
+    )
+    monkeypatch.setattr(
+        vector_store.metadata,
+        "version",
+        lambda package_name: "0.10.0",
+    )
+    return calls

--- a/tests/test_package_layout.py
+++ b/tests/test_package_layout.py
@@ -90,7 +90,15 @@ def test_subpackages_are_importable(subpackage: str) -> None:
             "derive_graph_delta_candidates",
         }.issubset(set(module.__all__))
     else:
-        assert module.__all__ == []
+        assert {
+            "AnnouncementChunk",
+            "AnnouncementRetrievalArtifact",
+            "AnnouncementRetrievalHit",
+            "build_retrieval_artifact",
+            "chunk_parsed_artifact",
+            "load_retrieval_artifact",
+            "query",
+        }.issubset(set(module.__all__))
 
 
 def test_config_defaults_are_instantiable() -> None:


### PR DESCRIPTION
Closes #10

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/graph/candidates.py`, `src/subsystem_announcement/graph/deltas.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/signals/classifier.py`, `tests/contracts/test_ex1_contract.py`, `tests/contracts/test_ex2_contract.py`, `tests/test_parse_docling_client.py`


---
### 1. 背景与目标
项目文档 §8.3、§11.7、§13.4 和 §21 把阶段 3 的核心退出条件定义为“历史公告可按章节与事件语义检索”。当前代码已经有 `subsystem_announcement.parse.artifact.ParsedAnnouncementArtifact`、`AnnouncementSection`、`AnnouncementTable` 和 `write_parsed_artifact(...)`，`runtime.pipeline.AnnouncementPipeline.process_envelope(...)` 也会把解析产物路径写入 `AnnouncementExtractionRun.parsed_artifact_path`。但 `src/subsystem_announcement/index/` 目前只有空 package，尚未把解析产物切成 retrieval chunks，也没有本地向量索引或 `AnnouncementRetrievalArtifact`。本 issue 的目标是在不进入日频主链的前提下补齐公告域离线检索链。

### 2. 所属模块
**primary writable paths：**
- `src/subsystem_announcement/index/__init__.py`
- `src/subsystem_announcement/index/chunker.py`（新建）
- `src/subsystem_announcement/index/retrieval_artifact.py`（新建）
- `src/subsystem_announcement/index/vector_store.py`（新建）
- `src/subsystem_announcement/index/sample_query.py`（新建）
- `src/subsystem_announcement/index/__main__.py`（新建，离线 CLI）
- `pyproject.toml`（仅允许补 LlamaIndex / DoclingNodeParser 相关精确版本依赖）
- `tests/test_index_chunker.py`（新建）
- `tests/test_index_retrieval_artifact.py`（新建）
- `tests/test_index_vector_store.py`（新建）

**adjacent read-only / integration paths：**
- `src/subsystem_announcement/parse/artifact.py`：读取 `ParsedAnnouncementArtifact`、`AnnouncementSection`、`AnnouncementTable`、`load_parsed_artifact(...)`
- `src/subsystem_announcement/discovery/document.py`：读取 `AnnouncementDocumentArtifact` 的 source metadata
- `src/subsystem_announcement/extract/evidence.py`：可复用 `render_table_text(table: AnnouncementTable) -> str`
- `src/subsystem_announcement/config.py`：读取现有 `AnnouncementConfig.llama_index_version` 与 `artifact_root`
- `src/subsystem_announcement/runtime/pipeline.py`：只读，确认索引构建没有被接入 `process_envelope(...)` 的日频路径

### 3. 实现范围
- 在 `retrieval_artifact.py` 定义 `AnnouncementChunk`、`AnnouncementRetrievalArtifact`、`AnnouncementRetrievalHit` 三个 Pydantic v2 模型，沿用现有模型风格：`BaseModel`、`ConfigDict(extra="forbid")`、timezone-aware `datetime` validator、`Field(...)` 约束。
- 在 `chunker.py` 实现 `chunk_parsed_artifact(parsed_artifact: ParsedAnnounce