### PR TITLE
feat(#31): [milestone-3 review] P0: Vector retrieval uses mock embeddings by default

### DIFF
--- a/src/subsystem_announcement/config.py
+++ b/src/subsystem_announcement/config.py
@@ -15,6 +15,10 @@ _DOCLING_VERSION = re.compile(r"^docling==[A-Za-z0-9][A-Za-z0-9._!+-]*$")
 _LLAMA_INDEX_VERSION = re.compile(
     r"^llama-index(?:-core)?==[A-Za-z0-9][A-Za-z0-9._!+-]*$"
 )
+_PYTHON_OBJECT_REF = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*:"
+    r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$"
+)
 
 
 class AnnouncementConfig(BaseModel):
@@ -25,6 +29,8 @@ class AnnouncementConfig(BaseModel):
     artifact_root: Path = Path("artifacts/announcement")
     docling_version: str = "not-configured"
     llama_index_version: str = "not-configured"
+    retrieval_embedding_adapter: str | None = None
+    allow_test_mock_embeddings: bool = False
     reasoner_endpoint: str | None = None
     entity_registry_endpoint: str | None = None
     sdk_endpoint: str | None = None
@@ -51,6 +57,21 @@ class AnnouncementConfig(BaseModel):
             value,
             pattern=_LLAMA_INDEX_VERSION,
             field_name="llama_index_version",
+        )
+
+    @field_validator("retrieval_embedding_adapter")
+    @classmethod
+    def validate_retrieval_embedding_adapter(cls, value: str | None) -> str | None:
+        """Allow explicit module:object embedding adapter references only."""
+
+        if value is None:
+            return None
+        stripped = value.strip()
+        if _PYTHON_OBJECT_REF.fullmatch(stripped):
+            return stripped
+        raise ValueError(
+            "retrieval_embedding_adapter must be a Python object reference in "
+            "module:attribute form"
         )
 
 

--- a/src/subsystem_announcement/index/__main__.py
+++ b/src/subsystem_announcement/index/__main__.py
@@ -55,6 +55,7 @@ def _build_parser() -> argparse.ArgumentParser:
     query_parser.add_argument("--artifact", type=Path, required=True)
     query_parser.add_argument("--text", required=True)
     query_parser.add_argument("--top-k", type=int, default=5)
+    query_parser.add_argument("--config", type=Path, default=None)
     return parser
 
 
@@ -73,8 +74,9 @@ def _build_command(args: argparse.Namespace) -> int:
 
 
 def _query_command(args: argparse.Namespace) -> int:
+    config = _load_cli_config(args.config)
     artifact = load_retrieval_artifact(args.artifact)
