### PR TITLE
feat(#34): CI install fails: docling vs llama-index-node-parser-docling version conflict

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 - **语言**：Python
 - **文档解析**：Docling（唯一 parser，版本必须锁定）
-- **检索索引**：LlamaIndex + DoclingNodeParser + SimpleVectorStore / FAISS（Lite）
+- **检索索引**：LlamaIndex chunk 节点 + SimpleVectorStore / FAISS（Lite）
 - **子系统框架**：`subsystem-sdk`（submit / heartbeat / validator / fixtures）
 - **结构化抽取辅助**：`reasoner-runtime.generate_structured()`（不直连 provider SDK）
 

--- a/docs/TASK_BREAKDOWN.md
+++ b/docs/TASK_BREAKDOWN.md
@@ -269,10 +269,10 @@ pytest -q
 
 ### ISSUE-009: 公告域 chunk / index 与 retrieval artifact
 **labels**: P2, feature, milestone-3
-**摘要**: 将 `ParsedAnnouncementArtifact` 按章节 / 表格 / 条款切片，通过 LlamaIndex `DoclingNodeParser` 构建本地向量索引，并输出 `AnnouncementRetrievalArtifact` 引用。
+**摘要**: 将 `ParsedAnnouncementArtifact` 按章节 / 表格 / 条款切片，通过 chunk_id 锚定的 LlamaIndex 节点构建本地向量索引，并输出 `AnnouncementRetrievalArtifact` 引用。
 **所属模块**: 主写 `src/subsystem_announcement/index/`（`chunker.py`、`vector_store.py`、`retrieval_artifact.py`、`sample_query.py`）+ `tests/test_index_*.py`。
 **写入边界**: 允许修改 index package 与测试；禁止修改 extract / signals / graph；禁止把索引构建压进日频关键路径，重建脚本须以离线 CLI 形式提供。
-**实现顺序**: 先实现章节/表格 chunk，再接 LlamaIndex `DoclingNodeParser` + `SimpleVectorStore` / FAISS Lite 二选一，再落 `AnnouncementRetrievalArtifact` 持久化，最后实现示例 `query(text)` 并补端到端检索测试。
+**实现顺序**: 先实现章节/表格 chunk，再接 chunk_id 锚定的 LlamaIndex 节点 + `SimpleVectorStore` / FAISS Lite 二选一，再落 `AnnouncementRetrievalArtifact` 持久化，最后实现示例 `query(text)` 并补端到端检索测试。
 **依赖**: #ISSUE-008（阶段 2 稳定后再并检索链）
 
 ---

--- a/docs/subsystem-announcement.project-doc.md
+++ b/docs/subsystem-announcement.project-doc.md
@@ -229,7 +229,7 @@ official announcement body
 ```text
 parsed announcement artifact
   -> chunk into retrieval units
-  -> LlamaIndex DoclingNodeParser
+  -> chunk_id-backed LlamaIndex nodes
   -> local vector / index
   -> query by historical context
 ```
@@ -531,7 +531,7 @@ use ts_code / company name deterministic match first
 ```text
 load parsed announcement JSON
   -> chunk by section / table / clause
-  -> LlamaIndex DoclingNodeParser
+  -> chunk_id-backed LlamaIndex nodes
   -> build local vector index
   -> store retrieval refs
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.11"
 dependencies = [
     "docling==2.15.1",
     "llama-index-core==0.10.0",
-    "llama-index-node-parser-docling>=0.4",
     "pydantic>=2.6",
     "typer>=0.12",
     "structlog>=24.1",

--- a/src/subsystem_announcement/index/vector_store.py
+++ b/src/subsystem_announcement/index/vector_store.py
@@ -46,7 +46,6 @@ class _LlamaIndexApi:
     StorageContext: Any
     VectorStoreIndex: Any
     SimpleVectorStore: Any
-    DoclingNodeParser: Any
     load_index_from_storage: Any
 
 
@@ -68,13 +67,11 @@ def build_vector_index(
     documents = [_document_from_chunk(api.Document, chunk) for chunk in chunks]
     vector_store = api.SimpleVectorStore()
     storage_context = api.StorageContext.from_defaults(vector_store=vector_store)
-    node_parser = api.DoclingNodeParser()
 
     index = _index_from_documents(
         api,
         documents,
         storage_context=storage_context,
-        node_parser=node_parser,
         embed_model=embedding,
     )
 
@@ -156,8 +153,8 @@ def resolve_llama_index_version(version_pin: str) -> str:
     except metadata.PackageNotFoundError as exc:
         raise RuntimeError(
             "LlamaIndex dependency is not installed for the configured exact "
-            f"pin {configured!r}. Install the locked LlamaIndex and "
-            "DoclingNodeParser dependencies before building retrieval indexes."
+            f"pin {configured!r}. Install the locked LlamaIndex core "
+            "dependency before building retrieval indexes."
         ) from exc
     if installed_version != expected_version:
         raise RuntimeError(
@@ -187,14 +184,12 @@ def _index_from_documents(
     documents: Sequence[Any],
     *,
     storage_context: Any,
-    node_parser: Any,
     embed_model: Any,
 ) -> Any:
     try:
         return api.VectorStoreIndex.from_documents(
             documents,
             storage_context=storage_context,
-            transformations=[node_parser],
             embed_model=embed_model,
         )
     except TypeError:
@@ -203,7 +198,6 @@ def _index_from_documents(
             return api.VectorStoreIndex.from_documents(
                 documents,
                 storage_context=storage_context,
-                transformations=[node_parser],
             )
         previous_embed_model = getattr(settings, "embed_model", None)
         settings.embed_model = embed_model
@@ -211,7 +205,6 @@ def _index_from_documents(
             return api.VectorStoreIndex.from_documents(
                 documents,
                 storage_context=storage_context,
-                transformations=[node_parser],
             )
         finally:
             settings.embed_model = previous_embed_model
@@ -246,27 +239,11 @@ def _load_llama_index_api() -> _LlamaIndexApi:
                 "retrieval indexes. Install the exact llama-index-core pin."
             ) from exc
 
-    try:
-        from llama_index.node_parser.docling import (  # type: ignore[import-not-found]
-            DoclingNodeParser,
-        )
-    except (ImportError, ModuleNotFoundError):
-        try:
-            from llama_index.node_parser.docling.base import (  # type: ignore[import-not-found]
-                DoclingNodeParser,
-            )
-        except (ImportError, ModuleNotFoundError) as exc:
-            raise RuntimeError(
-                "LlamaIndex DoclingNodeParser is required for announcement "
-                "retrieval indexes. Install the exact "
-                "llama-index-node-parser-docling pin."
-            ) from exc
     return _LlamaIndexApi(
         Document=Document,
         StorageContext=StorageContext,
         VectorStoreIndex=VectorStoreIndex,
         SimpleVectorStore=SimpleVectorStore,
-        DoclingNodeParser=DoclingNodeParser,
         load_index_from_storage=load_index_from_storage,
     )
 

--- a/src/subsystem_announcement/index/vector_store.py
+++ b/src/subsystem_announcement/index/vector_store.py
@@ -176,7 +176,7 @@ def _document_from_chunk(Document: Any, chunk: AnnouncementChunk) -> Any:
         "title_path": chunk.title_path,
         "source_reference": chunk.source_reference,
     }
-    return Document(text=chunk.text, metadata=metadata_payload)
+    return Document(text=chunk.text, metadata=metadata_payload, id_=chunk.chunk_id)
 
 
 def _index_from_documents(
@@ -190,6 +190,7 @@ def _index_from_documents(
         return api.VectorStoreIndex.from_documents(
             documents,
             storage_context=storage_context,
+            transformations=[],
             embed_model=embed_model,
         )
     except TypeError:
@@ -198,6 +199,7 @@ def _index_from_documents(
             return api.VectorStoreIndex.from_documents(
                 documents,
                 storage_context=storage_context,
+                transformations=[],
             )
         previous_embed_model = getattr(settings, "embed_model", None)
         settings.embed_model = embed_model
@@ -205,6 +207,7 @@ def _index_from_documents(
             return api.VectorStoreIndex.from_documents(
                 documents,
                 storage_context=storage_context,
+                transformations=[],
             )
         finally:
             settings.embed_model = previous_embed_model

--- a/tests/test_index_vector_store.py
+++ b/tests/test_index_vector_store.py
@@ -48,6 +48,57 @@ def test_build_vector_index_persists_simple_vector_store(
     assert installed["build_embed_models"]
 
 
+def test_build_vector_index_pins_chunk_node_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installed = _install_fake_llama_index(monkeypatch)
+    chunks = chunk_parsed_artifact(make_index_artifact(tmp_path))
+    config = AnnouncementConfig(
+        llama_index_version="llama-index-core==0.10.0",
+        allow_test_mock_embeddings=True,
+    )
+
+    index_ref = build_vector_index(
+        chunks,
+        persist_dir=tmp_path / "vector-store",
+        config=config,
+    )
+    persisted = json.loads(
+        (tmp_path / "vector-store" / "fake_vector_index.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    artifact = AnnouncementRetrievalArtifact(
+        announcement_id="ann-index-1",
+        chunk_refs=[chunk.chunk_id for chunk in chunks],
+        index_ref=index_ref.index_ref,
+        parser_version="docling==2.15.1",
+        llama_index_version=index_ref.llama_index_version,
+        embedding_strategy=index_ref.embedding_strategy,
+        chunk_count=len(chunks),
+        built_at=index_ref.built_at,
+        source_parsed_artifact_path=None,
+        chunks=chunks,
+    )
+
+    assert installed["build_transformations"] == [[]]
+    assert len(persisted["documents"]) == len(chunks)
+    assert [item["id_"] for item in persisted["documents"]] == [
+        chunk.chunk_id for chunk in chunks
+    ]
+    assert [item["metadata"]["chunk_id"] for item in persisted["documents"]] == [
+        chunk.chunk_id for chunk in chunks
+    ]
+
+    table_chunk = next(chunk for chunk in chunks if chunk.table_ref == "tbl-0001")
+    hits = query("1000万元", artifact, top_k=1, config=config)
+
+    assert installed["load_embed_models"]
+    assert hits[0].chunk_id == table_chunk.chunk_id
+    assert hits[0].metadata["chunk_type"] == "table"
+
+
 def test_query_returns_section_and_table_keyword_hits(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -371,11 +422,19 @@ def _chunk(chunk_id: str, section_id: str, text: str) -> AnnouncementChunk:
 def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     calls: dict[str, Any] = {
         "build_embed_models": [],
+        "build_transformations": [],
         "load_embed_models": [],
     }
 
     class FakeDocument:
-        def __init__(self, *, text: str, metadata: dict[str, Any]) -> None:
+        def __init__(
+            self,
+            *,
+            text: str,
+            metadata: dict[str, Any],
+            id_: str,
+        ) -> None:
+            self.id_ = id_
             self.text = text
             self.metadata = metadata
 
@@ -400,7 +459,11 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
                 index_path = Path(persist_dir) / "fake_vector_index.json"
                 data = json.loads(index_path.read_text(encoding="utf-8"))
                 self.documents = [
-                    FakeDocument(text=item["text"], metadata=item["metadata"])
+                    FakeDocument(
+                        id_=item["id_"],
+                        text=item["text"],
+                        metadata=item["metadata"],
+                    )
                     for item in data["documents"]
                 ]
                 self.embeddings = data.get("embeddings", [])
@@ -414,7 +477,11 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
             output_dir.mkdir(parents=True, exist_ok=True)
             payload = {
                 "documents": [
-                    {"text": document.text, "metadata": document.metadata}
+                    {
+                        "id_": document.id_,
+                        "text": document.text,
+                        "metadata": document.metadata,
+                    }
                     for document in self.documents
                 ],
                 "embeddings": self.embeddings,
@@ -451,8 +518,9 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
             transformations=None,
             embed_model=None,
         ):
-            assert transformations is None
+            assert transformations == []
             assert embed_model is not None
+            calls["build_transformations"].append(list(transformations))
             calls["build_embed_models"].append(embed_model)
             return cls(list(documents), storage_context, embed_model=embed_model)
 

--- a/tests/test_index_vector_store.py
+++ b/tests/test_index_vector_store.py
@@ -45,7 +45,7 @@ def test_build_vector_index_persists_simple_vector_store(
     assert ref.embedding_strategy.model_dimension == 384
     assert ref.chunk_ids == [chunk.chunk_id for chunk in chunks]
     assert (tmp_path / "vector-store" / "fake_vector_index.json").exists()
-    assert installed["docling_parser_calls"] == 1
+    assert installed["build_embed_models"]
 
 
 def test_query_returns_section_and_table_keyword_hits(
@@ -329,6 +329,9 @@ def test_build_vector_index_reports_missing_llama_index_dependency(
         "version",
         lambda package_name: "0.10.0",
     )
+    for module_name in list(sys.modules):
+        if module_name == "llama_index" or module_name.startswith("llama_index."):
+            monkeypatch.delitem(sys.modules, module_name, raising=False)
     monkeypatch.setitem(sys.modules, "llama_index", None)
 
     with pytest.raises(RuntimeError, match="LlamaIndex core"):
@@ -367,7 +370,6 @@ def _chunk(chunk_id: str, section_id: str, text: str) -> AnnouncementChunk:
 
 def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     calls: dict[str, Any] = {
-        "docling_parser_calls": 0,
         "build_embed_models": [],
         "load_embed_models": [],
     }
@@ -422,10 +424,6 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
                 encoding="utf-8",
             )
 
-    class FakeDoclingNodeParser:
-        def __init__(self) -> None:
-            calls["docling_parser_calls"] += 1
-
     class FakeVectorStoreIndex:
         def __init__(
             self,
@@ -450,11 +448,10 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
             documents,
             *,
             storage_context,
-            transformations,
+            transformations=None,
             embed_model=None,
         ):
-            assert transformations
-            assert isinstance(transformations[0], FakeDoclingNodeParser)
+            assert transformations is None
             assert embed_model is not None
             calls["build_embed_models"].append(embed_model)
             return cls(list(documents), storage_context, embed_model=embed_model)
@@ -532,10 +529,6 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
     core_module.load_index_from_storage = fake_load_index_from_storage
     vector_stores_module = types.ModuleType("llama_index.core.vector_stores")
     vector_stores_module.SimpleVectorStore = FakeSimpleVectorStore
-    node_parser_module = types.ModuleType("llama_index.node_parser")
-    node_parser_module.__path__ = []
-    docling_module = types.ModuleType("llama_index.node_parser.docling")
-    docling_module.DoclingNodeParser = FakeDoclingNodeParser
     embeddings_module = types.ModuleType("llama_index.core.embeddings")
     embeddings_module.__path__ = []
     mock_embedding_module = types.ModuleType(
@@ -550,12 +543,7 @@ def _install_fake_llama_index(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]
         "llama_index.core.vector_stores",
         vector_stores_module,
     )
-    monkeypatch.setitem(sys.modules, "llama_index.node_parser", node_parser_module)
-    monkeypatch.setitem(
-        sys.modules,
-        "llama_index.node_parser.docling",
-        docling_module,
-    )
+    monkeypatch.setitem(sys.modules, "llama_index.node_parser.docling", None)
     monkeypatch.setitem(sys.modules, "llama_index.core.embeddings", embeddings_module)
     monkeypatch.setitem(
         sys.modules,

--- a/tests/test_parse_artifact.py
+++ b/tests/test_parse_artifact.py
@@ -78,6 +78,9 @@ def test_docling_dependency_is_exactly_pinned() -> None:
 
     assert docling_dependencies == ["docling==2.15.1"]
     assert not any(dependency.startswith("docling>=") for dependency in dependencies)
+    assert "llama-index-node-parser-docling" not in {
+        dependency.split("==", 1)[0].split(">=", 1)[0] for dependency in dependencies
+    }
 
 
 def test_parsed_artifact_round_trips_to_disk(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #34

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/graph/candidates.py`, `src/subsystem_announcement/graph/deltas.py`, `src/subsystem_announcement/index/retrieval_artifact.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/runtime/metrics.py`, `src/subsystem_announcement/runtime/pipeline.py`, `src/subsystem_announcement/signals/classifier.py`


---
## Background

CI \`pip install -e .\` fails with ResolutionImpossible:

\`\`\`
docling 2.15.1 depends on docling-core<3.0.0 and >=2.13.1
llama-index-node-parser-docling 0.1.0 depends on docling-core<2.0.0 and >=1.7.1
\`\`\`

I bumped \`llama-index-node-parser-docling\` to \`>=0.4\` but conflict persists (probably another sub-dep chain).

## Required fix

Reconcile docling-core version constraint across all docling-related packages. Likely needs:
1. Remove \`llama-index-node-parser-docling\` dependency entirely (use docling directly)
2. OR pin compatible versions of llama-index-* + docling
3. OR drop docling for an alternative (if not strictly needed)

## Verification

After fix:
- CI install step succeeds
- Existing tests still pass

## Files

- \`pyproject.toml\` (dependencies block)