### PR TITLE
feat(#34): CI install fails: docling vs llama-index-node-parser-docling version conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "docling==2.15.1",
+    "docling-core==2.13.1",
     "llama-index-core==0.10.0",
     "pydantic>=2.6",
     "typer>=0.12",

--- a/src/subsystem_announcement/__main__.py
+++ b/src/subsystem_announcement/__main__.py
@@ -480,6 +480,7 @@ def _doctor_report(config: AnnouncementConfig) -> str:
         [
             "ok",
             f"parser_version={_version_status(config.docling_version)}",
+            f"parser_core_version={_version_status(config.docling_core_version)}",
             f"index_version={_version_status(config.llama_index_version)}",
         ]
     )

--- a/src/subsystem_announcement/config.py
+++ b/src/subsystem_announcement/config.py
@@ -12,6 +12,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 DEFAULT_CONFIG_PATH = Path("config/announcement.toml")
 _DOCLING_VERSION = re.compile(r"^docling==[A-Za-z0-9][A-Za-z0-9._!+-]*$")
+_DOCLING_CORE_VERSION = re.compile(
+    r"^docling-core==[A-Za-z0-9][A-Za-z0-9._!+-]*$"
+)
 _LLAMA_INDEX_VERSION = re.compile(
     r"^llama-index(?:-core)?==[A-Za-z0-9][A-Za-z0-9._!+-]*$"
 )
@@ -28,6 +31,7 @@ class AnnouncementConfig(BaseModel):
 
     artifact_root: Path = Path("artifacts/announcement")
     docling_version: str = "not-configured"
+    docling_core_version: str = "not-configured"
     llama_index_version: str = "not-configured"
     retrieval_embedding_adapter: str | None = None
     allow_test_mock_embeddings: bool = False
@@ -46,6 +50,17 @@ class AnnouncementConfig(BaseModel):
             value,
             pattern=_DOCLING_VERSION,
             field_name="docling_version",
+        )
+
+    @field_validator("docling_core_version")
+    @classmethod
+    def validate_docling_core_version(cls, value: str) -> str:
+        """Allow only explicit docling-core pins or the unset scaffold sentinel."""
+
+        return _validate_version_field(
+            value,
+            pattern=_DOCLING_CORE_VERSION,
+            field_name="docling_core_version",
         )
 
     @field_validator("llama_index_version")

--- a/src/subsystem_announcement/parse/artifact.py
+++ b/src/subsystem_announcement/parse/artifact.py
@@ -68,6 +68,7 @@ class ParsedAnnouncementArtifact(BaseModel):
     announcement_id: str = Field(min_length=1)
     content_hash: str = Field(min_length=64, max_length=64)
     parser_version: str = Field(min_length=1)
+    parser_core_version: str = Field(default="not-configured", min_length=1)
     title_hierarchy: list[str] = Field(default_factory=list)
     sections: list[AnnouncementSection] = Field(min_length=1)
     tables: list[AnnouncementTable] = Field(default_factory=list)

--- a/src/subsystem_announcement/parse/docling_client.py
+++ b/src/subsystem_announcement/parse/docling_client.py
@@ -14,6 +14,9 @@ from .normalize import normalize_docling_result
 
 _SUPPORTED_ATTACHMENT_TYPES = frozenset({"pdf", "html", "word"})
 _PINNED_DOCLING_VERSION = re.compile(r"^docling==[A-Za-z0-9][A-Za-z0-9._!+-]*$")
+_PINNED_DOCLING_CORE_VERSION = re.compile(
+    r"^docling-core==[A-Za-z0-9][A-Za-z0-9._!+-]*$"
+)
 
 
 class DoclingAnnouncementParser:
@@ -34,6 +37,7 @@ class DoclingAnnouncementParser:
             )
 
         parser_version = resolve_docling_version(config)
+        parser_core_version = resolve_docling_core_version(config)
         if not document_ref.local_path.exists():
             raise DoclingParseError(
                 "Announcement document is not available for Docling parse: "
@@ -59,7 +63,12 @@ class DoclingAnnouncementParser:
                 f"path={document_ref.local_path}"
             ) from exc
 
-        return normalize_docling_result(raw_result, document_ref, parser_version)
+        return normalize_docling_result(
+            raw_result,
+            document_ref,
+            parser_version,
+            parser_core_version,
+        )
 
 
 def resolve_docling_version(config: AnnouncementConfig) -> str:
@@ -76,6 +85,23 @@ def resolve_docling_version(config: AnnouncementConfig) -> str:
         raise DoclingParseError(
             "Docling parser version is not configured and the docling package "
             "is not installed; parser_version cannot be not-configured."
+        ) from None
+
+
+def resolve_docling_core_version(config: AnnouncementConfig) -> str:
+    """Resolve concrete docling-core provenance for parse artifacts."""
+
+    try:
+        return f"docling-core=={metadata.version('docling-core')}"
+    except metadata.PackageNotFoundError:
+        configured = config.docling_core_version.strip()
+        if configured != "not-configured" and _PINNED_DOCLING_CORE_VERSION.fullmatch(
+            configured
+        ):
+            return configured
+        raise DoclingParseError(
+            "Docling core version is not configured and the docling-core package "
+            "is not installed; parser_core_version cannot be not-configured."
         ) from None
 
 