-    hits = query(args.text, artifact, top_k=args.top_k)
+    hits = query(args.text, artifact, top_k=args.top_k, config=config)
     print(
         json.dumps(
             [hit.model_dump(mode="json") for hit in hits],

--- a/src/subsystem_announcement/index/retrieval_artifact.py
+++ b/src/subsystem_announcement/index/retrieval_artifact.py
@@ -42,6 +42,30 @@ class AnnouncementChunk(BaseModel):
         return self
 
 
+class AnnouncementEmbeddingStrategy(BaseModel):
+    """Embedding identity used to build and query a persisted vector index."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    strategy_type: Literal["adapter", "injected", "test_mock"]
+    adapter_ref: str | None = None
+    model_ref: str = Field(min_length=1)
+    model_version: str | None = None
+    model_dimension: int | None = Field(default=None, ge=1)
+    model_fingerprint: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_strategy(self) -> "AnnouncementEmbeddingStrategy":
+        """Keep adapter-built indexes tied to the configured adapter ref."""
+
+        if self.strategy_type == "adapter":
+            if not self.adapter_ref:
+                raise ValueError("adapter embedding strategy requires adapter_ref")
+        elif self.adapter_ref is not None:
+            raise ValueError("adapter_ref is only valid for adapter strategy")
+        return self
+
+
 class AnnouncementRetrievalArtifact(BaseModel):
     """Local retrieval index reference for one parsed announcement."""
 
@@ -52,6 +76,7 @@ class AnnouncementRetrievalArtifact(BaseModel):
     index_ref: str = Field(min_length=1)
     parser_version: str = Field(min_length=1)
     llama_index_version: str = Field(min_length=1)
+    embedding_strategy: AnnouncementEmbeddingStrategy
     chunk_count: int = Field(ge=1)
     built_at: datetime
     source_parsed_artifact_path: Path | None = None
@@ -140,6 +165,7 @@ def build_retrieval_artifact(
         index_ref=vector_ref.index_ref,
         parser_version=parsed_artifact.parser_version,
         llama_index_version=vector_ref.llama_index_version,
+        embedding_strategy=vector_ref.embedding_strategy,
         chunk_count=len(chunks),
         built_at=vector_ref.built_at,
         source_parsed_artifact_path=parsed_artifact_path,

--- a/src/subsystem_announcement/index/sample_query.py
+++ b/src/subsystem_announcement/index/sample_query.py
@@ -16,6 +16,8 @@ from .retrieval_artifact import (
 )
 from .vector_store import load_vector_index
 
+_LEXICAL_SCORE_WEIGHT = 0.05
+
 
 def query(
     text: str,
@@ -40,25 +42,39 @@ def query(
         llama_index_version=artifact.llama_index_version,
         config=config,
         embed_model=embed_model,
+        embedding_strategy=artifact.embedding_strategy,
     )
-    vector_scores = _vector_scores(index, query_text, top_k=top_k)
-    lexical_scores = {
+    raw_vector_scores = _vector_scores(index, query_text, top_k=top_k)
+    raw_lexical_scores = {
         chunk.chunk_id: score
         for chunk in artifact.chunks
         if (score := _lexical_score(query_text, _chunk_search_text(chunk))) > 0.0
     }
+    vector_scores = _normalise_positive_scores(raw_vector_scores)
+    lexical_scores = _normalise_positive_scores(raw_lexical_scores)
+    vector_weight, lexical_weight = _score_weights(artifact)
 
     chunks_by_id = {chunk.chunk_id: chunk for chunk in artifact.chunks}
+    chunk_positions = {
+        chunk_id: index for index, chunk_id in enumerate(artifact.chunk_refs)
+    }
     candidate_ids = [
         chunk.chunk_id
         for chunk in artifact.chunks
-        if chunk.chunk_id in lexical_scores or chunk.chunk_id in vector_scores
+        if chunk.chunk_id in raw_lexical_scores or chunk.chunk_id in raw_vector_scores
     ]
+    combined_scores = {
+        chunk_id: (vector_weight * vector_scores.get(chunk_id, 0.0))
+        + (lexical_weight * lexical_scores.get(chunk_id, 0.0))
+        for chunk_id in candidate_ids
+    }
     ranked_ids = sorted(
         candidate_ids,
         key=lambda chunk_id: (
-            max(lexical_scores.get(chunk_id, 0.0), vector_scores.get(chunk_id, 0.0)),
-            -artifact.chunk_refs.index(chunk_id),
+            combined_scores.get(chunk_id, 0.0),
+            vector_scores.get(chunk_id, 0.0),
+            lexical_scores.get(chunk_id, 0.0),
+            -chunk_positions[chunk_id],
         ),
         reverse=True,
     )
@@ -66,9 +82,15 @@ def query(
     hits: list[AnnouncementRetrievalHit] = []
     for chunk_id in ranked_ids[:top_k]:
         chunk = chunks_by_id[chunk_id]
-        score = max(lexical_scores.get(chunk_id, 0.0), vector_scores.get(chunk_id, 0.0))
+        score = combined_scores.get(chunk_id, 0.0)
         hits.append(_hit_from_chunk(chunk, query_text=query_text, score=score))
     return hits
+
+
+def _score_weights(artifact: AnnouncementRetrievalArtifact) -> tuple[float, float]:
+    if artifact.embedding_strategy.strategy_type == "test_mock":
+        return 0.01, 1.0
+    return 1.0, _LEXICAL_SCORE_WEIGHT
 
 
 def _vector_scores(index: Any, query_text: str, *, top_k: int) -> dict[str, float]:
@@ -85,6 +107,23 @@ def _vector_scores(index: Any, query_text: str, *, top_k: int) -> dict[str, floa
         score = 0.0 if raw_score is None else max(float(raw_score), 0.0)
         scores[chunk_id] = max(scores.get(chunk_id, 0.0), score)
     return scores
+
+
+def _normalise_positive_scores(scores: dict[str, float]) -> dict[str, float]:
+    max_score = max((score for score in scores.values() if score > 0.0), default=0.0)
+    if max_score <= 0.0:
+        return {}
+    if max_score <= 1.0:
+        return {
+            chunk_id: min(max(score, 0.0), 1.0)
+            for chunk_id, score in scores.items()
+            if score > 0.0
+        }
+    return {
+        chunk_id: min(max(score / max_score, 0.0), 1.0)
+        for chunk_id, score in scores.items()
+        if score > 0.0
+    }
 
 
 def _lexical_score(query_text: str, chunk_text: str) -> float:

--- a/src/subsystem_announcement/index/sample_query.py
+++ b/src/subsystem_announcement/index/sample_query.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from subsystem_announcement.config import AnnouncementConfig
+
 from .retrieval_artifact import (
     AnnouncementChunk,
     AnnouncementRetrievalArtifact,
@@ -20,6 +22,7 @@ def query(
     artifact: AnnouncementRetrievalArtifact,
     *,
     top_k: int = 5,
+    config: AnnouncementConfig | None = None,
     embed_model: Any | None = None,
 ) -> list[AnnouncementRetrievalHit]:
     """Query a retrieval artifact and return chunk-level hits only."""
@@ -35,6 +38,7 @@ def query(
     index = load_vector_index(
         persist_dir=Path(artifact.index_ref),
         llama_index_version=artifact.llama_index_version,
+        config=config,
         embed_model=embed_model,
     )
     vector_scores = _vector_scores(index, query_text, top_k=top_k)

--- a/src/subsystem_announcement/index/vector_store.py
+++ b/src/subsystem_announcement/index/vector_store.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib
+import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -14,7 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from subsystem_announcement.config import AnnouncementConfig
 
-from .retrieval_artifact import AnnouncementChunk
+from .retrieval_artifact import AnnouncementChunk, AnnouncementEmbeddingStrategy
 
 
 class AnnouncementVectorIndexRef(BaseModel):
@@ -24,6 +26,7 @@ class AnnouncementVectorIndexRef(BaseModel):
 
     index_ref: str = Field(min_length=1)
     llama_index_version: str = Field(min_length=1)
+    embedding_strategy: AnnouncementEmbeddingStrategy
     chunk_ids: list[str] = Field(default_factory=list)
     built_at: datetime
 
@@ -82,6 +85,11 @@ def build_vector_index(
     return AnnouncementVectorIndexRef(
         index_ref=str(output_dir),
         llama_index_version=llama_index_version,
+        embedding_strategy=_embedding_strategy_from_model(
+            config=config,
+            embed_model=embed_model,
+            embedding=embedding,
+        ),
         chunk_ids=[chunk.chunk_id for chunk in chunks],
         built_at=datetime.now(timezone.utc),
     )
@@ -93,12 +101,22 @@ def load_vector_index(
     llama_index_version: str,
     config: AnnouncementConfig | None = None,
     embed_model: Any | None = None,
+    embedding_strategy: AnnouncementEmbeddingStrategy | None = None,
 ) -> Any:
     """Load a persisted LlamaIndex vector index for retrieval."""
 
     resolve_llama_index_version(llama_index_version)
     api = _load_llama_index_api()
     embedding = _resolve_embed_model(config=config, embed_model=embed_model)
+    if embedding_strategy is not None:
+        _validate_embedding_strategy(
+            expected=embedding_strategy,
+            actual=_embedding_strategy_from_model(
+                config=config,
+                embed_model=embed_model,
+                embedding=embedding,
+            ),
+        )
     storage_context = api.StorageContext.from_defaults(persist_dir=str(persist_dir))
     try:
         return api.load_index_from_storage(
@@ -337,6 +355,145 @@ def _mock_embed_model() -> Any:
                 "builds when no embed_model is explicitly provided."
             ) from exc
     return MockEmbedding(embed_dim=384)
+
+
+def _embedding_strategy_from_model(
+    *,
+    config: AnnouncementConfig | None,
+    embed_model: Any | None,
+    embedding: Any,
+) -> AnnouncementEmbeddingStrategy:
+    strategy_type = _embedding_strategy_type(config=config, embed_model=embed_model)
+    adapter_ref = (
+        config.retrieval_embedding_adapter
+        if strategy_type == "adapter" and config is not None
+        else None
+    )
+    model_ref = _model_ref(embedding)
+    model_version = _string_identity_attr(
+        embedding,
+        ("model_version", "version", "revision", "__version__"),
+    )
+    model_dimension = _int_identity_attr(
+        embedding,
+        ("embed_dim", "embedding_dim", "dimensions", "dimension"),
+    )
+    identity_payload = {
+        "strategy_type": strategy_type,
+        "adapter_ref": adapter_ref,
+        "model_ref": model_ref,
+        "model_version": model_version,
+        "model_dimension": model_dimension,
+        "identity_attributes": _embedding_identity_attrs(embedding),
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            identity_payload,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return AnnouncementEmbeddingStrategy(
+        strategy_type=strategy_type,
+        adapter_ref=adapter_ref,
+        model_ref=model_ref,
+        model_version=model_version,
+        model_dimension=model_dimension,
+        model_fingerprint=fingerprint,
+    )
+
+
+def _embedding_strategy_type(
+    *,
+    config: AnnouncementConfig | None,
+    embed_model: Any | None,
+) -> str:
+    if embed_model is not None:
+        return "injected"
+    if config is not None and config.retrieval_embedding_adapter is not None:
+        return "adapter"
+    return "test_mock"
+
+
+def _validate_embedding_strategy(
+    *,
+    expected: AnnouncementEmbeddingStrategy,
+    actual: AnnouncementEmbeddingStrategy,
+) -> None:
+    if expected == actual:
+        return
+    raise RuntimeError(
+        "Retrieval embedding strategy mismatch: index was built with "
+        f"{_describe_embedding_strategy(expected)}, but query is configured with "
+        f"{_describe_embedding_strategy(actual)}. Rebuild the retrieval artifact "
+        "or query it with the same embedding adapter/model."
+    )
+
+
+def _describe_embedding_strategy(strategy: AnnouncementEmbeddingStrategy) -> str:
+    adapter = f" adapter={strategy.adapter_ref!r}" if strategy.adapter_ref else ""
+    version = f" version={strategy.model_version!r}" if strategy.model_version else ""
+    dimension = (
+        f" dimension={strategy.model_dimension}"
+        if strategy.model_dimension is not None
+        else ""
+    )
+    return (
+        f"type={strategy.strategy_type!r}{adapter} model={strategy.model_ref!r}"
+        f"{version}{dimension} fingerprint={strategy.model_fingerprint[:12]}"
+    )
+
+
+def _model_ref(value: Any) -> str:
+    model_type = type(value)
+    return f"{model_type.__module__}.{model_type.__qualname__}"
+
+
+def _embedding_identity_attrs(value: Any) -> dict[str, str | int | float | bool | None]:
+    attrs: dict[str, str | int | float | bool | None] = {}
+    for name in (
+        "model_name",
+        "model",
+        "model_id",
+        "model_version",
+        "version",
+        "revision",
+        "__version__",
+        "embed_dim",
+        "embedding_dim",
+        "dimensions",
+        "dimension",
+    ):
+        attr_value = _safe_getattr(value, name)
+        if isinstance(attr_value, str | int | float | bool) or attr_value is None:
+            attrs[name] = attr_value
+    return attrs
+
+
+def _string_identity_attr(value: Any, names: tuple[str, ...]) -> str | None:
+    for name in names:
+        attr_value = _safe_getattr(value, name)
+        if isinstance(attr_value, str) and attr_value.strip():
+            return attr_value.strip()
+    return None
+
+
+def _int_identity_attr(value: Any, names: tuple[str, ...]) -> int | None:
+    for name in names:
+        attr_value = _safe_getattr(value, name)
+        if isinstance(attr_value, bool):
+            continue
+        if isinstance(attr_value, int) and attr_value > 0:
+            return attr_value
+    return None
+
+
+def _safe_getattr(value: Any, name: str) -> Any:
+    try:
+        return getattr(value, name)
+    except Exception:
+        return None
 
 
 def _try_load_settings() -> Any | None:

--- a/src/subsystem_announcement/index/vector_store.py
+++ b/src/subsystem_announcement/index/vector_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -60,7 +61,7 @@ def build_vector_index(
 
     llama_index_version = resolve_llama_index_version(config.llama_index_version)
     api = _load_llama_index_api()
-    embedding = embed_model if embed_model is not None else _default_embed_model()
+    embedding = _resolve_embed_model(config=config, embed_model=embed_model)
     documents = [_document_from_chunk(api.Document, chunk) for chunk in chunks]
     vector_store = api.SimpleVectorStore()
     storage_context = api.StorageContext.from_defaults(vector_store=vector_store)
@@ -90,13 +91,14 @@ def load_vector_index(
     *,
     persist_dir: Path,
     llama_index_version: str,
+    config: AnnouncementConfig | None = None,
     embed_model: Any | None = None,
 ) -> Any:
     """Load a persisted LlamaIndex vector index for retrieval."""
 
     resolve_llama_index_version(llama_index_version)
     api = _load_llama_index_api()
-    embedding = embed_model if embed_model is not None else _default_embed_model()
+    embedding = _resolve_embed_model(config=config, embed_model=embed_model)
     storage_context = api.StorageContext.from_defaults(persist_dir=str(persist_dir))
     try:
         return api.load_index_from_storage(
@@ -251,7 +253,77 @@ def _load_llama_index_api() -> _LlamaIndexApi:
     )
 
 
-def _default_embed_model() -> Any:
+def _resolve_embed_model(
+    *,
+    config: AnnouncementConfig | None,
+    embed_model: Any | None,
+) -> Any:
+    if embed_model is not None:
+        return embed_model
+    if config is not None and config.retrieval_embedding_adapter is not None:
+        return _load_embedding_adapter(config.retrieval_embedding_adapter)
+    if config is not None and config.allow_test_mock_embeddings:
+        return _mock_embed_model()
+    raise RuntimeError(
+        "Retrieval embedding model is not configured. Set "
+        "AnnouncementConfig.retrieval_embedding_adapter to a module:attribute "
+        "adapter, pass embed_model explicitly, or set "
+        "allow_test_mock_embeddings=True only in tests."
+    )
+
+
+def _load_embedding_adapter(adapter_ref: str) -> Any:
+    module_name, object_path = adapter_ref.split(":", 1)
+    try:
+        module = importlib.import_module(module_name)
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise RuntimeError(
+            "Unable to import retrieval embedding adapter module "
+            f"{module_name!r}."
+        ) from exc
+
+    adapter: Any = module
+    try:
+        for name in object_path.split("."):
+            adapter = getattr(adapter, name)
+    except AttributeError as exc:
+        raise RuntimeError(
+            "Unable to resolve retrieval embedding adapter object "
+            f"{adapter_ref!r}."
+        ) from exc
+
+    if isinstance(adapter, type) or (
+        callable(adapter) and not _looks_like_embedding_model(adapter)
+    ):
+        try:
+            adapter = adapter()
+        except TypeError as exc:
+            raise RuntimeError(
+                "Retrieval embedding adapter factory must be callable without "
+                f"arguments: {adapter_ref!r}."
+            ) from exc
+
+    if adapter is None:
+        raise RuntimeError(
+            "Retrieval embedding adapter resolved to None: "
+            f"{adapter_ref!r}."
+        )
+    return adapter
+
+
+def _looks_like_embedding_model(value: Any) -> bool:
+    return any(
+        hasattr(value, name)
+        for name in (
+            "get_text_embedding",
+            "get_query_embedding",
+            "_get_text_embedding",
+            "_get_query_embedding",
+        )
+    )
+
+
+def _mock_embed_model() -> Any:
     try:
         from llama_index.core.embeddings.mock_embed_model import (  # type: ignore[import-not-found]
             MockEmbedding,

--- a/tests/test_index_retrieval_artifact.py
+++ b/tests/test_index_retrieval_artifact.py
@@ -13,6 +13,7 @@ from subsystem_announcement.discovery import (
 )
 from subsystem_announcement.discovery.document import AnnouncementDocumentArtifact
 from subsystem_announcement.index.retrieval_artifact import (
+    AnnouncementEmbeddingStrategy,
     AnnouncementRetrievalArtifact,
     build_retrieval_artifact,
     load_retrieval_artifact,
@@ -37,6 +38,7 @@ def test_retrieval_artifact_builds_and_round_trips(
         return AnnouncementVectorIndexRef(
             index_ref=str(persist_dir),
             llama_index_version=config.llama_index_version,
+            embedding_strategy=_embedding_strategy(),
             chunk_ids=[chunk.chunk_id for chunk in chunks],
             built_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
         )
@@ -64,6 +66,7 @@ def test_retrieval_artifact_builds_and_round_trips(
     assert loaded.chunk_count == 3
     assert loaded.chunk_refs == [chunk.chunk_id for chunk in loaded.chunks]
     assert loaded.index_ref == str(tmp_path / "index-output" / "vector_store")
+    assert loaded.embedding_strategy == _embedding_strategy()
 
 
 @pytest.mark.parametrize(
@@ -149,6 +152,7 @@ def test_retrieval_artifact_rejects_inconsistent_chunk_refs(
             index_ref=str(tmp_path / "index"),
             parser_version=parsed_artifact.parser_version,
             llama_index_version="llama-index-core==0.10.0",
+            embedding_strategy=_embedding_strategy(),
             chunk_count=1,
             built_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
             source_parsed_artifact_path=None,
@@ -169,6 +173,7 @@ def test_retrieval_artifact_accepts_external_chunk_refs_without_inline_chunks(
         index_ref=str(tmp_path / "index"),
         parser_version="docling==2.15.1",
         llama_index_version="llama-index-core==0.10.0",
+        embedding_strategy=_embedding_strategy(),
         chunk_count=1,
         built_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
         source_parsed_artifact_path=None,
@@ -189,6 +194,7 @@ def test_pipeline_process_envelope_records_retrieval_artifact(
         return AnnouncementVectorIndexRef(
             index_ref=str(persist_dir),
             llama_index_version=config.llama_index_version,
+            embedding_strategy=_embedding_strategy(),
             chunk_ids=[chunk.chunk_id for chunk in chunks],
             built_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
         )
@@ -274,6 +280,17 @@ def _envelope() -> AnnouncementEnvelope:
         official_url="https://static.sse.com.cn/disclosure/ann-index-1.pdf",
         source_exchange="sse",
         attachment_type="pdf",
+    )
+
+
+def _embedding_strategy() -> AnnouncementEmbeddingStrategy:
+    return AnnouncementEmbeddingStrategy(
+        strategy_type="adapter",
+        adapter_ref="tests.fixtures:embedding",
+        model_ref="tests.fixtures.Embedding",
+        model_version="fixture-v1",
+        model_dimension=2,
+        model_fingerprint="fixture-fingerprint",
     )
 
 

--- a/tests/test_index_vector_store.py
+++ b/tests/test_index_vector_store.py
@@ -11,7 +11,10 @@ import pytest
 import subsystem_announcement.index.vector_store as vector_store
 from subsystem_announcement.config import AnnouncementConfig
 from subsystem_announcement.index import chunk_parsed_artifact
-from subsystem_announcement.index.retrieval_artifact import AnnouncementRetrievalArtifact
+from subsystem_announcement.index.retrieval_artifact import (
+    AnnouncementChunk,
+    AnnouncementRetrievalArtifact,
+)
 from subsystem_announcement.index.sample_query import query
 from subsystem_announcement.index.vector_store import build_vector_index
 
@@ -24,7 +27,10 @@ def test_build_vector_index_persists_simple_vector_store(
 ) -> None:
     installed = _install_fake_llama_index(monkeypatch)
     chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
-    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+    config = AnnouncementConfig(
+        llama_index_version="llama-index-core==0.10.0",
+        allow_test_mock_embeddings=True,
+    )
 
     ref = build_vector_index(
         chunks,
@@ -45,7 +51,10 @@ def test_query_returns_section_and_table_keyword_hits(
 ) -> None:
     _install_fake_llama_index(monkeypatch)
     chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
-    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+    config = AnnouncementConfig(
+        llama_index_version="llama-index-core==0.10.0",
+        allow_test_mock_embeddings=True,
+    )
     index_ref = build_vector_index(
         chunks,
         persist_dir=tmp_path / "vector-store",
@@ -63,13 +72,101 @@ def test_query_returns_section_and_table_keyword_hits(
         chunks=chunks,
     )
 
-    section_hits = query("风险提示", artifact, top_k=1)
-    table_hits = query("1000万元", artifact, top_k=1)
+    section_hits = query("风险提示", artifact, top_k=1, config=config)
+    table_hits = query("1000万元", artifact, top_k=1, config=config)
 
     assert section_hits[0].section_id == "sec-0002"
     assert section_hits[0].table_ref is None
     assert table_hits[0].table_ref == "tbl-0001"
     assert table_hits[0].metadata["chunk_type"] == "table"
+
+
+def test_build_vector_index_rejects_implicit_mock_embeddings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_llama_index(monkeypatch)
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+
+    with pytest.raises(RuntimeError, match="retrieval_embedding_adapter"):
+        build_vector_index(
+            chunks,
+            persist_dir=tmp_path / "vector-store",
+            config=config,
+        )
+
+
+def test_build_vector_index_uses_configured_embedding_adapter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installed = _install_fake_llama_index(monkeypatch)
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+    embedding = FakeSemanticEmbedding()
+    adapter_module = types.ModuleType("fake_embedding_adapter")
+    adapter_module.build_embedding = lambda: embedding
+    monkeypatch.setitem(sys.modules, "fake_embedding_adapter", adapter_module)
+    config = AnnouncementConfig(
+        llama_index_version="llama-index-core==0.10.0",
+        retrieval_embedding_adapter="fake_embedding_adapter:build_embedding",
+    )
+
+    build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+    )
+
+    assert installed["build_embed_models"] == [embedding]
+
+
+def test_query_uses_semantic_vectors_without_exact_word_overlap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_llama_index(monkeypatch)
+    embedding = FakeSemanticEmbedding()
+    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+    chunks = [
+        _chunk(
+            "chunk:ann-semantic:sec-0001:section:dividend",
+            "sec-0001",
+            "公司完成现金分红方案实施，权益分派已办理完毕。",
+        ),
+        _chunk(
+            "chunk:ann-semantic:sec-0002:section:inquiry",
+            "sec-0002",
+            "公司收到上海证券交易所监管问询函，将按要求及时回复。",
+        ),
+    ]
+    index_ref = build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+        embed_model=embedding,
+    )
+    artifact = AnnouncementRetrievalArtifact(
+        announcement_id="ann-semantic",
+        chunk_refs=[chunk.chunk_id for chunk in chunks],
+        index_ref=index_ref.index_ref,
+        parser_version="docling==2.15.1",
+        llama_index_version=index_ref.llama_index_version,
+        chunk_count=len(chunks),
+        built_at=index_ref.built_at,
+        source_parsed_artifact_path=None,
+        chunks=chunks,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Retrieval embedding model is not configured",
+    ):
+        query("交易所关注函", artifact, top_k=1)
+
+    assert "交易所关注函" not in chunks[1].text
+    hits = query("交易所关注函", artifact, top_k=1, embed_model=embedding)
+    assert hits[0].chunk_id == chunks[1].chunk_id
 
 
 def test_build_vector_index_rejects_unconfigured_llama_index(
@@ -90,7 +187,10 @@ def test_build_vector_index_reports_missing_llama_index_dependency(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
-    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+    config = AnnouncementConfig(
+        llama_index_version="llama-index-core==0.10.0",
+        allow_test_mock_embeddings=True,
+    )
     monkeypatch.setattr(
         vector_store.metadata,
         "version",
@@ -106,8 +206,36 @@ def test_build_vector_index_reports_missing_llama_index_dependency(
         )
 
 
-def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
-    calls = {"docling_parser_calls": 0}
+class FakeSemanticEmbedding:
+    def embed(self, text: str) -> list[float]:
+        if "交易所关注函" in text or "监管问询函" in text:
+            return [1.0, 0.0]
+        if "分红" in text:
+            return [0.0, 1.0]
+        return [0.0, 0.0]
+
+
+def _chunk(chunk_id: str, section_id: str, text: str) -> AnnouncementChunk:
+    return AnnouncementChunk(
+        chunk_id=chunk_id,
+        announcement_id="ann-semantic",
+        chunk_type="section",
+        section_id=section_id,
+        table_ref=None,
+        text=text,
+        start_offset=0,
+        end_offset=len(text),
+        title_path=["测试公告"],
+        source_reference={"official_url": "https://example.test/ann-semantic.pdf"},
+    )
+
+
+def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    calls: dict[str, Any] = {
+        "docling_parser_calls": 0,
+        "build_embed_models": [],
+        "load_embed_models": [],
+    }
 
     class FakeDocument:
         def __init__(self, *, text: str, metadata: dict[str, Any]) -> None:
@@ -130,6 +258,7 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]
             self.vector_store = vector_store
             self.persist_dir = persist_dir
             self.documents: list[FakeDocument] = []
+            self.embeddings: list[list[float]] = []
             if persist_dir is not None:
                 index_path = Path(persist_dir) / "fake_vector_index.json"
                 data = json.loads(index_path.read_text(encoding="utf-8"))
@@ -137,6 +266,7 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]
                     FakeDocument(text=item["text"], metadata=item["metadata"])
                     for item in data["documents"]
                 ]
+                self.embeddings = data.get("embeddings", [])
 
         @classmethod
         def from_defaults(cls, **kwargs):
@@ -149,7 +279,8 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]
                 "documents": [
                     {"text": document.text, "metadata": document.metadata}
                     for document in self.documents
-                ]
+                ],
+                "embeddings": self.embeddings,
             }
             (output_dir / "fake_vector_index.json").write_text(
                 json.dumps(payload, ensure_ascii=False),
@@ -165,10 +296,18 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]
             self,
             documents: list[FakeDocument],
             storage_context: FakeStorageContext,
+            *,
+            embed_model: Any,
+            embeddings: list[list[float]] | None = None,
         ) -> None:
             self.documents = documents
             self.storage_context = storage_context
             self.storage_context.documents = documents
+            self.embed_model = embed_model
+            self.embeddings = embeddings or [
+                _embed(embed_model, document.text) for document in documents
+            ]
+            self.storage_context.embeddings = self.embeddings
 
         @classmethod
         def from_documents(
@@ -182,17 +321,46 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]
             assert transformations
             assert isinstance(transformations[0], FakeDoclingNodeParser)
             assert embed_model is not None
-            return cls(list(documents), storage_context)
+            calls["build_embed_models"].append(embed_model)
+            return cls(list(documents), storage_context, embed_model=embed_model)
 
         def as_retriever(self, *, similarity_top_k: int):
-            return FakeRetriever(self.documents, similarity_top_k)
+            return FakeRetriever(
+                self.documents,
+                self.embeddings,
+                self.embed_model,
+                similarity_top_k,
+            )
 
     class FakeRetriever:
-        def __init__(self, documents, top_k: int) -> None:
+        def __init__(
+            self,
+            documents,
+            embeddings: list[list[float]],
+            embed_model: Any,
+            top_k: int,
+        ) -> None:
             self.documents = documents
+            self.embeddings = embeddings
+            self.embed_model = embed_model
             self.top_k = top_k
 
         def retrieve(self, text: str):
+            query_embedding = _embed(self.embed_model, text)
+            if query_embedding and any(self.embeddings):
+                ranked_with_scores = sorted(
+                    zip(self.documents, self.embeddings, strict=True),
+                    key=lambda item: _dot(query_embedding, item[1]),
+                    reverse=True,
+                )
+                return [
+                    types.SimpleNamespace(
+                        node=document,
+                        score=_dot(query_embedding, embedding),
+                    )
+                    for document, embedding in ranked_with_scores[: self.top_k]
+                ]
+
             ranked = sorted(
                 self.documents,
                 key=lambda document: text in document.text,
@@ -212,7 +380,13 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]
 
     def fake_load_index_from_storage(storage_context, embed_model=None):
         assert embed_model is not None
-        return FakeVectorStoreIndex(storage_context.documents, storage_context)
+        calls["load_embed_models"].append(embed_model)
+        return FakeVectorStoreIndex(
+            storage_context.documents,
+            storage_context,
+            embed_model=embed_model,
+            embeddings=storage_context.embeddings,
+        )
 
     llama_index_module = types.ModuleType("llama_index")
     llama_index_module.__path__ = []
@@ -259,3 +433,14 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]
         lambda package_name: "0.10.0",
     )
     return calls
+
+
+def _embed(embed_model: Any, text: str) -> list[float]:
+    embed = getattr(embed_model, "embed", None)
+    if embed is None:
+        return []
+    return list(embed(text))
+
+
+def _dot(left: list[float], right: list[float]) -> float:
+    return sum(a * b for a, b in zip(left, right, strict=False))

--- a/tests/test_index_vector_store.py
+++ b/tests/test_index_vector_store.py
@@ -13,6 +13,7 @@ from subsystem_announcement.config import AnnouncementConfig
 from subsystem_announcement.index import chunk_parsed_artifact
 from subsystem_announcement.index.retrieval_artifact import (
     AnnouncementChunk,
+    AnnouncementEmbeddingStrategy,
     AnnouncementRetrievalArtifact,
 )
 from subsystem_announcement.index.sample_query import query
@@ -40,6 +41,8 @@ def test_build_vector_index_persists_simple_vector_store(
 
     assert ref.index_ref == str(tmp_path / "vector-store")
     assert ref.llama_index_version == "llama-index-core==0.10.0"
+    assert ref.embedding_strategy.strategy_type == "test_mock"
+    assert ref.embedding_strategy.model_dimension == 384
     assert ref.chunk_ids == [chunk.chunk_id for chunk in chunks]
     assert (tmp_path / "vector-store" / "fake_vector_index.json").exists()
     assert installed["docling_parser_calls"] == 1
@@ -66,6 +69,7 @@ def test_query_returns_section_and_table_keyword_hits(
         index_ref=index_ref.index_ref,
         parser_version="docling==2.15.1",
         llama_index_version=index_ref.llama_index_version,
+        embedding_strategy=index_ref.embedding_strategy,
         chunk_count=len(chunks),
         built_at=index_ref.built_at,
         source_parsed_artifact_path=None,
@@ -121,6 +125,42 @@ def test_build_vector_index_uses_configured_embedding_adapter(
     assert installed["build_embed_models"] == [embedding]
 
 
+def test_build_vector_index_records_configured_embedding_strategy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_llama_index(monkeypatch)
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+    embedding = FakeSemanticEmbedding()
+    embedding.model_version = "semantic-fixture-v1"
+    adapter_module = types.ModuleType("versioned_embedding_adapter")
+    adapter_module.build_embedding = lambda: embedding
+    monkeypatch.setitem(sys.modules, "versioned_embedding_adapter", adapter_module)
+    config = AnnouncementConfig(
+        llama_index_version="llama-index-core==0.10.0",
+        retrieval_embedding_adapter="versioned_embedding_adapter:build_embedding",
+    )
+
+    ref = build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+    )
+
+    assert ref.embedding_strategy == AnnouncementEmbeddingStrategy(
+        strategy_type="adapter",
+        adapter_ref="versioned_embedding_adapter:build_embedding",
+        model_ref=(
+            f"{FakeSemanticEmbedding.__module__}."
+            f"{FakeSemanticEmbedding.__qualname__}"
+        ),
+        model_version="semantic-fixture-v1",
+        model_dimension=None,
+        model_fingerprint=ref.embedding_strategy.model_fingerprint,
+    )
+    assert len(ref.embedding_strategy.model_fingerprint) == 64
+
+
 def test_query_uses_semantic_vectors_without_exact_word_overlap(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -137,7 +177,8 @@ def test_query_uses_semantic_vectors_without_exact_word_overlap(
         _chunk(
             "chunk:ann-semantic:sec-0002:section:inquiry",
             "sec-0002",
-            "公司收到上海证券交易所监管问询函，将按要求及时回复。",
+            "公司收到上海证券交易所监管问询函，"
+            "将按要求及时回复。",
         ),
     ]
     index_ref = build_vector_index(
@@ -152,6 +193,7 @@ def test_query_uses_semantic_vectors_without_exact_word_overlap(
         index_ref=index_ref.index_ref,
         parser_version="docling==2.15.1",
         llama_index_version=index_ref.llama_index_version,
+        embedding_strategy=index_ref.embedding_strategy,
         chunk_count=len(chunks),
         built_at=index_ref.built_at,
         source_parsed_artifact_path=None,
@@ -167,6 +209,97 @@ def test_query_uses_semantic_vectors_without_exact_word_overlap(
     assert "交易所关注函" not in chunks[1].text
     hits = query("交易所关注函", artifact, top_k=1, embed_model=embedding)
     assert hits[0].chunk_id == chunks[1].chunk_id
+
+
+def test_query_semantic_hit_beats_lexical_only_distractor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_llama_index(monkeypatch)
+    embedding = FakeSemanticEmbedding()
+    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+    chunks = [
+        _chunk(
+            "chunk:ann-semantic:sec-0001:section:lexical-distractor",
+            "sec-0001",
+            "术语说明：交易所关注函一词出现在历史背景介绍中。",
+        ),
+        _chunk(
+            "chunk:ann-semantic:sec-0002:section:semantic-match",
+            "sec-0002",
+            "公司收到上海证券交易所监管问询函，"
+            "将按要求及时回复。",
+        ),
+    ]
+    index_ref = build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+        embed_model=embedding,
+    )
+    artifact = AnnouncementRetrievalArtifact(
+        announcement_id="ann-semantic",
+        chunk_refs=[chunk.chunk_id for chunk in chunks],
+        index_ref=index_ref.index_ref,
+        parser_version="docling==2.15.1",
+        llama_index_version=index_ref.llama_index_version,
+        embedding_strategy=index_ref.embedding_strategy,
+        chunk_count=len(chunks),
+        built_at=index_ref.built_at,
+        source_parsed_artifact_path=None,
+        chunks=chunks,
+    )
+
+    hits = query("交易所关注函", artifact, top_k=1, embed_model=embedding)
+
+    assert hits[0].chunk_id == chunks[1].chunk_id
+    assert "交易所关注函" not in chunks[1].text
+
+
+def test_query_rejects_embedding_strategy_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_llama_index(monkeypatch)
+    embedding = FakeSemanticEmbedding()
+    config = AnnouncementConfig(llama_index_version="llama-index-core==0.10.0")
+    chunks = [
+        _chunk(
+            "chunk:ann-semantic:sec-0001:section:inquiry",
+            "sec-0001",
+            "公司收到上海证券交易所监管问询函，"
+            "将按要求及时回复。",
+        )
+    ]
+    index_ref = build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+        embed_model=embedding,
+    )
+    artifact = AnnouncementRetrievalArtifact(
+        announcement_id="ann-semantic",
+        chunk_refs=[chunk.chunk_id for chunk in chunks],
+        index_ref=index_ref.index_ref,
+        parser_version="docling==2.15.1",
+        llama_index_version=index_ref.llama_index_version,
+        embedding_strategy=index_ref.embedding_strategy,
+        chunk_count=len(chunks),
+        built_at=index_ref.built_at,
+        source_parsed_artifact_path=None,
+        chunks=chunks,
+    )
+
+    with pytest.raises(RuntimeError, match="embedding strategy mismatch"):
+        query(
+            "交易所关注函",
+            artifact,
+            top_k=1,
+            config=AnnouncementConfig(
+                llama_index_version="llama-index-core==0.10.0",
+                allow_test_mock_embeddings=True,
+            ),
+        )
 
 
 def test_build_vector_index_rejects_unconfigured_llama_index(
@@ -208,6 +341,8 @@ def test_build_vector_index_reports_missing_llama_index_dependency(
 
 class FakeSemanticEmbedding:
     def embed(self, text: str) -> list[float]:
+        if "术语说明" in text:
+            return [0.0, 1.0]
         if "交易所关注函" in text or "监管问询函" in text:
             return [1.0, 0.0]
         if "分红" in text:

--- a/tests/test_metrics_regression.py
+++ b/tests/test_metrics_regression.py
@@ -9,6 +9,9 @@ from subsystem_announcement.discovery.document import AnnouncementDocumentArtifa
 from subsystem_announcement.extract import extract_fact_candidates
 from subsystem_announcement.graph import derive_graph_delta_candidates
 from subsystem_announcement.index import AnnouncementRetrievalArtifact
+from subsystem_announcement.index.retrieval_artifact import (
+    AnnouncementEmbeddingStrategy,
+)
 from subsystem_announcement.parse.artifact import ParsedAnnouncementArtifact
 from subsystem_announcement.runtime.metrics import (
     MetricThresholds,
@@ -297,7 +300,19 @@ def _fixture_build_retrieval(
         index_ref=str((output_root or Path(config.artifact_root)) / "vector_store"),
         parser_version=parsed_artifact.parser_version,
         llama_index_version=config.llama_index_version,
+        embedding_strategy=_embedding_strategy(),
         chunk_count=1,
         built_at=parsed_artifact.parsed_at,
         source_parsed_artifact_path=parsed_artifact_path,
+    )
+
+
+def _embedding_strategy() -> AnnouncementEmbeddingStrategy:
+    return AnnouncementEmbeddingStrategy(
+        strategy_type="adapter",
+        adapter_ref="tests.fixtures:embedding",
+        model_ref="tests.fixtures.Embedding",
+        model_version="fixture-v1",
+        model_dimension=2,
+        model_fingerprint="fixture-fingerprint",
     )

--- a/tests/test_replay_repair.py
+++ b/tests/test_replay_repair.py
@@ -17,6 +17,9 @@ from subsystem_announcement.extract import (
     FactType,
 )
 from subsystem_announcement.index import AnnouncementRetrievalArtifact
+from subsystem_announcement.index.retrieval_artifact import (
+    AnnouncementEmbeddingStrategy,
+)
 from subsystem_announcement.parse.artifact import (
     ParsedAnnouncementArtifact,
     load_parsed_artifact,
@@ -426,9 +429,21 @@ def _fake_rebuild_index(
         index_ref=str(Path(config.artifact_root) / "index" / "fake"),
         parser_version=parsed_artifact.parser_version,
         llama_index_version=config.llama_index_version,
+        embedding_strategy=_embedding_strategy(),
         chunk_count=1,
         built_at=_timestamp(),
         source_parsed_artifact_path=parsed_artifact_path,
+    )
+
+
+def _embedding_strategy() -> AnnouncementEmbeddingStrategy:
+    return AnnouncementEmbeddingStrategy(
+        strategy_type="adapter",
+        adapter_ref="tests.fixtures:embedding",
+        model_ref="tests.fixtures.Embedding",
+        model_version="fixture-v1",
+        model_dimension=2,
+        model_fingerprint="fixture-fingerprint",
     )
 
 


### PR DESCRIPTION
Closes #31

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/graph/candidates.py`, `src/subsystem_announcement/graph/deltas.py`, `src/subsystem_announcement/index/vector_store.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/runtime/metrics.py`, `src/subsystem_announcement/runtime/replay.py`, `src/subsystem_announcement/signals/classifier.py`


---
## 背景与目标
Milestone review for milestone-3 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
build_vector_index falls back to _default_embed_model when no embed_model is supplied, and that default is LlamaIndex MockEmbedding. Mock embeddings make the persisted vector index deterministic for tests, but they do not provide meaningful semantic retrieval. The query path then mostly depends on exact lexical overlap, so the implementation does not satisfy the stated section/event semantic retrieval goal.

## 实现范围
- 修改文件: `src/subsystem_announcement/index/vector_store.py`
- Make the embedding strategy explicit in AnnouncementConfig. Use a real approved local embedding model or a configured embedding adapter for production/offline indexing, and reserve MockEmbedding for tests through an explicit test flag or injected embed_model. Add a regression query where the query and relevant chunk use different wording so exact lexical matching cannot pass by itself.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/subsystem-announcement/.venv/bin/python -m pytest
```
