### PR TITLE
feat(#30): [milestone-3 review] P0: Retrieval artifact is not integrated into the runtime pipeline

### DIFF
--- a/src/subsystem_announcement/runtime/pipeline.py
+++ b/src/subsystem_announcement/runtime/pipeline.py
@@ -31,6 +31,11 @@ from subsystem_announcement.graph import (
     GraphFunc,
     derive_graph_delta_candidates,
 )
+from subsystem_announcement.index import (
+    AnnouncementRetrievalArtifact,
+    build_retrieval_artifact,
+    write_retrieval_artifact,
+)
 from subsystem_announcement.parse import ParsedAnnouncementArtifact, parse_announcement
 from subsystem_announcement.parse.artifact import write_parsed_artifact
 from subsystem_announcement.signals import (
@@ -68,6 +73,10 @@ ExtractFunc = Callable[
     ...,
     Sequence[AnnouncementFactCandidate] | Awaitable[Sequence[AnnouncementFactCandidate]],
 ]
+BuildRetrievalFunc = Callable[
+    ...,
+    AnnouncementRetrievalArtifact | Awaitable[AnnouncementRetrievalArtifact],
+]
 
 
 class AnnouncementPipeline:
@@ -80,6 +89,7 @@ class AnnouncementPipeline:
         subsystem: AnnouncementSubsystem | None = None,
         discovery_func: DiscoveryFunc = consume_announcement_ref,
         parse_func: ParseFunc = parse_announcement,
+        build_retrieval_func: BuildRetrievalFunc = build_retrieval_artifact,
         extract_func: ExtractFunc = extract_fact_candidates,
         signal_func: SignalFunc = derive_signal_candidates,
         graph_func: GraphFunc = derive_graph_delta_candidates,
@@ -90,6 +100,7 @@ class AnnouncementPipeline:
         self._subsystem = subsystem
         self._discovery_func = discovery_func
         self._parse_func = parse_func
+        self._build_retrieval_func = build_retrieval_func
         self._extract_func = extract_func
         self._signal_func = signal_func
         self._graph_func = graph_func
@@ -120,6 +131,21 @@ class AnnouncementPipeline:
                 parsed_artifact,
                 self.config.artifact_root,
             )
+            run.index_build_status = "running"
+            try:
+                retrieval_artifact = await self._call_build_retrieval(
+                    parsed_artifact,
+                    run.parsed_artifact_path,
+                )
+                run.retrieval_artifact_path = write_retrieval_artifact(
+                    retrieval_artifact,
+                    Path(self.config.artifact_root)
+                    / "index"
+                    / parsed_artifact.announcement_id,
+                )
+                run.index_build_status = "succeeded"
+            except RuntimeError:
+                run.index_build_status = "pending"
 
             facts = list(await self._call_extract(parsed_artifact))
             signals = list(await self._call_signals(facts))
@@ -147,6 +173,8 @@ class AnnouncementPipeline:
             )
         except Exception as exc:
             run.status = "failed"
+            if run.index_build_status == "running":
+                run.index_build_status = "failed"
             run.errors.append(
                 RunTraceError(stage=_stage_for_run(run), message=str(exc))
             )
@@ -166,6 +194,19 @@ class AnnouncementPipeline:
         document: AnnouncementDocumentArtifact,
     ) -> ParsedAnnouncementArtifact:
         return await _maybe_await(self._parse_func(document, self.config))
