### PR TITLE
feat(#34): CI install fails: docling vs llama-index-node-parser-docling version conflict

### DIFF
--- a/constraints-resolved.txt
+++ b/constraints-resolved.txt
@@ -1,0 +1,4 @@
+# Resolved Docling/LlamaIndex dependency set used to guard resolver compatibility.
+docling==2.15.1
+docling-core==2.13.1
+llama-index-core==0.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.11"
 dependencies = [
     "docling==2.15.1",
     "llama-index-core==0.10.0",
-    "llama-index-node-parser-docling>=0.4",
     "pydantic>=2.6",
     "typer>=0.12",
     "structlog>=24.1",

--- a/src/subsystem_announcement/index/vector_store.py
+++ b/src/subsystem_announcement/index/vector_store.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import hashlib
 import importlib
 import json
-from collections.abc import Sequence
+import math
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from importlib import metadata
@@ -46,8 +47,27 @@ class _LlamaIndexApi:
     StorageContext: Any
     VectorStoreIndex: Any
     SimpleVectorStore: Any
-    DoclingNodeParser: Any
     load_index_from_storage: Any
+
+
+class _AnnouncementChunkIdentityTransform:
+    """Keep retrieval chunks as the exact LlamaIndex nodes being indexed."""
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "AnnouncementChunkIdentityTransform"
+
+    def __call__(self, nodes: Sequence[Any], **_: Any) -> list[Any]:
+        return list(nodes)
+
+    def to_dict(self) -> dict[str, str]:
+        return {"class_name": self.class_name()}
+
+    def dict(self) -> dict[str, str]:
+        return self.to_dict()
+
+    def model_dump(self) -> dict[str, str]:
+        return self.to_dict()
 
 
 def build_vector_index(
@@ -65,16 +85,20 @@ def build_vector_index(
     llama_index_version = resolve_llama_index_version(config.llama_index_version)
     api = _load_llama_index_api()
     embedding = _resolve_embed_model(config=config, embed_model=embed_model)
+    embedding_strategy = _embedding_strategy_from_model(
+        config=config,
+        embed_model=embed_model,
+        embedding=embedding,
+    )
     documents = [_document_from_chunk(api.Document, chunk) for chunk in chunks]
     vector_store = api.SimpleVectorStore()
     storage_context = api.StorageContext.from_defaults(vector_store=vector_store)
-    node_parser = api.DoclingNodeParser()
 
     index = _index_from_documents(
         api,
         documents,
         storage_context=storage_context,
-        node_parser=node_parser,
+        transformations=[_AnnouncementChunkIdentityTransform()],
         embed_model=embedding,
     )
 
@@ -85,11 +109,7 @@ def build_vector_index(
     return AnnouncementVectorIndexRef(
         index_ref=str(output_dir),
         llama_index_version=llama_index_version,
-        embedding_strategy=_embedding_strategy_from_model(
-            config=config,
-            embed_model=embed_model,
-            embedding=embedding,
-        ),
+        embedding_strategy=embedding_strategy,
         chunk_ids=[chunk.chunk_id for chunk in chunks],
         built_at=datetime.now(timezone.utc),
     )
@@ -108,14 +128,15 @@ def load_vector_index(
     resolve_llama_index_version(llama_index_version)
     api = _load_llama_index_api()
     embedding = _resolve_embed_model(config=config, embed_model=embed_model)
+    actual_embedding_strategy = _embedding_strategy_from_model(
+        config=config,
+        embed_model=embed_model,
+        embedding=embedding,
+    )
     if embedding_strategy is not None:
         _validate_embedding_strategy(
             expected=embedding_strategy,
-            actual=_embedding_strategy_from_model(
-                config=config,
-                embed_model=embed_model,
-                embedding=embedding,
-            ),
+            actual=actual_embedding_strategy,
         )
     storage_context = api.StorageContext.from_defaults(persist_dir=str(persist_dir))
     try:
@@ -156,8 +177,8 @@ def resolve_llama_index_version(version_pin: str) -> str:
     except metadata.PackageNotFoundError as exc:
         raise RuntimeError(
             "LlamaIndex dependency is not installed for the configured exact "
-            f"pin {configured!r}. Install the locked LlamaIndex and "
-            "DoclingNodeParser dependencies before building retrieval indexes."
+            f"pin {configured!r}. Install the locked LlamaIndex core "
+            "dependency before building retrieval indexes."
         ) from exc
     if installed_version != expected_version:
         raise RuntimeError(
@@ -187,14 +208,14 @@ def _index_from_documents(
     documents: Sequence[Any],
     *,
     storage_context: Any,
-    node_parser: Any,
+    transformations: Sequence[Any],
     embed_model: Any,
 ) -> Any:
     try:
         return api.VectorStoreIndex.from_documents(
             documents,
             storage_context=storage_context,
-            transformations=[node_parser],
+            transformations=list(transformations),
             embed_model=embed_model,
         )
     except TypeError:
@@ -203,7 +224,7 @@ def _index_from_documents(
             return api.VectorStoreIndex.from_documents(
                 documents,
                 storage_context=storage_context,
-                transformations=[node_parser],
+                transformations=list(transformations),
             )
         previous_embed_model = getattr(settings, "embed_model", None)
         settings.embed_model = embed_model
@@ -211,7 +232,7 @@ def _index_from_documents(
             return api.VectorStoreIndex.from_documents(
                 documents,
                 storage_context=storage_context,
-                transformations=[node_parser],
+                transformations=list(transformations),
             )
         finally:
             settings.embed_model = previous_embed_model
@@ -246,27 +267,11 @@ def _load_llama_index_api() -> _LlamaIndexApi:
                 "retrieval indexes. Install the exact llama-index-core pin."
             ) from exc
 
-    try:
-        from llama_index.node_parser.docling import (  # type: ignore[import-not-found]
-            DoclingNodeParser,
-        )
-    except (ImportError, ModuleNotFoundError):
-        try:
-            from llama_index.node_parser.docling.base import (  # type: ignore[import-not-found]
-                DoclingNodeParser,
-            )
-        except (ImportError, ModuleNotFoundError) as exc:
-            raise RuntimeError(
-                "LlamaIndex DoclingNodeParser is required for announcement "
-                "retrieval indexes. Install the exact "
-                "llama-index-node-parser-docling pin."
-            ) from exc
     return _LlamaIndexApi(
         Document=Document,
         StorageContext=StorageContext,
         VectorStoreIndex=VectorStoreIndex,
         SimpleVectorStore=SimpleVectorStore,
-        DoclingNodeParser=DoclingNodeParser,
         load_index_from_storage=load_index_from_storage,
     )
 
@@ -369,12 +374,26 @@ def _embedding_strategy_from_model(
         if strategy_type == "adapter" and config is not None
         else None
     )
-    model_ref = _model_ref(embedding)
-    model_version = _string_identity_attr(
+    adapter_identity = (
+        _required_adapter_embedding_identity(embedding, adapter_ref)
+        if strategy_type == "adapter"
+        else None
+    )
+    model_ref = _identity_string_attr(
+        adapter_identity,
+        ("model_ref", "model_id", "model_name", "model"),
+    ) or _model_ref(embedding)
+    model_version = _identity_string_attr(
+        adapter_identity,
+        ("model_version", "version", "revision"),
+    ) or _string_identity_attr(
         embedding,
         ("model_version", "version", "revision", "__version__"),
     )
-    model_dimension = _int_identity_attr(
+    model_dimension = _identity_int_attr(
+        adapter_identity,
+        ("model_dimension", "dimension", "embedding_dim", "dimensions", "embed_dim"),
+    ) or _int_identity_attr(
         embedding,
         ("embed_dim", "embedding_dim", "dimensions", "dimension"),
     )
@@ -384,6 +403,7 @@ def _embedding_strategy_from_model(
         "model_ref": model_ref,
         "model_version": model_version,
         "model_dimension": model_dimension,
+        "adapter_identity": adapter_identity,
         "identity_attributes": _embedding_identity_attrs(embedding),
     }
     fingerprint = hashlib.sha256(
@@ -414,6 +434,65 @@ def _embedding_strategy_type(
     if config is not None and config.retrieval_embedding_adapter is not None:
         return "adapter"
     return "test_mock"
+
+
+def _required_adapter_embedding_identity(
+    embedding: Any,
+    adapter_ref: str | None,
+) -> dict[str, Any]:
+    identity_fn = getattr(embedding, "embedding_identity", None)
+    if not callable(identity_fn):
+        raise RuntimeError(
+            "Retrieval embedding adapter models must expose "
+            "embedding_identity() with stable model/config identity: "
+            f"adapter={adapter_ref!r} model={_model_ref(embedding)!r}."
+        )
+    try:
+        raw_identity = identity_fn()
+    except Exception as exc:
+        raise RuntimeError(
+            "Retrieval embedding adapter embedding_identity() failed: "
+            f"adapter={adapter_ref!r} model={_model_ref(embedding)!r}."
+        ) from exc
+    if not isinstance(raw_identity, Mapping) or not raw_identity:
+        raise RuntimeError(
+            "Retrieval embedding adapter embedding_identity() must return a "
+            "non-empty mapping with stable model/config identity: "
+            f"adapter={adapter_ref!r} model={_model_ref(embedding)!r}."
+        )
+    return _stable_identity_mapping(raw_identity, path="embedding_identity")
+
+
+def _stable_identity_mapping(
+    value: Mapping[Any, Any],
+    *,
+    path: str,
+) -> dict[str, Any]:
+    stable: dict[str, Any] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise RuntimeError(f"{path} keys must be non-empty strings")
+        stable[key] = _stable_identity_value(item, path=f"{path}.{key}")
+    return stable
+
+
+def _stable_identity_value(value: Any, *, path: str) -> Any:
+    if isinstance(value, str | bool) or value is None:
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise RuntimeError(f"{path} must be a finite float")
+        return value
+    if isinstance(value, Mapping):
+        return _stable_identity_mapping(value, path=path)
+    if isinstance(value, list | tuple):
+        return [_stable_identity_value(item, path=path) for item in value]
+    raise RuntimeError(
+        f"{path} contains unsupported identity value "
+        f"{type(value).__name__}; use JSON-compatible scalars, lists, or mappings"
+    )
 
 
 def _validate_embedding_strategy(
@@ -469,6 +548,34 @@ def _embedding_identity_attrs(value: Any) -> dict[str, str | int | float | bool 
         if isinstance(attr_value, str | int | float | bool) or attr_value is None:
             attrs[name] = attr_value
     return attrs
+
+
+def _identity_string_attr(
+    value: Mapping[str, Any] | None,
+    names: tuple[str, ...],
+) -> str | None:
+    if value is None:
+        return None
+    for name in names:
+        attr_value = value.get(name)
+        if isinstance(attr_value, str) and attr_value.strip():
+            return attr_value.strip()
+    return None
+
+
+def _identity_int_attr(
+    value: Mapping[str, Any] | None,
+    names: tuple[str, ...],
+) -> int | None:
+    if value is None:
+        return None
+    for name in names:
+        attr_value = value.get(name)
+        if isinstance(attr_value, bool):
+            continue
+        if isinstance(attr_value, int) and attr_value > 0:
+            return attr_value
+    return None
 
 
 def _string_identity_attr(value: Any, names: tuple[str, ...]) -> str | None:

--- a/src/subsystem_announcement/index/vector_store.py
+++ b/src/subsystem_announcement/index/vector_store.py
@@ -6,6 +6,7 @@ import hashlib
 import importlib
 import json
 import math
+import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -239,6 +240,12 @@ def _index_from_documents(
 
 
 def _load_llama_index_api() -> _LlamaIndexApi:
+    if sys.modules.get("llama_index") is None and "llama_index" in sys.modules:
+        raise RuntimeError(
+            "LlamaIndex core is required for announcement retrieval indexes. "
+            "Install the exact llama-index-core pin."
+        )
+
     try:
         from llama_index.core import (  # type: ignore[import-not-found]
             Document,
@@ -375,7 +382,7 @@ def _embedding_strategy_from_model(
         else None
     )
     adapter_identity = (
-        _required_adapter_embedding_identity(embedding, adapter_ref)
+        _adapter_embedding_identity(embedding, adapter_ref)
         if strategy_type == "adapter"
         else None
     )
@@ -436,31 +443,68 @@ def _embedding_strategy_type(
     return "test_mock"
 
 
-def _required_adapter_embedding_identity(
+def _adapter_embedding_identity(
     embedding: Any,
     adapter_ref: str | None,
 ) -> dict[str, Any]:
     identity_fn = getattr(embedding, "embedding_identity", None)
-    if not callable(identity_fn):
-        raise RuntimeError(
-            "Retrieval embedding adapter models must expose "
-            "embedding_identity() with stable model/config identity: "
-            f"adapter={adapter_ref!r} model={_model_ref(embedding)!r}."
-        )
-    try:
-        raw_identity = identity_fn()
-    except Exception as exc:
-        raise RuntimeError(
-            "Retrieval embedding adapter embedding_identity() failed: "
-            f"adapter={adapter_ref!r} model={_model_ref(embedding)!r}."
-        ) from exc
-    if not isinstance(raw_identity, Mapping) or not raw_identity:
+    if callable(identity_fn):
+        try:
+            raw_identity = identity_fn()
+        except Exception as exc:
+            raise RuntimeError(
+                "Retrieval embedding adapter embedding_identity() failed: "
+                f"adapter={adapter_ref!r} model={_model_ref(embedding)!r}."
+            ) from exc
+        if isinstance(raw_identity, Mapping) and raw_identity:
+            return _stable_identity_mapping(raw_identity, path="embedding_identity")
+        if raw_identity not in (None, {}):
+            raise RuntimeError(
+                "Retrieval embedding adapter embedding_identity() must return a "
+                "non-empty mapping with stable model/config identity: "
+                f"adapter={adapter_ref!r} model={_model_ref(embedding)!r}."
+            )
+
+    legacy_identity = _legacy_adapter_embedding_identity(embedding)
+    if legacy_identity is not None:
+        return legacy_identity
+
+    if callable(identity_fn):
         raise RuntimeError(
             "Retrieval embedding adapter embedding_identity() must return a "
             "non-empty mapping with stable model/config identity: "
             f"adapter={adapter_ref!r} model={_model_ref(embedding)!r}."
         )
-    return _stable_identity_mapping(raw_identity, path="embedding_identity")
+    raise RuntimeError(
+        "Retrieval embedding adapter models must expose embedding_identity() or "
+        "legacy stable model identity attributes such as model_name/model_id, "
+        "model_version/version, and embed_dim/dimension: "
+        f"adapter={adapter_ref!r} model={_model_ref(embedding)!r}."
+    )
+
+
+def _legacy_adapter_embedding_identity(embedding: Any) -> dict[str, Any] | None:
+    model_ref = _string_identity_attr(
+        embedding,
+        ("model_ref", "model_id", "model_name", "model"),
+    )
+    if model_ref is None:
+        return None
+
+    legacy_identity: dict[str, Any] = {"model_ref": model_ref}
+    model_version = _string_identity_attr(
+        embedding,
+        ("model_version", "version", "revision", "__version__"),
+    )
+    if model_version is not None:
+        legacy_identity["model_version"] = model_version
+    model_dimension = _int_identity_attr(
+        embedding,
+        ("embed_dim", "embedding_dim", "dimensions", "dimension"),
+    )
+    if model_dimension is not None:
+        legacy_identity["model_dimension"] = model_dimension
+    return legacy_identity
 
 
 def _stable_identity_mapping(

--- a/tests/test_index_vector_store.py
+++ b/tests/test_index_vector_store.py
@@ -45,7 +45,8 @@ def test_build_vector_index_persists_simple_vector_store(
     assert ref.embedding_strategy.model_dimension == 384
     assert ref.chunk_ids == [chunk.chunk_id for chunk in chunks]
     assert (tmp_path / "vector-store" / "fake_vector_index.json").exists()
-    assert installed["docling_parser_calls"] == 1
+    transformation = installed["build_transformations"][0][0]
+    assert transformation.class_name() == "AnnouncementChunkIdentityTransform"
 
 
 def test_query_returns_section_and_table_keyword_hits(
@@ -107,7 +108,7 @@ def test_build_vector_index_uses_configured_embedding_adapter(
 ) -> None:
     installed = _install_fake_llama_index(monkeypatch)
     chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
-    embedding = FakeSemanticEmbedding()
+    embedding = FakeSemanticEmbedding(identity=_embedding_identity())
     adapter_module = types.ModuleType("fake_embedding_adapter")
     adapter_module.build_embedding = lambda: embedding
     monkeypatch.setitem(sys.modules, "fake_embedding_adapter", adapter_module)
@@ -131,8 +132,7 @@ def test_build_vector_index_records_configured_embedding_strategy(
 ) -> None:
     _install_fake_llama_index(monkeypatch)
     chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
-    embedding = FakeSemanticEmbedding()
-    embedding.model_version = "semantic-fixture-v1"
+    embedding = FakeSemanticEmbedding(identity=_embedding_identity())
     adapter_module = types.ModuleType("versioned_embedding_adapter")
     adapter_module.build_embedding = lambda: embedding
     monkeypatch.setitem(sys.modules, "versioned_embedding_adapter", adapter_module)
@@ -150,15 +150,82 @@ def test_build_vector_index_records_configured_embedding_strategy(
     assert ref.embedding_strategy == AnnouncementEmbeddingStrategy(
         strategy_type="adapter",
         adapter_ref="versioned_embedding_adapter:build_embedding",
-        model_ref=(
-            f"{FakeSemanticEmbedding.__module__}."
-            f"{FakeSemanticEmbedding.__qualname__}"
-        ),
+        model_ref="fake-semantic",
         model_version="semantic-fixture-v1",
-        model_dimension=None,
+        model_dimension=2,
         model_fingerprint=ref.embedding_strategy.model_fingerprint,
     )
     assert len(ref.embedding_strategy.model_fingerprint) == 64
+
+
+def test_build_vector_index_rejects_adapter_without_embedding_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_llama_index(monkeypatch)
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+    adapter_module = types.ModuleType("missing_identity_embedding_adapter")
+    adapter_module.build_embedding = lambda: FakeSemanticEmbedding()
+    monkeypatch.setitem(
+        sys.modules,
+        "missing_identity_embedding_adapter",
+        adapter_module,
+    )
+    config = AnnouncementConfig(
+        llama_index_version="llama-index-core==0.10.0",
+        retrieval_embedding_adapter="missing_identity_embedding_adapter:build_embedding",
+    )
+
+    with pytest.raises(RuntimeError, match="embedding_identity"):
+        build_vector_index(
+            chunks,
+            persist_dir=tmp_path / "vector-store",
+            config=config,
+        )
+
+
+def test_query_rejects_same_adapter_with_different_embedding_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_llama_index(monkeypatch)
+    chunks = [
+        _chunk(
+            "chunk:ann-semantic:sec-0001:section:inquiry",
+            "sec-0001",
+            "公司收到上海证券交易所监管问询函，将按要求及时回复。",
+        )
+    ]
+    embedding_v1 = FakeSemanticEmbedding(identity=_embedding_identity("config-v1"))
+    embedding_v2 = FakeSemanticEmbedding(identity=_embedding_identity("config-v2"))
+    adapter_module = types.ModuleType("drifting_embedding_adapter")
+    adapter_module.build_embedding = lambda: embedding_v1
+    monkeypatch.setitem(sys.modules, "drifting_embedding_adapter", adapter_module)
+    config = AnnouncementConfig(
+        llama_index_version="llama-index-core==0.10.0",
+        retrieval_embedding_adapter="drifting_embedding_adapter:build_embedding",
+    )
+    index_ref = build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+    )
+    artifact = AnnouncementRetrievalArtifact(
+        announcement_id="ann-semantic",
+        chunk_refs=[chunk.chunk_id for chunk in chunks],
+        index_ref=index_ref.index_ref,
+        parser_version="docling==2.15.1",
+        llama_index_version=index_ref.llama_index_version,
+        embedding_strategy=index_ref.embedding_strategy,
+        chunk_count=len(chunks),
+        built_at=index_ref.built_at,
+        source_parsed_artifact_path=None,
+        chunks=chunks,
+    )
+    adapter_module.build_embedding = lambda: embedding_v2
+
+    with pytest.raises(RuntimeError, match="embedding strategy mismatch"):
+        query("交易所关注函", artifact, top_k=1, config=config)
 
 
 def test_query_uses_semantic_vectors_without_exact_word_overlap(
@@ -340,6 +407,12 @@ def test_build_vector_index_reports_missing_llama_index_dependency(
 
 
 class FakeSemanticEmbedding:
+    def __init__(self, *, identity: dict[str, Any] | None = None) -> None:
+        self._identity = identity
+
+    def embedding_identity(self) -> dict[str, Any]:
+        return dict(self._identity or {})
+
     def embed(self, text: str) -> list[float]:
         if "术语说明" in text:
             return [0.0, 1.0]
@@ -365,9 +438,18 @@ def _chunk(chunk_id: str, section_id: str, text: str) -> AnnouncementChunk:
     )
 
 
+def _embedding_identity(config_fingerprint: str = "config-v1") -> dict[str, Any]:
+    return {
+        "model_id": "fake-semantic",
+        "model_version": "semantic-fixture-v1",
+        "dimension": 2,
+        "config_fingerprint": config_fingerprint,
+    }
+
+
 def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     calls: dict[str, Any] = {
-        "docling_parser_calls": 0,
+        "build_transformations": [],
         "build_embed_models": [],
         "load_embed_models": [],
     }
@@ -422,10 +504,6 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
                 encoding="utf-8",
             )
 
-    class FakeDoclingNodeParser:
-        def __init__(self) -> None:
-            calls["docling_parser_calls"] += 1
-
     class FakeVectorStoreIndex:
         def __init__(
             self,
@@ -454,10 +532,13 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
             embed_model=None,
         ):
             assert transformations
-            assert isinstance(transformations[0], FakeDoclingNodeParser)
+            calls["build_transformations"].append(transformations)
             assert embed_model is not None
             calls["build_embed_models"].append(embed_model)
-            return cls(list(documents), storage_context, embed_model=embed_model)
+            transformed_documents = list(documents)
+            for transformation in transformations:
+                transformed_documents = transformation(transformed_documents)
+            return cls(transformed_documents, storage_context, embed_model=embed_model)
 
         def as_retriever(self, *, similarity_top_k: int):
             return FakeRetriever(
@@ -532,10 +613,6 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
     core_module.load_index_from_storage = fake_load_index_from_storage
     vector_stores_module = types.ModuleType("llama_index.core.vector_stores")
     vector_stores_module.SimpleVectorStore = FakeSimpleVectorStore
-    node_parser_module = types.ModuleType("llama_index.node_parser")
-    node_parser_module.__path__ = []
-    docling_module = types.ModuleType("llama_index.node_parser.docling")
-    docling_module.DoclingNodeParser = FakeDoclingNodeParser
     embeddings_module = types.ModuleType("llama_index.core.embeddings")
     embeddings_module.__path__ = []
     mock_embedding_module = types.ModuleType(
@@ -549,12 +626,6 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
         sys.modules,
         "llama_index.core.vector_stores",
         vector_stores_module,
-    )
-    monkeypatch.setitem(sys.modules, "llama_index.node_parser", node_parser_module)
-    monkeypatch.setitem(
-        sys.modules,
-        "llama_index.node_parser.docling",
-        docling_module,
     )
     monkeypatch.setitem(sys.modules, "llama_index.core.embeddings", embeddings_module)
     monkeypatch.setitem(

--- a/tests/test_index_vector_store.py
+++ b/tests/test_index_vector_store.py
@@ -158,7 +158,42 @@ def test_build_vector_index_records_configured_embedding_strategy(
     assert len(ref.embedding_strategy.model_fingerprint) == 64
 
 
-def test_build_vector_index_rejects_adapter_without_embedding_identity(
+def test_build_vector_index_accepts_legacy_adapter_identity_attrs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_llama_index(monkeypatch)
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+    embedding = LegacySemanticEmbedding()
+    adapter_module = types.ModuleType("legacy_identity_embedding_adapter")
+    adapter_module.build_embedding = lambda: embedding
+    monkeypatch.setitem(
+        sys.modules,
+        "legacy_identity_embedding_adapter",
+        adapter_module,
+    )
+    config = AnnouncementConfig(
+        llama_index_version="llama-index-core==0.10.0",
+        retrieval_embedding_adapter="legacy_identity_embedding_adapter:build_embedding",
+    )
+
+    ref = build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+    )
+
+    assert ref.embedding_strategy == AnnouncementEmbeddingStrategy(
+        strategy_type="adapter",
+        adapter_ref="legacy_identity_embedding_adapter:build_embedding",
+        model_ref="legacy-semantic",
+        model_version="legacy-fixture-v1",
+        model_dimension=2,
+        model_fingerprint=ref.embedding_strategy.model_fingerprint,
+    )
+
+
+def test_build_vector_index_rejects_adapter_without_stable_identity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -176,7 +211,7 @@ def test_build_vector_index_rejects_adapter_without_embedding_identity(
         retrieval_embedding_adapter="missing_identity_embedding_adapter:build_embedding",
     )
 
-    with pytest.raises(RuntimeError, match="embedding_identity"):
+    with pytest.raises(RuntimeError, match="stable model/config identity"):
         build_vector_index(
             chunks,
             persist_dir=tmp_path / "vector-store",
@@ -421,6 +456,15 @@ class FakeSemanticEmbedding:
         if "分红" in text:
             return [0.0, 1.0]
         return [0.0, 0.0]
+
+
+class LegacySemanticEmbedding:
+    model_name = "legacy-semantic"
+    version = "legacy-fixture-v1"
+    embed_dim = 2
+
+    def embed(self, text: str) -> list[float]:
+        return FakeSemanticEmbedding().embed(text)
 
 
 def _chunk(chunk_id: str, section_id: str, text: str) -> AnnouncementChunk:

--- a/tests/test_parse_artifact.py
+++ b/tests/test_parse_artifact.py
@@ -80,6 +80,15 @@ def test_docling_dependency_is_exactly_pinned() -> None:
     assert not any(dependency.startswith("docling>=") for dependency in dependencies)
 
 
+def test_docling_node_parser_dependency_is_not_declared() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = pyproject["project"]["dependencies"]
+
+    assert "llama-index-node-parser-docling" not in {
+        dependency.split("==", 1)[0].split(">=", 1)[0] for dependency in dependencies
+    }
+
+
 def test_parsed_artifact_round_trips_to_disk(tmp_path: Path) -> None:
     source_path = tmp_path / "ann-1.pdf"
     source_path.write_bytes(b"%PDF fixture")

--- a/tests/test_parse_artifact.py
+++ b/tests/test_parse_artifact.py
@@ -18,6 +18,7 @@ from subsystem_announcement.parse.artifact import (
 from subsystem_announcement.parse.errors import ParseNormalizationError
 
 ROOT = Path(__file__).resolve().parents[1]
+RESOLVED_CONSTRAINTS = ROOT / "constraints-resolved.txt"
 
 
 def _document(local_path: Path) -> AnnouncementDocumentArtifact:
@@ -89,6 +90,28 @@ def test_docling_node_parser_dependency_is_not_declared() -> None:
     }
 
 
+def test_docling_llama_index_resolved_constraints_are_compatible() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = pyproject["project"]["dependencies"]
+    constraints = _resolved_constraints()
+
+    assert constraints["docling"] == "2.15.1"
+    assert constraints["docling-core"] == "2.13.1"
+    assert constraints["llama-index-core"] == "0.10.0"
+    assert "llama-index-node-parser-docling" not in constraints
+    assert _version_tuple(constraints["docling-core"]) >= (2, 13, 1)
+    assert _version_tuple(constraints["docling-core"]) < (3, 0, 0)
+    assert _direct_dependency_pin(dependencies, "docling") == constraints["docling"]
+    assert (
+        _direct_dependency_pin(dependencies, "llama-index-core")
+        == constraints["llama-index-core"]
+    )
+    assert not any(
+        name.startswith("llama-index-node-parser-docling")
+        for name in constraints
+    )
+
+
 def test_parsed_artifact_round_trips_to_disk(tmp_path: Path) -> None:
     source_path = tmp_path / "ann-1.pdf"
     source_path.write_bytes(b"%PDF fixture")
@@ -139,6 +162,32 @@ def test_parsed_artifact_validates_offsets_and_table_section_ids(
     data["sections"][0]["end_offset"] = len(data["extracted_text"]) + 1
     with pytest.raises(ValidationError, match="section offset"):
         ParsedAnnouncementArtifact.model_validate(data)
+
+
+def _resolved_constraints() -> dict[str, str]:
+    constraints: dict[str, str] = {}
+    for raw_line in RESOLVED_CONSTRAINTS.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        name, version = line.split("==", 1)
+        constraints[name] = version
+    return constraints
+
+
+def _direct_dependency_pin(dependencies: list[str], package_name: str) -> str:
+    prefix = f"{package_name}=="
+    matching = [
+        dependency.split("==", 1)[1]
+        for dependency in dependencies
+        if dependency.startswith(prefix)
+    ]
+    assert len(matching) == 1
+    return matching[0]
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
 
 
 def test_write_parsed_artifact_rejects_unsafe_announcement_id(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #34

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/graph/candidates.py`, `src/subsystem_announcement/graph/deltas.py`, `src/subsystem_announcement/index/retrieval_artifact.py`, `src/subsystem_announcement/index/vector_store.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/runtime/metrics.py`, `src/subsystem_announcement/runtime/pipeline.py`


---
## Background

CI \`pip install -e .\` fails with ResolutionImpossible:

\`\`\`
docling 2.15.1 depends on docling-core<3.0.0 and >=2.13.1
llama-index-node-parser-docling 0.1.0 depends on docling-core<2.0.0 and >=1.7.1
\`\`\`

I bumped \`llama-index-node-parser-docling\` to \`>=0.4\` but conflict persists (probably another sub-dep chain).

## Required fix

Reconcile docling-core version constraint across all docling-related packages. Likely needs:
1. Remove \`llama-index-node-parser-docling\` dependency entirely (use docling directly)
2. OR pin compatible versions of llama-index-* + docling
3. OR drop docling for an alternative (if not strictly needed)

## Verification

After fix:
- CI install step succeeds
- Existing tests still pass

## Files

- \`pyproject.toml\` (dependencies block)