--- a/src/subsystem_announcement/parse/normalize.py
+++ b/src/subsystem_announcement/parse/normalize.py
@@ -19,11 +19,17 @@ def normalize_docling_result(
     raw_result: object,
     document_ref: AnnouncementDocumentArtifact,
     parser_version: str,
+    parser_core_version: str = "not-configured",
 ) -> ParsedAnnouncementArtifact:
     """Convert a Docling result object into the persisted artifact schema."""
 
     try:
-        return _normalize_docling_result(raw_result, document_ref, parser_version)
+        return _normalize_docling_result(
+            raw_result,
+            document_ref,
+            parser_version,
+            parser_core_version,
+        )
     except ParseNormalizationError:
         raise
     except Exception as exc:
@@ -37,6 +43,7 @@ def _normalize_docling_result(
     raw_result: object,
     document_ref: AnnouncementDocumentArtifact,
     parser_version: str,
+    parser_core_version: str,
 ) -> ParsedAnnouncementArtifact:
     document = _get_value(raw_result, "document") or raw_result
     section_inputs = list(_iter_section_inputs(document))
@@ -142,6 +149,7 @@ def _normalize_docling_result(
         announcement_id=document_ref.announcement_id,
         content_hash=document_ref.content_hash,
         parser_version=parser_version,
+        parser_core_version=parser_core_version,
         title_hierarchy=title_hierarchy,
         sections=sections,
         tables=tables,

--- a/src/subsystem_announcement/runtime/metrics.py
+++ b/src/subsystem_announcement/runtime/metrics.py
@@ -187,6 +187,15 @@ def compute_metrics_for_manifest(
                 f"{sample_id}: parser_version {parsed_artifact.parser_version!r} "
                 f"does not match config {config.docling_version!r}"
             )
+        if (
+            config.docling_core_version != "not-configured"
+            and parsed_artifact.parser_core_version != config.docling_core_version
+        ):
+            diagnostics.append(
+                f"{sample_id}: parser_core_version "
+                f"{parsed_artifact.parser_core_version!r} does not match config "
+                f"{config.docling_core_version!r}"
+            )
         if parsed_artifact.content_hash != document_artifact.content_hash:
             diagnostics.append(
                 f"{sample_id}: parsed content_hash does not match fixture document"

--- a/src/subsystem_announcement/runtime/repair.py
+++ b/src/subsystem_announcement/runtime/repair.py
@@ -72,6 +72,7 @@ class RepairResult(BaseModel):
     announcement_id: str = Field(min_length=1)
     parsed_artifact_path: Path
     parser_version: str = Field(min_length=1)
+    parser_core_version: str = Field(min_length=1)
     retrieval_artifact_path: Path | None
     repaired_at: datetime
 
@@ -107,6 +108,17 @@ def repair_parsed_artifact(
         raise RepairError(
             "Docling version upgrade repair produced unexpected parser_version: "
             f"expected={config.docling_version} actual={parsed_artifact.parser_version}"
+        )
+    if (
+        request.reason is RepairReason.DOCLING_VERSION_UPGRADE
+        and config.docling_core_version != "not-configured"
+        and parsed_artifact.parser_core_version != config.docling_core_version
+    ):
+        raise RepairError(
+            "Docling version upgrade repair produced unexpected "
+            "parser_core_version: "
+            f"expected={config.docling_core_version} "
+            f"actual={parsed_artifact.parser_core_version}"
         )
 
     if request.reason is RepairReason.DOCLING_VERSION_UPGRADE:
@@ -148,6 +160,7 @@ def repair_parsed_artifact(
         announcement_id=parsed_artifact.announcement_id,
         parsed_artifact_path=parsed_artifact_path,
         parser_version=parsed_artifact.parser_version,
+        parser_core_version=parsed_artifact.parser_core_version,
         retrieval_artifact_path=retrieval_artifact_path,
         repaired_at=repaired_at,
     )
@@ -247,6 +260,7 @@ def _write_latest_upgrade_pointer(
         "announcement_id": artifact.announcement_id,
         "content_hash": artifact.content_hash,
         "parser_version": artifact.parser_version,
+        "parser_core_version": artifact.parser_core_version,
         "parsed_artifact_path": str(artifact_path),
         "repaired_at": repaired_at.isoformat(),
     }
@@ -267,6 +281,10 @@ def _upgrade_artifact_root(
         _parsed_announcement_root(config, artifact.announcement_id)
         / "upgrades"
         / _safe_path_component(artifact.parser_version, field_name="parser_version")
+        / _safe_path_component(
+            artifact.parser_core_version,
+            field_name="parser_core_version",
+        )
     )
 
 

--- a/src/subsystem_announcement/runtime/sdk_adapter.py
+++ b/src/subsystem_announcement/runtime/sdk_adapter.py
@@ -7,6 +7,7 @@ import importlib.util
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from threading import RLock
 from typing import Any, Final, TypeAlias
 from uuid import uuid4
 
@@ -38,11 +39,19 @@ class UnsupportedSubsystemSdkError(RuntimeError):
 @dataclass(frozen=True)
 class _SdkApi:
     subsystem_base_interface: type[Any]
+    base_subsystem_context: type[Any]
     registration_spec: type[Any]
     submit_receipt: type[Any]
+    submit_client: type[Any]
+    heartbeat_client: type[Any]
+    mock_submit_backend: type[Any]
+    submit_backend_heartbeat_adapter: type[Any]
     register_subsystem: Any
+    configure_runtime: Any
     send_heartbeat: Any
     submit: Any
+    build_ex0_payload: Any
+    validation_result: type[Any]
     assert_producer_only: Any
 
 
@@ -52,6 +61,7 @@ def _load_official_sdk_api() -> _SdkApi | None:
 
     try:
         base_module = importlib.import_module("subsystem_sdk.base")
+        backends_module = importlib.import_module("subsystem_sdk.backends")
         submit_module = importlib.import_module("subsystem_sdk.submit")
         heartbeat_module = importlib.import_module("subsystem_sdk.heartbeat")
         validate_module = importlib.import_module("subsystem_sdk.validate")
@@ -60,14 +70,28 @@ def _load_official_sdk_api() -> _SdkApi | None:
                 base_module,
                 "SubsystemBaseInterface",
             ),
+            base_subsystem_context=_required_symbol(
+                base_module,
+                "BaseSubsystemContext",
+            ),
             registration_spec=_required_symbol(
                 base_module,
                 "SubsystemRegistrationSpec",
             ),
             submit_receipt=_required_symbol(submit_module, "SubmitReceipt"),
+            submit_client=_required_symbol(submit_module, "SubmitClient"),
+            heartbeat_client=_required_symbol(heartbeat_module, "HeartbeatClient"),
+            mock_submit_backend=_required_symbol(backends_module, "MockSubmitBackend"),
+            submit_backend_heartbeat_adapter=_required_symbol(
+                backends_module,
+                "SubmitBackendHeartbeatAdapter",
+            ),
             register_subsystem=_required_symbol(base_module, "register_subsystem"),
+            configure_runtime=_required_symbol(base_module, "configure_runtime"),
             send_heartbeat=_required_symbol(heartbeat_module, "send_heartbeat"),
             submit=_required_symbol(submit_module, "submit"),
+            build_ex0_payload=_required_symbol(heartbeat_module, "build_ex0_payload"),
+            validation_result=_required_symbol(validate_module, "ValidationResult"),
             assert_producer_only=_required_symbol(
                 validate_module,
                 "assert_producer_only",
@@ -77,10 +101,14 @@ def _load_official_sdk_api() -> _SdkApi | None:
         raise UnsupportedSubsystemSdkError(
             "Unsupported subsystem-sdk version: expected pinned public API "
             "subsystem_sdk.base.{SubsystemBaseInterface,"
-            "SubsystemRegistrationSpec,register_subsystem}, "
-            "subsystem_sdk.submit.{SubmitReceipt,submit}, "
-            "subsystem_sdk.heartbeat.send_heartbeat, and "
-            "subsystem_sdk.validate.assert_producer_only."
+            "BaseSubsystemContext,SubsystemRegistrationSpec,"
+            "configure_runtime,register_subsystem}, "
+            "subsystem_sdk.backends.{MockSubmitBackend,"
+            "SubmitBackendHeartbeatAdapter}, "
+            "subsystem_sdk.submit.{SubmitClient,SubmitReceipt,submit}, "
+            "subsystem_sdk.heartbeat.{HeartbeatClient,build_ex0_payload,"
+            "send_heartbeat}, and subsystem_sdk.validate."
+            "{ValidationResult,assert_producer_only}."
         ) from exc
 
 
@@ -116,11 +144,15 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
                 "Install the pinned dependency or inject the local SDK stub "
                 "from test-only code."
             )
+        self._use_sdk = SDK_AVAILABLE and not _stub_explicitly_allowed(allow_sdk_stub)
         self.config = config
         self.run_id = str(uuid4())
         self.last_ex_id: str | None = None
         self.last_submit_failed = False
         self._submit_seq = 0
+        self._sdk_context: Any | None = None
+        self._sdk_context_lock = RLock()
+        self._sdk_registration_spec: Any | None = None
 
     def on_register(self) -> RegistrationSpec:
         """Return this subsystem's registration spec."""
@@ -128,10 +160,8 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
         from .registration import build_registration_spec
 
         spec = build_registration_spec(self.config)
-        if SDK_AVAILABLE:
-            _require_sdk_api().register_subsystem(
-                _to_sdk_registration_spec(spec, self.config),
-            )
+        if self._use_sdk:
+            _require_sdk_api().register_subsystem(self._get_sdk_registration_spec())
         return spec
 
     def on_heartbeat(self) -> HeartbeatPayload:
@@ -146,26 +176,28 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
             last_ex_id=self.last_ex_id,
             status="degraded" if self.last_submit_failed else "ok",
         )
-        if SDK_AVAILABLE:
-            sdk_payload = _to_sdk_heartbeat_payload(payload)
-            _validate_sdk_payload("Ex-0", sdk_payload)
-            _ensure_accepted(
-                _require_sdk_api().send_heartbeat(sdk_payload),
-                "heartbeat",
-            )
+        if self._use_sdk:
+            sdk_status = _to_sdk_heartbeat_status(payload)
+            with _require_sdk_api().configure_runtime(self._get_sdk_context()):
+                _ensure_accepted(
+                    _require_sdk_api().send_heartbeat(sdk_status),
+                    "heartbeat",
+                )
         return payload
 
     def submit(self, candidate: ExPayload) -> SubmitResult:
         """Submit a candidate through the SDK surface."""
 
         ex_type = _payload_ex_type(candidate)
-        if SDK_AVAILABLE:
+        if self._use_sdk:
             sdk_payload = _to_sdk_submit_payload(candidate)
             _validate_sdk_payload(ex_type, sdk_payload)
-            result = _coerce_submit_result(
-                _require_sdk_api().submit(sdk_payload),
-                ex_type,
-            )
+            with _require_sdk_api().configure_runtime(self._get_sdk_context()):
+                result = _coerce_submit_result(
+                    _require_sdk_api().submit(sdk_payload),
+                    ex_type,
+                    use_sdk=True,
+                )
             if getattr(result, "accepted", False):
                 self.last_ex_id = getattr(result, "receipt_id", None)
             return result
@@ -173,13 +205,32 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
         self._submit_seq += 1
         receipt_id = f"{self.run_id}:{self._submit_seq}"
         self.last_ex_id = receipt_id
-        return SubmitResult(
+        return StubSubmitResult(
             accepted=True,
             receipt_id=receipt_id,
             ex_type=ex_type,
             warnings=(),
             errors=(),
         )
+
+    def _get_sdk_registration_spec(self) -> Any:
+        if self._sdk_registration_spec is None:
+            from .registration import build_registration_spec
+
+            self._sdk_registration_spec = _to_sdk_registration_spec(
+                build_registration_spec(self.config),
+                self.config,
+            )
+        return self._sdk_registration_spec
+
+    def _get_sdk_context(self) -> Any:
+        if self._sdk_context is None:
+            with self._sdk_context_lock:
+                if self._sdk_context is None:
+                    self._sdk_context = _build_sdk_runtime_context(
+                        self._get_sdk_registration_spec()
+                    )
+        return self._sdk_context
 
 
 def _stub_explicitly_allowed(allow_sdk_stub: bool) -> bool:
@@ -234,18 +285,16 @@ def _to_sdk_registration_spec(
         heartbeat_policy_ref=f"interval:{config.heartbeat_interval_seconds}s",
         capabilities={
             "parser_version": spec.parser_version,
+            "parser_core_version": config.docling_core_version,
             "registration_ttl_seconds": spec.registration_ttl_seconds,
             "sdk_endpoint": spec.sdk_endpoint,
         },
     )
 
 
-def _to_sdk_heartbeat_payload(payload: HeartbeatPayload) -> dict[str, Any]:
+def _to_sdk_heartbeat_status(payload: HeartbeatPayload) -> dict[str, Any]:
     return {
-        "subsystem_id": PACKAGE_NAME,
-        "version": __version__,
-        "heartbeat_at": payload.timestamp,
-        "status": payload.status,
+        "status": _sdk_heartbeat_state(payload.status),
         "last_output_at": None,
         "pending_count": 0,
     }
@@ -259,15 +308,58 @@ def _to_sdk_submit_payload(candidate: PayloadLike) -> dict[str, Any]:
     heartbeat_at = payload.get("emitted_at")
     if not isinstance(heartbeat_at, datetime):
         heartbeat_at = datetime.now(timezone.utc)
-    return {
-        "ex_type": "Ex-0",
-        "subsystem_id": PACKAGE_NAME,
-        "version": __version__,
-        "heartbeat_at": heartbeat_at,
-        "status": "ok",
-        "last_output_at": heartbeat_at,
-        "pending_count": 0,
-    }
+    return _require_sdk_api().build_ex0_payload(
+        PACKAGE_NAME,
+        __version__,
+        {
+            "status": "healthy",
+            "last_output_at": heartbeat_at,
+            "pending_count": 0,
+        },
+        heartbeat_at=heartbeat_at,
+    )
+
+
+def _build_sdk_runtime_context(registration_spec: Any) -> Any:
+    sdk_api = _require_sdk_api()
+    submit_backend = sdk_api.mock_submit_backend()
+    validator = _validate_sdk_payload_result
+    return sdk_api.base_subsystem_context(
+        registration=registration_spec,
+        submit_client=sdk_api.submit_client(submit_backend, validator=validator),
+        heartbeat_client=sdk_api.heartbeat_client(
+            sdk_api.submit_backend_heartbeat_adapter(submit_backend),
+            validator=validator,
+        ),
+        validator=validator,
+    )
+
+
+def _validate_sdk_payload_result(payload: Mapping[str, Any]) -> Any:
+    sdk_api = _require_sdk_api()
+    ex_type = payload.get("ex_type")
+    if ex_type not in {"Ex-0", "Ex-1", "Ex-2", "Ex-3"}:
+        ex_type = "Ex-0"
+    try:
+        sdk_api.assert_producer_only(payload)
+    except Exception as exc:
+        return sdk_api.validation_result.fail(
+            ex_type=ex_type,
+            schema_version="producer-semantics",
+            field_errors=(str(exc),),
+        )
+    return sdk_api.validation_result.ok(
+        ex_type=ex_type,
+        schema_version="producer-semantics",
+    )
+
+
+def _sdk_heartbeat_state(status: str) -> str:
+    if status == "ok":
+        return "healthy"
+    if status in {"healthy", "degraded", "unhealthy"}:
+        return status
+    return "degraded"
 
 
 def _validate_sdk_payload(ex_type: str, payload: Mapping[str, Any]) -> None:
@@ -289,8 +381,8 @@ def _ensure_accepted(raw_result: Any, operation: str) -> None:
     raise RuntimeError(_rejection_message(raw_result, operation))
 
 
-def _coerce_submit_result(raw_result: Any, ex_type: str) -> SubmitResult:
-    result_model = _submit_result_model()
+def _coerce_submit_result(raw_result: Any, ex_type: str, *, use_sdk: bool) -> Any:
+    result_model = _submit_result_model(use_sdk=use_sdk)
     if isinstance(raw_result, result_model):
         return raw_result
 
@@ -315,13 +407,13 @@ def _coerce_submit_result(raw_result: Any, ex_type: str) -> SubmitResult:
 
     result_data.setdefault("warnings", ())
     result_data.setdefault("errors", ())
-    if not SDK_AVAILABLE:
+    if not use_sdk:
         result_data.setdefault("ex_type", ex_type)
     return result_model(**result_data)
 
 
-def _submit_result_model() -> type[Any]:
-    if SDK_AVAILABLE and _SDK_API is not None:
+def _submit_result_model(*, use_sdk: bool) -> type[Any]:
+    if use_sdk and _SDK_API is not None:
         return _SDK_API.submit_receipt
     return StubSubmitResult
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,15 +48,13 @@ def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> FakeSDKRecorder:
             if recorder.raise_on_submit:
                 raise RuntimeError("fake submit failure")
             if recorder.reject_submit:
-                from subsystem_announcement.runtime.sdk_adapter import SubmitResult
-
-                result = SubmitResult(
-                    accepted=False,
-                    receipt_id="fake-rejected",
-                    ex_type=payload["ex_type"],
-                    warnings=(),
-                    errors=("fake rejected",),
-                )
+                result = {
+                    "accepted": False,
+                    "receipt_id": "fake-rejected",
+                    "ex_type": payload["ex_type"],
+                    "warnings": (),
+                    "errors": ("fake rejected",),
+                }
                 recorder.submit_results.append(result)
                 return result
             result = super().submit(candidate)

--- a/tests/fixtures/announcement.toml
+++ b/tests/fixtures/announcement.toml
@@ -1,5 +1,6 @@
 artifact_root = "artifacts/announcement-test"
 docling_version = "docling==2.15.1"
+docling_core_version = "docling-core==2.13.1"
 llama_index_version = "llama-index-core==0.10.0"
 heartbeat_interval_seconds = 60
 registration_ttl_seconds = 900

--- a/tests/fixtures/announcements/config.toml
+++ b/tests/fixtures/announcements/config.toml
@@ -1,5 +1,6 @@
 artifact_root = "tests/fixtures/announcements/artifacts"
 docling_version = "docling==2.15.1"
+docling_core_version = "docling-core==2.13.1"
 llama_index_version = "llama-index-core==0.10.0"
 heartbeat_interval_seconds = 60
 registration_ttl_seconds = 900

--- a/tests/test_metrics_regression.py
+++ b/tests/test_metrics_regression.py
@@ -79,6 +79,25 @@ def test_metrics_report_satisfies_stage3_thresholds() -> None:
     assert_metrics_within_thresholds(report)
 
 
+def test_metrics_flags_docling_core_version_mismatch() -> None:
+    def stale_core_parse(
+        document: AnnouncementDocumentArtifact,
+        config: AnnouncementConfig,
+    ) -> ParsedAnnouncementArtifact:
+        return _fixture_parse(document, config).model_copy(
+            update={"parser_core_version": "docling-core==2.12.0"}
+        )
+
+    report = compute_metrics_for_manifest(
+        MANIFEST,
+        config=_config(),
+        parse_func=stale_core_parse,
+        build_retrieval_func=_fixture_build_retrieval,
+    )
+
+    assert any("parser_core_version" in diagnostic for diagnostic in report.diagnostics)
+
+
 def test_metrics_timings_are_measured_not_read_from_manifest(
     tmp_path: Path,
 ) -> None:
@@ -257,6 +276,7 @@ def _config() -> AnnouncementConfig:
     return AnnouncementConfig(
         artifact_root=ROOT / "tests" / "fixtures" / "announcements" / "artifacts",
         docling_version="docling==2.15.1",
+        docling_core_version="docling-core==2.13.1",
         llama_index_version="llama-index-core==0.10.0",
     )
 
@@ -282,6 +302,7 @@ def _fixture_parse(
         update={
             "content_hash": document.content_hash,
             "parser_version": config.docling_version,
+            "parser_core_version": config.docling_core_version,
             "source_document": document,
         }
     )

--- a/tests/test_package_layout.py
+++ b/tests/test_package_layout.py
@@ -125,6 +125,9 @@ def test_config_rejects_unpinned_parser_and_index_versions() -> None:
     with pytest.raises(ValidationError, match="docling_version"):
         AnnouncementConfig(docling_version="docling>=2")
 
+    with pytest.raises(ValidationError, match="docling_core_version"):
+        AnnouncementConfig(docling_core_version="docling-core>=2")
+
     with pytest.raises(ValidationError, match="llama_index_version"):
         AnnouncementConfig(llama_index_version="llama-index>=0.11")
 
@@ -156,6 +159,7 @@ def test_cli_doctor_loads_default_config() -> None:
     assert result.returncode == 0
     assert "ok" in result.stdout.splitlines()
     assert "parser_version=not-configured (unset)" in result.stdout.splitlines()
+    assert "parser_core_version=not-configured (unset)" in result.stdout.splitlines()
     assert "index_version=not-configured (unset)" in result.stdout.splitlines()
 
 

--- a/tests/test_parse_artifact.py
+++ b/tests/test_parse_artifact.py
@@ -72,16 +72,23 @@ def _artifact(local_path: Path) -> ParsedAnnouncementArtifact:
 def test_docling_dependency_is_exactly_pinned() -> None:
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     dependencies = pyproject["project"]["dependencies"]
-    docling_dependencies = [
-        dependency for dependency in dependencies if dependency.startswith("docling")
+    docling_dependencies = {
+        dependency.split("==", 1)[0]: dependency
+        for dependency in dependencies
+        if dependency.startswith("docling")
+    }
+    legacy_docling_parser_dependencies = [
+        dependency
+        for dependency in dependencies
+        if dependency.startswith("llama-index-node-parser-docling")
     ]
 
-    assert docling_dependencies == ["docling==2.15.1"]
+    assert docling_dependencies == {
+        "docling": "docling==2.15.1",
+        "docling-core": "docling-core==2.13.1",
+    }
     assert not any(dependency.startswith("docling>=") for dependency in dependencies)
-    assert not any(
-        dependency.startswith("llama-index-node-parser-docling")
-        for dependency in dependencies
-    )
+    assert legacy_docling_parser_dependencies == []
 
 
 def test_parsed_artifact_round_trips_to_disk(tmp_path: Path) -> None:

--- a/tests/test_parse_artifact.py
+++ b/tests/test_parse_artifact.py
@@ -40,6 +40,7 @@ def _artifact(local_path: Path) -> ParsedAnnouncementArtifact:
         announcement_id="ann-1",
         content_hash="a" * 64,
         parser_version="docling==2.15.1",
+        parser_core_version="docling-core==2.13.1",
         title_hierarchy=["重大合同公告"],
         sections=[
             AnnouncementSection(
@@ -101,6 +102,7 @@ def test_parsed_artifact_round_trips_to_disk(tmp_path: Path) -> None:
 
     assert artifact_path == tmp_path / "parsed" / "ann-1" / f"{'a' * 64}.json"
     assert loaded == artifact
+    assert loaded.parser_core_version == "docling-core==2.13.1"
     assert loaded.announcement_id == loaded.source_document.announcement_id
     assert loaded.content_hash == loaded.source_document.content_hash
 

--- a/tests/test_parse_docling_client.py
+++ b/tests/test_parse_docling_client.py
@@ -16,6 +16,7 @@ from subsystem_announcement.discovery.document import AnnouncementDocumentArtifa
 from subsystem_announcement.parse import ParsedAnnouncementArtifact, parse_announcement
 from subsystem_announcement.parse.docling_client import (
     DoclingAnnouncementParser,
+    resolve_docling_core_version,
     resolve_docling_version,
 )
 from subsystem_announcement.parse.errors import (
@@ -56,6 +57,18 @@ def test_resolve_docling_version_prefers_installed_metadata(
     assert version == "docling==2.99.0"
 
 
+def test_resolve_docling_core_version_prefers_installed_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(docling_client.metadata, "version", lambda name: "2.88.0")
+
+    version = resolve_docling_core_version(
+        AnnouncementConfig(docling_core_version="docling-core==2.13.1")
+    )
+
+    assert version == "docling-core==2.88.0"
+
+
 def test_resolve_docling_version_uses_validated_config_when_package_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -67,6 +80,22 @@ def test_resolve_docling_version_uses_validated_config_when_package_missing(
     assert (
         resolve_docling_version(AnnouncementConfig(docling_version="docling==2.15.1"))
         == "docling==2.15.1"
+    )
+
+
+def test_resolve_docling_core_version_uses_validated_config_when_package_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_version(name: str) -> str:
+        raise docling_client.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(docling_client.metadata, "version", missing_version)
+
+    assert (
+        resolve_docling_core_version(
+            AnnouncementConfig(docling_core_version="docling-core==2.13.1")
+        )
+        == "docling-core==2.13.1"
     )
 
 
@@ -109,10 +138,14 @@ def test_parse_announcement_uses_docling_boundary(
 
     artifact = parse_announcement(
         _document(source_path),
-        AnnouncementConfig(docling_version="docling==2.15.1"),
+        AnnouncementConfig(
+            docling_version="docling==2.15.1",
+            docling_core_version="docling-core==2.13.1",
+        ),
     )
 
     assert isinstance(artifact, ParsedAnnouncementArtifact)
+    assert artifact.parser_core_version == "docling-core==2.13.1"
     assert converted_paths == [str(source_path)]
     assert artifact.sections[0].text == "公司签署重大合同。"
 
@@ -149,7 +182,10 @@ def test_parse_announcement_wraps_docling_failures(
     with pytest.raises(DoclingParseError, match="Docling failed"):
         parse_announcement(
             _document(source_path),
-            AnnouncementConfig(docling_version="docling==2.15.1"),
+            AnnouncementConfig(
+                docling_version="docling==2.15.1",
+                docling_core_version="docling-core==2.13.1",
+            ),
         )
 
 
@@ -250,7 +286,10 @@ def test_manifest_samples_parse_through_docling_boundary_smoke(
             }
 
     _install_fake_docling(monkeypatch, ManifestDocumentConverter)
-    config = AnnouncementConfig(docling_version="docling==2.15.1")
+    config = AnnouncementConfig(
+        docling_version="docling==2.15.1",
+        docling_core_version="docling-core==2.13.1",
+    )
 
     for sample in manifest["samples"]:
         sample_path = fixture_root / sample["file"]

--- a/tests/test_parse_normalize.py
+++ b/tests/test_parse_normalize.py
@@ -57,11 +57,13 @@ def test_normalize_docling_result_builds_sections_tables_and_offsets(
         raw_result,
         _document(source_path),
         "docling==2.15.1",
+        "docling-core==2.13.1",
     )
 
     assert artifact.announcement_id == "ann-1"
     assert artifact.content_hash == "b" * 64
     assert artifact.parser_version == "docling==2.15.1"
+    assert artifact.parser_core_version == "docling-core==2.13.1"
     assert [section.section_id for section in artifact.sections] == [
         "sec-0001",
         "sec-0002",

--- a/tests/test_replay_repair.py
+++ b/tests/test_replay_repair.py
@@ -242,6 +242,7 @@ def test_repair_docling_version_upgrade_requires_configured_parser_version(
     )
 
     assert result.parser_version == config.docling_version
+    assert result.parser_core_version == config.docling_core_version
     assert result.retrieval_artifact_path is None
     assert "upgrades" in result.parsed_artifact_path.parts
     latest_pointer = (
@@ -252,6 +253,7 @@ def test_repair_docling_version_upgrade_requires_configured_parser_version(
     )
     latest = json.loads(latest_pointer.read_text(encoding="utf-8"))
     assert latest["parsed_artifact_path"] == str(result.parsed_artifact_path)
+    assert latest["parser_core_version"] == config.docling_core_version
 
 
 def test_docling_upgrade_repair_preserves_previous_parse_when_index_fails(
@@ -260,11 +262,15 @@ def test_docling_upgrade_repair_preserves_previous_parse_when_index_fails(
     config = AnnouncementConfig(
         artifact_root=tmp_path,
         docling_version="docling==2.16.0",
+        docling_core_version="docling-core==2.13.1",
         llama_index_version="llama-index-core==0.10.0",
     )
     document = _cache_document(config, "ANN-REPAIR-003")
     previous = _fake_parse(document, config).model_copy(
-        update={"parser_version": "docling==2.15.1"}
+        update={
+            "parser_version": "docling==2.15.1",
+            "parser_core_version": "docling-core==2.12.0",
+        }
     )
     previous_path = write_parsed_artifact(previous, config.artifact_root)
 
@@ -293,6 +299,7 @@ def test_docling_upgrade_repair_preserves_previous_parse_when_index_fails(
 
     preserved = load_parsed_artifact(previous_path)
     assert preserved.parser_version == "docling==2.15.1"
+    assert preserved.parser_core_version == "docling-core==2.12.0"
     assert preserved.extracted_text == previous.extracted_text
     assert not (previous_path.parent / "latest.json").exists()
 
@@ -368,6 +375,7 @@ def _config(tmp_path: Path) -> AnnouncementConfig:
     return AnnouncementConfig(
         artifact_root=tmp_path,
         docling_version="docling==2.15.1",
+        docling_core_version="docling-core==2.13.1",
         llama_index_version="llama-index-core==0.10.0",
     )
 
@@ -412,6 +420,7 @@ def _fake_parse(
         update={
             "content_hash": document.content_hash,
             "parser_version": config.docling_version,
+            "parser_core_version": config.docling_core_version,
             "source_document": document,
         }
     )

--- a/tests/test_runtime_sdk.py
+++ b/tests/test_runtime_sdk.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import subprocess
 import sys
+from contextlib import nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -35,6 +36,11 @@ def _cli_env() -> dict[str, str]:
         else os.pathsep.join([str(SRC), existing_pythonpath])
     )
     return env
+
+
+def _require_sdk_unavailable() -> None:
+    if SDK_AVAILABLE:
+        pytest.skip("subsystem-sdk is installed; SDK-unavailable path is not active")
 
 
 def test_registration_spec_contains_module_ex_types_and_parser_version() -> None:
@@ -170,7 +176,7 @@ def test_once_rejected_submit_raises_for_health_check(fake_sdk) -> None:
         asyncio.run(run(AnnouncementConfig(heartbeat_interval_seconds=1), once=True))
 
     assert len(fake_sdk.submissions) == 1
-    assert fake_sdk.submit_results[0].accepted is False
+    assert fake_sdk.submit_results[0]["accepted"] is False
 
 
 def test_concurrent_heartbeats_keep_same_run_id() -> None:
@@ -187,6 +193,7 @@ def test_concurrent_heartbeats_keep_same_run_id() -> None:
 
 
 def test_sdk_missing_fails_without_explicit_test_stub() -> None:
+    _require_sdk_unavailable()
     assert SDK_AVAILABLE is False
     with pytest.raises(SubsystemSdkUnavailableError, match="subsystem-sdk is required"):
         AnnouncementSubsystem(AnnouncementConfig())
@@ -195,6 +202,7 @@ def test_sdk_missing_fails_without_explicit_test_stub() -> None:
 def test_sdk_missing_fails_even_with_legacy_test_stub_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _require_sdk_unavailable()
     assert SDK_AVAILABLE is False
     monkeypatch.setenv("SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB", "1")
 
@@ -251,8 +259,39 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
             self.warnings = tuple(kwargs.get("warnings", ()))
             self.errors = tuple(kwargs.get("errors", ()))
 
+    class FakeValidationResult:
+        @classmethod
+        def ok(cls, **kwargs):  # type: ignore[no-untyped-def]
+            return kwargs
+
+        @classmethod
+        def fail(cls, **kwargs):  # type: ignore[no-untyped-def]
+            return kwargs
+
+    class FakeContext:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.kwargs = kwargs
+
+    class FakeSubmitBackend:
+        pass
+
+    class FakeSubmitClient:
+        def __init__(self, backend, *, validator):  # type: ignore[no-untyped-def]
+            self.backend = backend
+            self.validator = validator
+
+    class FakeHeartbeatClient(FakeSubmitClient):
+        pass
+
+    class FakeHeartbeatAdapter:
+        def __init__(self, backend):  # type: ignore[no-untyped-def]
+            self.backend = backend
+
     def register_subsystem(spec):  # type: ignore[no-untyped-def]
         calls.append(("register", spec.kwargs))
+
+    def configure_runtime(context):  # type: ignore[no-untyped-def]
+        return nullcontext(context)
 
     def send_heartbeat(payload):  # type: ignore[no-untyped-def]
         calls.append(("heartbeat", payload))
@@ -280,13 +319,39 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
         assert "ingest_seq" not in payload
         assert "layer_b_receipt_id" not in payload
 
+    def build_ex0_payload(  # type: ignore[no-untyped-def]
+        subsystem_id,
+        version,
+        status,
+        *,
+        heartbeat_at,
+    ):
+        return {
+            "ex_type": "Ex-0",
+            "semantic": "metadata_or_heartbeat",
+            "subsystem_id": subsystem_id,
+            "version": version,
+            "heartbeat_at": heartbeat_at,
+            "status": status["status"],
+            "last_output_at": status["last_output_at"],
+            "pending_count": status["pending_count"],
+        }
+
     fake_api = sdk_adapter._SdkApi(
         subsystem_base_interface=FakeBase,
+        base_subsystem_context=FakeContext,
         registration_spec=FakeRegistrationSpec,
         submit_receipt=FakeSubmitReceipt,
+        submit_client=FakeSubmitClient,
+        heartbeat_client=FakeHeartbeatClient,
+        mock_submit_backend=FakeSubmitBackend,
+        submit_backend_heartbeat_adapter=FakeHeartbeatAdapter,
         register_subsystem=register_subsystem,
+        configure_runtime=configure_runtime,
         send_heartbeat=send_heartbeat,
         submit=submit,
+        build_ex0_payload=build_ex0_payload,
+        validation_result=FakeValidationResult,
         assert_producer_only=assert_producer_only,
     )
     monkeypatch.setattr(sdk_adapter, "SDK_AVAILABLE", True)
@@ -313,6 +378,7 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
             "heartbeat_policy_ref": "interval:60s",
             "capabilities": {
                 "parser_version": "not-configured",
+                "parser_core_version": "not-configured",
                 "registration_ttl_seconds": 900,
                 "sdk_endpoint": None,
             },
@@ -321,10 +387,7 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
     assert (
         "heartbeat",
         {
-            "subsystem_id": "subsystem-announcement",
-            "version": "0.1.0",
-            "heartbeat_at": heartbeat.timestamp,
-            "status": "ok",
+            "status": "healthy",
             "last_output_at": None,
             "pending_count": 0,
         },
@@ -333,9 +396,10 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
     assert len(submit_calls) == 1
     submit_payload = submit_calls[0][1]
     assert submit_payload["ex_type"] == "Ex-0"
+    assert submit_payload["semantic"] == "metadata_or_heartbeat"
     assert submit_payload["subsystem_id"] == "subsystem-announcement"
     assert submit_payload["version"] == "0.1.0"
-    assert submit_payload["status"] == "ok"
+    assert submit_payload["status"] == "healthy"
     assert submit_payload["pending_count"] == 0
     assert "run_id" not in submit_payload
     assert "reason" not in submit_payload
@@ -363,6 +427,7 @@ def test_load_config_rejects_non_positive_runtime_intervals(
 
 
 def test_cli_ping_fails_when_sdk_is_unavailable() -> None:
+    _require_sdk_unavailable()
     result = subprocess.run(
         [sys.executable, "-m", "subsystem_announcement", "ping"],
         cwd=ROOT,
@@ -378,6 +443,7 @@ def test_cli_ping_fails_when_sdk_is_unavailable() -> None:
 
 
 def test_cli_ping_fails_when_legacy_test_stub_env_is_set() -> None:
+    _require_sdk_unavailable()
     env = _cli_env()
     env["SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB"] = "1"
 
@@ -396,6 +462,7 @@ def test_cli_ping_fails_when_legacy_test_stub_env_is_set() -> None:
 
 
 def test_cli_run_once_fails_when_sdk_is_unavailable() -> None:
+    _require_sdk_unavailable()
     result = subprocess.run(
         [sys.executable, "-m", "subsystem_announcement", "run", "--once"],
         cwd=ROOT,


### PR DESCRIPTION
Closes #34

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `pyproject.toml`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/graph/candidates.py`, `src/subsystem_announcement/graph/deltas.py`, `src/subsystem_announcement/index/retrieval_artifact.py`, `src/subsystem_announcement/index/vector_store.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/runtime/metrics.py`


---
## Background

CI \`pip install -e .\` fails with ResolutionImpossible:

\`\`\`
docling 2.15.1 depends on docling-core<3.0.0 and >=2.13.1
llama-index-node-parser-docling 0.1.0 depends on docling-core<2.0.0 and >=1.7.1
\`\`\`

I bumped \`llama-index-node-parser-docling\` to \`>=0.4\` but conflict persists (probably another sub-dep chain).

## Required fix

Reconcile docling-core version constraint across all docling-related packages. Likely needs:
1. Remove \`llama-index-node-parser-docling\` dependency entirely (use docling directly)
2. OR pin compatible versions of llama-index-* + docling
3. OR drop docling for an alternative (if not strictly needed)

## Verification

After fix:
- CI install step succeeds
- Existing tests still pass

## Files

- \`pyproject.toml\` (dependencies block)