+
+    async def _call_build_retrieval(
+        self,
+        artifact: ParsedAnnouncementArtifact,
+        parsed_artifact_path: Path,
+    ) -> AnnouncementRetrievalArtifact:
+        return await _maybe_await(
+            self._build_retrieval_func(
+                artifact,
+                config=self.config,
+                parsed_artifact_path=parsed_artifact_path,
+            )
+        )
 
     async def _call_extract(
         self,
@@ -438,6 +479,8 @@ def _stage_for_run(run: AnnouncementExtractionRun) -> str:
         return "discovery"
     if run.parsed_artifact_path is None:
         return "parse"
+    if run.index_build_status in {"running", "failed"}:
+        return "index"
     if run.candidate_count == 0 and not run.candidate_traces:
         return "extract"
     return "submit"

--- a/src/subsystem_announcement/runtime/replay.py
+++ b/src/subsystem_announcement/runtime/replay.py
@@ -155,8 +155,12 @@ async def replay_announcement(
         trace_store=trace_store,
     )
     run = await pipeline.process_envelope(envelope)
-    retrieval_artifact_path = None
-    if request.rebuild_index and run.parsed_artifact_path is not None:
+    retrieval_artifact_path = run.retrieval_artifact_path
+    if (
+        request.rebuild_index
+        and retrieval_artifact_path is None
+        and run.parsed_artifact_path is not None
+    ):
         retrieval_artifact_path = await _rebuild_index(
             run.parsed_artifact_path,
             config=config,

--- a/src/subsystem_announcement/runtime/trace.py
+++ b/src/subsystem_announcement/runtime/trace.py
@@ -52,6 +52,14 @@ class AnnouncementExtractionRun(BaseModel):
     finished_at: datetime | None = None
     document_artifact_path: Path | None = None
     parsed_artifact_path: Path | None = None
+    retrieval_artifact_path: Path | None = None
+    index_build_status: Literal[
+        "not_started",
+        "running",
+        "succeeded",
+        "failed",
+        "pending",
+    ] = "not_started"
     candidate_count: int = Field(default=0, ge=0)
     submit_success_count: int = Field(default=0, ge=0)
     submit_duplicate_count: int = Field(default=0, ge=0)

--- a/tests/test_index_retrieval_artifact.py
+++ b/tests/test_index_retrieval_artifact.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-import inspect
+import asyncio
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from subsystem_announcement.config import AnnouncementConfig
+from subsystem_announcement.discovery import (
+    AnnouncementDiscoveryResult,
+    AnnouncementEnvelope,
+)
+from subsystem_announcement.discovery.document import AnnouncementDocumentArtifact
 from subsystem_announcement.index.retrieval_artifact import (
     AnnouncementRetrievalArtifact,
     build_retrieval_artifact,
@@ -14,7 +19,9 @@ from subsystem_announcement.index.retrieval_artifact import (
     write_retrieval_artifact,
 )
 from subsystem_announcement.index.vector_store import AnnouncementVectorIndexRef
+from subsystem_announcement.parse import ParsedAnnouncementArtifact
 from subsystem_announcement.runtime.pipeline import AnnouncementPipeline
+from subsystem_announcement.runtime.trace import TraceStore
 
 from .test_index_chunker import make_index_artifact
 
@@ -170,7 +177,139 @@ def test_retrieval_artifact_accepts_external_chunk_refs_without_inline_chunks(
     assert artifact.chunks == []
 
 
-def test_pipeline_process_envelope_does_not_build_retrieval_index() -> None:
-    source = inspect.getsource(AnnouncementPipeline.process_envelope)
+def test_pipeline_process_envelope_records_retrieval_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vector_calls: list[list[str]] = []
 
-    assert "build_retrieval_artifact" not in source
+    def fake_build_vector_index(chunks, *, persist_dir, config, embed_model=None):
+        persist_dir.mkdir(parents=True, exist_ok=True)
+        vector_calls.append([chunk.chunk_id for chunk in chunks])
+        return AnnouncementVectorIndexRef(
+            index_ref=str(persist_dir),
+            llama_index_version=config.llama_index_version,
+            chunk_ids=[chunk.chunk_id for chunk in chunks],
+            built_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
+        )
+
+    monkeypatch.setattr(
+        "subsystem_announcement.index.vector_store.build_vector_index",
+        fake_build_vector_index,
+    )
+    config = AnnouncementConfig(
+        artifact_root=tmp_path / "artifacts",
+        docling_version="docling==2.15.1",
+        llama_index_version="llama-index-core==0.10.0",
+    )
+    pipeline = AnnouncementPipeline(
+        config,
+        discovery_func=_fake_discovery,
+        parse_func=_fake_parse,
+        extract_func=lambda artifact: [],
+    )
+
+    run = asyncio.run(pipeline.process_envelope(_envelope()))
+
+    assert run.status == "succeeded"
+    assert run.parsed_artifact_path is not None
+    assert run.parsed_artifact_path.exists()
+    assert run.index_build_status == "succeeded"
+    assert run.retrieval_artifact_path == (
+        tmp_path / "artifacts" / "index" / "ann-index-1" / "retrieval_artifact.json"
+    )
+    assert run.retrieval_artifact_path.exists()
+    assert vector_calls
+
+    retrieval_artifact = load_retrieval_artifact(run.retrieval_artifact_path)
+    assert retrieval_artifact.announcement_id == "ann-index-1"
+    assert retrieval_artifact.source_parsed_artifact_path == run.parsed_artifact_path
+    assert retrieval_artifact.chunk_count == 3
+    assert retrieval_artifact.chunk_refs == vector_calls[0]
+
+    assert run.trace_path is not None
+    loaded_trace = TraceStore(config).load(run.trace_path)
+    assert loaded_trace.retrieval_artifact_path == run.retrieval_artifact_path
+    assert loaded_trace.index_build_status == "succeeded"
+
+
+def test_pipeline_marks_retrieval_artifact_pending_when_index_build_is_offline(
+    tmp_path: Path,
+) -> None:
+    config = AnnouncementConfig(
+        artifact_root=tmp_path / "artifacts",
+        docling_version="docling==2.15.1",
+        llama_index_version="llama-index-core==0.10.0",
+    )
+
+    def unavailable_index(*args, **kwargs):
+        raise RuntimeError("LlamaIndex dependency is unavailable")
+
+    pipeline = AnnouncementPipeline(
+        config,
+        discovery_func=_fake_discovery,
+        parse_func=_fake_parse,
+        build_retrieval_func=unavailable_index,
+        extract_func=lambda artifact: [],
+    )
+
+    run = asyncio.run(pipeline.process_envelope(_envelope()))
+
+    assert run.status == "succeeded"
+    assert run.parsed_artifact_path is not None
+    assert run.retrieval_artifact_path is None
+    assert run.index_build_status == "pending"
+    assert run.trace_path is not None
+    loaded_trace = TraceStore(config).load(run.trace_path)
+    assert loaded_trace.index_build_status == "pending"
+    assert loaded_trace.retrieval_artifact_path is None
+
+
+def _envelope() -> AnnouncementEnvelope:
+    return AnnouncementEnvelope(
+        announcement_id="ann-index-1",
+        ts_code="600000.SH",
+        title="重大合同公告",
+        publish_time=datetime(2026, 4, 18, 9, 0, tzinfo=timezone.utc),
+        official_url="https://static.sse.com.cn/disclosure/ann-index-1.pdf",
+        source_exchange="sse",
+        attachment_type="pdf",
+    )
+
+
+async def _fake_discovery(
+    envelope: AnnouncementEnvelope,
+    config: AnnouncementConfig,
+) -> AnnouncementDiscoveryResult:
+    document_path = Path(config.artifact_root) / "documents" / "ann-index-1.pdf"
+    document_path.parent.mkdir(parents=True, exist_ok=True)
+    document_path.write_bytes(b"%PDF mocked fixture")
+    document = AnnouncementDocumentArtifact(
+        announcement_id=envelope.announcement_id,
+        ts_code=envelope.ts_code,
+        title=envelope.title,
+        publish_time=envelope.publish_time,
+        content_hash="b" * 64,
+        official_url=envelope.official_url,
+        source_exchange=envelope.source_exchange,
+        attachment_type=envelope.attachment_type,
+        local_path=document_path,
+        content_type="application/pdf",
+        byte_size=document_path.stat().st_size,
+        fetched_at=datetime(2026, 4, 18, 9, 30, tzinfo=timezone.utc),
+    )
+    return AnnouncementDiscoveryResult(status="fetched", document=document)
+
+
+def _fake_parse(
+    document: AnnouncementDocumentArtifact,
+    config: AnnouncementConfig,
+) -> ParsedAnnouncementArtifact:
+    artifact = make_index_artifact(Path(config.artifact_root))
+    return artifact.model_copy(
+        update={
+            "content_hash": document.content_hash,
+            "parser_version": config.docling_version,
+            "source_document": document,
+        }
+    )


### PR DESCRIPTION
Closes #30

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/graph/candidates.py`, `src/subsystem_announcement/graph/deltas.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/runtime/metrics.py`, `src/subsystem_announcement/runtime/replay.py`, `src/subsystem_announcement/signals/classifier.py`, `tests/contracts/test_ex1_contract.py`


---
## 背景与目标
Milestone review for milestone-3 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The index implementation is available through offline helpers and optional replay/repair flags, but normal AnnouncementPipeline.process_envelope runs still do not build or record a retrieval artifact. The added test explicitly asserts that build_retrieval_artifact is absent from the pipeline, which means a successfully ingested announcement can have a parsed_artifact_path in its trace but no first-class retrieval artifact path or rebuild status. That breaks the milestone goal that historical announcements be retrievable by section/event semantics and leaves downstream code relying on path conventions or manual CLI runs.

## 实现范围
- 修改文件: `tests/test_index_retrieval_artifact.py`
- Add a first-class retrieval stage or clearly defined offline index job that is connected to AnnouncementExtractionRun. Persist retrieval_artifact_path and index build status in the trace, and cover process_envelope -> parsed artifact -> retrieval artifact with an integration test. If daily ingestion must not block on indexing, enqueue or mark a pending index artifact explicitly instead of silently omitting it.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/subsystem-announcement/.venv/bin/python -m pytest
```
