### PR TITLE
feat(#34): CI install fails: docling vs llama-index-node-parser-docling version conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "docling==2.15.1",
+    "docling-core>=2.13.1,<3.0.0",
     "llama-index-core==0.10.0",
     "pydantic>=2.6",
     "typer>=0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "docling==2.15.1",
-    "docling-core>=2.13.1,<3.0.0",
+    "docling-core==2.13.1",
     "llama-index-core==0.10.0",
     "pydantic>=2.6",
     "typer>=0.12",

--- a/src/subsystem_announcement/runtime/sdk_adapter.py
+++ b/src/subsystem_announcement/runtime/sdk_adapter.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Final, TypeAlias
 from uuid import uuid4
 
@@ -47,9 +48,13 @@ class _SdkApi:
     assert_producer_only: Any
     base_subsystem_context: type[Any] | None = None
     configure_runtime: Any | None = None
+    get_runtime: Any | None = None
+    runtime_not_configured_error: type[Exception] | None = None
     submit_client: type[Any] | None = None
     heartbeat_client: type[Any] | None = None
-    mock_submit_backend: type[Any] | None = None
+    submit_backend_config: type[Any] | None = None
+    build_submit_backend: Any | None = None
+    load_submit_backend_config: Any | None = None
     submit_backend_heartbeat_adapter: type[Any] | None = None
     validation_result: type[Any] | None = None
 
@@ -64,6 +69,7 @@ def _load_official_sdk_api() -> _SdkApi | None:
         heartbeat_module = importlib.import_module("subsystem_sdk.heartbeat")
         validate_module = importlib.import_module("subsystem_sdk.validate")
         backends_module = importlib.import_module("subsystem_sdk.backends")
+        runtime_module = importlib.import_module("subsystem_sdk.base.runtime")
         return _SdkApi(
             subsystem_base_interface=_required_symbol(
                 base_module,
@@ -86,9 +92,25 @@ def _load_official_sdk_api() -> _SdkApi | None:
                 "BaseSubsystemContext",
             ),
             configure_runtime=_required_symbol(base_module, "configure_runtime"),
+            get_runtime=_required_symbol(runtime_module, "get_runtime"),
+            runtime_not_configured_error=_required_symbol(
+                base_module,
+                "RuntimeNotConfiguredError",
+            ),
             submit_client=_required_symbol(submit_module, "SubmitClient"),
             heartbeat_client=_required_symbol(heartbeat_module, "HeartbeatClient"),
-            mock_submit_backend=_required_symbol(backends_module, "MockSubmitBackend"),
+            submit_backend_config=_required_symbol(
+                backends_module,
+                "SubmitBackendConfig",
+            ),
+            build_submit_backend=_required_symbol(
+                backends_module,
+                "build_submit_backend",
+            ),
+            load_submit_backend_config=_required_symbol(
+                base_module,
+                "load_submit_backend_config",
+            ),
             submit_backend_heartbeat_adapter=_required_symbol(
                 backends_module,
                 "SubmitBackendHeartbeatAdapter",
@@ -99,10 +121,12 @@ def _load_official_sdk_api() -> _SdkApi | None:
         raise UnsupportedSubsystemSdkError(
             "Unsupported subsystem-sdk version: expected pinned public API "
             "subsystem_sdk.base.{BaseSubsystemContext,SubsystemBaseInterface,"
-            "SubsystemRegistrationSpec,configure_runtime,register_subsystem}, "
+            "SubsystemRegistrationSpec,RuntimeNotConfiguredError,"
+            "configure_runtime,load_submit_backend_config,register_subsystem}, "
+            "subsystem_sdk.base.runtime.get_runtime, "
             "subsystem_sdk.submit.{SubmitClient,SubmitReceipt,submit}, "
             "subsystem_sdk.heartbeat.{HeartbeatClient,send_heartbeat}, "
-            "subsystem_sdk.backends.{MockSubmitBackend,"
+            "subsystem_sdk.backends.{SubmitBackendConfig,build_submit_backend,"
             "SubmitBackendHeartbeatAdapter}, and "
             "subsystem_sdk.validate.{ValidationResult,assert_producer_only}."
         ) from exc
@@ -211,6 +235,8 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
 
     def _sdk_runtime_scope(self) -> Any:
         api = _require_sdk_api()
+        if _get_configured_sdk_runtime(api) is not None:
+            return nullcontext()
         context = self._ensure_sdk_context()
         if context is None or api.configure_runtime is None:
             return nullcontext()
@@ -225,7 +251,8 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
             api.base_subsystem_context,
             api.submit_client,
             api.heartbeat_client,
-            api.mock_submit_backend,
+            api.submit_backend_config,
+            api.build_submit_backend,
             api.submit_backend_heartbeat_adapter,
             api.validation_result,
         )
@@ -240,7 +267,7 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
                 self.config,
             )
 
-        submit_backend = api.mock_submit_backend()
+        submit_backend = _build_sdk_submit_backend(api, self.config)
         submit_client = api.submit_client(
             submit_backend,
             validator=_sdk_validate_payload,
@@ -256,6 +283,82 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
             validator=_sdk_validate_payload,
         )
         return self._sdk_context
+
+
+_BACKEND_CONFIG_SUFFIXES: Final[frozenset[str]] = frozenset(
+    {".json", ".toml", ".yaml", ".yml"}
+)
+
+
+def _get_configured_sdk_runtime(api: _SdkApi) -> Any | None:
+    if api.get_runtime is None:
+        return None
+    try:
+        return api.get_runtime()
+    except Exception as exc:
+        runtime_error = api.runtime_not_configured_error
+        if runtime_error is not None and isinstance(exc, runtime_error):
+            return None
+        raise
+
+
+def _build_sdk_submit_backend(api: _SdkApi, config: AnnouncementConfig) -> Any:
+    backend_config = _load_sdk_submit_backend_config(api, config)
+    _reject_mock_sdk_backend(backend_config, "configured SDK submit backend")
+
+    backend = api.build_submit_backend(backend_config)
+    _reject_mock_sdk_backend(backend, "constructed SDK submit backend")
+    return backend
+
+
+def _load_sdk_submit_backend_config(
+    api: _SdkApi,
+    config: AnnouncementConfig,
+) -> Any:
+    endpoint = config.sdk_endpoint
+    if endpoint is None or not endpoint.strip():
+        raise SubsystemSdkUnavailableError(
+            "subsystem-sdk runtime is not configured and sdk_endpoint is unset; "
+            "wrap runtime calls in subsystem_sdk.base.configure_runtime(...) or "
+            "set AnnouncementConfig.sdk_endpoint to a non-mock SDK backend "
+            "configuration path or PostgreSQL DSN."
+        )
+
+    endpoint_text = endpoint.strip()
+    if _looks_like_backend_config_path(endpoint_text):
+        if api.load_submit_backend_config is None:
+            raise UnsupportedSubsystemSdkError(
+                "subsystem-sdk load_submit_backend_config is required for "
+                "sdk_endpoint backend config paths"
+            )
+        return api.load_submit_backend_config(Path(endpoint_text))
+
+    config_model = api.submit_backend_config
+    if config_model is None:
+        raise UnsupportedSubsystemSdkError(
+            "subsystem-sdk SubmitBackendConfig is required for sdk_endpoint DSNs"
+        )
+    return config_model(backend_kind="lite_pg", dsn=endpoint_text)
+
+
+def _looks_like_backend_config_path(endpoint: str) -> bool:
+    if "://" in endpoint:
+        return False
+    return Path(endpoint).suffix.lower() in _BACKEND_CONFIG_SUFFIXES
+
+
+def _reject_mock_sdk_backend(value: Any, label: str) -> None:
+    if _backend_kind(value) != "mock":
+        return
+    raise UnsupportedSubsystemSdkError(
+        f"{label} must not use backend_kind='mock' in production runtime"
+    )
+
+
+def _backend_kind(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return value.get("backend_kind")
+    return getattr(value, "backend_kind", None)
 
 
 def _stub_explicitly_allowed(allow_sdk_stub: bool) -> bool:

--- a/src/subsystem_announcement/runtime/sdk_adapter.py
+++ b/src/subsystem_announcement/runtime/sdk_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 from collections.abc import Mapping, Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Final, TypeAlias
@@ -44,6 +45,13 @@ class _SdkApi:
     send_heartbeat: Any
     submit: Any
     assert_producer_only: Any
+    base_subsystem_context: type[Any] | None = None
+    configure_runtime: Any | None = None
+    submit_client: type[Any] | None = None
+    heartbeat_client: type[Any] | None = None
+    mock_submit_backend: type[Any] | None = None
+    submit_backend_heartbeat_adapter: type[Any] | None = None
+    validation_result: type[Any] | None = None
 
 
 def _load_official_sdk_api() -> _SdkApi | None:
@@ -55,6 +63,7 @@ def _load_official_sdk_api() -> _SdkApi | None:
         submit_module = importlib.import_module("subsystem_sdk.submit")
         heartbeat_module = importlib.import_module("subsystem_sdk.heartbeat")
         validate_module = importlib.import_module("subsystem_sdk.validate")
+        backends_module = importlib.import_module("subsystem_sdk.backends")
         return _SdkApi(
             subsystem_base_interface=_required_symbol(
                 base_module,
@@ -72,15 +81,30 @@ def _load_official_sdk_api() -> _SdkApi | None:
                 validate_module,
                 "assert_producer_only",
             ),
+            base_subsystem_context=_required_symbol(
+                base_module,
+                "BaseSubsystemContext",
+            ),
+            configure_runtime=_required_symbol(base_module, "configure_runtime"),
+            submit_client=_required_symbol(submit_module, "SubmitClient"),
+            heartbeat_client=_required_symbol(heartbeat_module, "HeartbeatClient"),
+            mock_submit_backend=_required_symbol(backends_module, "MockSubmitBackend"),
+            submit_backend_heartbeat_adapter=_required_symbol(
+                backends_module,
+                "SubmitBackendHeartbeatAdapter",
+            ),
+            validation_result=_required_symbol(validate_module, "ValidationResult"),
         )
     except Exception as exc:
         raise UnsupportedSubsystemSdkError(
             "Unsupported subsystem-sdk version: expected pinned public API "
-            "subsystem_sdk.base.{SubsystemBaseInterface,"
-            "SubsystemRegistrationSpec,register_subsystem}, "
-            "subsystem_sdk.submit.{SubmitReceipt,submit}, "
-            "subsystem_sdk.heartbeat.send_heartbeat, and "
-            "subsystem_sdk.validate.assert_producer_only."
+            "subsystem_sdk.base.{BaseSubsystemContext,SubsystemBaseInterface,"
+            "SubsystemRegistrationSpec,configure_runtime,register_subsystem}, "
+            "subsystem_sdk.submit.{SubmitClient,SubmitReceipt,submit}, "
+            "subsystem_sdk.heartbeat.{HeartbeatClient,send_heartbeat}, "
+            "subsystem_sdk.backends.{MockSubmitBackend,"
+            "SubmitBackendHeartbeatAdapter}, and "
+            "subsystem_sdk.validate.{ValidationResult,assert_producer_only}."
         ) from exc
 
 
@@ -98,7 +122,7 @@ SubsystemBaseInterface = (
     if _SDK_API is not None
     else StubSubsystemBaseInterface
 )
-SubmitResult = _SDK_API.submit_receipt if _SDK_API is not None else StubSubmitResult
+SubmitResult = StubSubmitResult
 
 
 class AnnouncementSubsystem(SubsystemBaseInterface):
@@ -117,6 +141,9 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
                 "from test-only code."
             )
         self.config = config
+        self._use_sdk = SDK_AVAILABLE and not allow_sdk_stub
+        self._sdk_registration: Any | None = None
+        self._sdk_context: Any | None = None
         self.run_id = str(uuid4())
         self.last_ex_id: str | None = None
         self.last_submit_failed = False
@@ -128,10 +155,9 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
         from .registration import build_registration_spec
 
         spec = build_registration_spec(self.config)
-        if SDK_AVAILABLE:
-            _require_sdk_api().register_subsystem(
-                _to_sdk_registration_spec(spec, self.config),
-            )
+        if self._use_sdk:
+            self._sdk_registration = _to_sdk_registration_spec(spec, self.config)
+            _require_sdk_api().register_subsystem(self._sdk_registration)
         return spec
 
     def on_heartbeat(self) -> HeartbeatPayload:
@@ -146,26 +172,28 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
             last_ex_id=self.last_ex_id,
             status="degraded" if self.last_submit_failed else "ok",
         )
-        if SDK_AVAILABLE:
-            sdk_payload = _to_sdk_heartbeat_payload(payload)
-            _validate_sdk_payload("Ex-0", sdk_payload)
-            _ensure_accepted(
-                _require_sdk_api().send_heartbeat(sdk_payload),
-                "heartbeat",
-            )
+        if self._use_sdk:
+            with self._sdk_runtime_scope():
+                _ensure_accepted(
+                    _require_sdk_api().send_heartbeat(
+                        _to_sdk_heartbeat_status(payload)
+                    ),
+                    "heartbeat",
+                )
         return payload
 
     def submit(self, candidate: ExPayload) -> SubmitResult:
         """Submit a candidate through the SDK surface."""
 
         ex_type = _payload_ex_type(candidate)
-        if SDK_AVAILABLE:
+        if self._use_sdk:
             sdk_payload = _to_sdk_submit_payload(candidate)
             _validate_sdk_payload(ex_type, sdk_payload)
-            result = _coerce_submit_result(
-                _require_sdk_api().submit(sdk_payload),
-                ex_type,
-            )
+            with self._sdk_runtime_scope():
+                result = _coerce_submit_result(
+                    _require_sdk_api().submit(sdk_payload),
+                    ex_type,
+                )
             if getattr(result, "accepted", False):
                 self.last_ex_id = getattr(result, "receipt_id", None)
             return result
@@ -173,13 +201,61 @@ class AnnouncementSubsystem(SubsystemBaseInterface):
         self._submit_seq += 1
         receipt_id = f"{self.run_id}:{self._submit_seq}"
         self.last_ex_id = receipt_id
-        return SubmitResult(
+        return StubSubmitResult(
             accepted=True,
             receipt_id=receipt_id,
             ex_type=ex_type,
             warnings=(),
             errors=(),
         )
+
+    def _sdk_runtime_scope(self) -> Any:
+        api = _require_sdk_api()
+        context = self._ensure_sdk_context()
+        if context is None or api.configure_runtime is None:
+            return nullcontext()
+        return api.configure_runtime(context)
+
+    def _ensure_sdk_context(self) -> Any | None:
+        if self._sdk_context is not None:
+            return self._sdk_context
+
+        api = _require_sdk_api()
+        required = (
+            api.base_subsystem_context,
+            api.submit_client,
+            api.heartbeat_client,
+            api.mock_submit_backend,
+            api.submit_backend_heartbeat_adapter,
+            api.validation_result,
+        )
+        if any(symbol is None for symbol in required):
+            return None
+
+        if self._sdk_registration is None:
+            from .registration import build_registration_spec
+
+            self._sdk_registration = _to_sdk_registration_spec(
+                build_registration_spec(self.config),
+                self.config,
+            )
+
+        submit_backend = api.mock_submit_backend()
+        submit_client = api.submit_client(
+            submit_backend,
+            validator=_sdk_validate_payload,
+        )
+        heartbeat_client = api.heartbeat_client(
+            api.submit_backend_heartbeat_adapter(submit_backend),
+            validator=_sdk_validate_payload,
+        )
+        self._sdk_context = api.base_subsystem_context(
+            registration=self._sdk_registration,
+            submit_client=submit_client,
+            heartbeat_client=heartbeat_client,
+            validator=_sdk_validate_payload,
+        )
+        return self._sdk_context
 
 
 def _stub_explicitly_allowed(allow_sdk_stub: bool) -> bool:
@@ -231,7 +307,7 @@ def _to_sdk_registration_spec(
         domain="announcement",
         supported_ex_types=spec.owned_ex_types,
         owner=PACKAGE_NAME,
-        heartbeat_policy_ref=f"interval:{config.heartbeat_interval_seconds}s",
+        heartbeat_policy_ref="default",
         capabilities={
             "parser_version": spec.parser_version,
             "registration_ttl_seconds": spec.registration_ttl_seconds,
@@ -240,12 +316,9 @@ def _to_sdk_registration_spec(
     )
 
 
-def _to_sdk_heartbeat_payload(payload: HeartbeatPayload) -> dict[str, Any]:
+def _to_sdk_heartbeat_status(payload: HeartbeatPayload) -> dict[str, Any]:
     return {
-        "subsystem_id": PACKAGE_NAME,
-        "version": __version__,
-        "heartbeat_at": payload.timestamp,
-        "status": payload.status,
+        "status": _to_sdk_heartbeat_state(payload.status),
         "last_output_at": None,
         "pending_count": 0,
     }
@@ -261,10 +334,11 @@ def _to_sdk_submit_payload(candidate: PayloadLike) -> dict[str, Any]:
         heartbeat_at = datetime.now(timezone.utc)
     return {
         "ex_type": "Ex-0",
+        "semantic": "metadata_or_heartbeat",
         "subsystem_id": PACKAGE_NAME,
         "version": __version__,
         "heartbeat_at": heartbeat_at,
-        "status": "ok",
+        "status": "healthy",
         "last_output_at": heartbeat_at,
         "pending_count": 0,
     }
@@ -272,6 +346,37 @@ def _to_sdk_submit_payload(candidate: PayloadLike) -> dict[str, Any]:
 
 def _validate_sdk_payload(ex_type: str, payload: Mapping[str, Any]) -> None:
     _require_sdk_api().assert_producer_only(ex_type, payload)
+
+
+def _sdk_validate_payload(payload: Mapping[str, Any]) -> Any:
+    api = _require_sdk_api()
+    result_model = api.validation_result
+    if result_model is None:
+        raise UnsupportedSubsystemSdkError(
+            "subsystem-sdk ValidationResult is required for runtime context wiring"
+        )
+
+    ex_type = _payload_ex_type(payload)
+    try:
+        _validate_sdk_payload(ex_type, payload)
+    except Exception as exc:
+        return result_model.fail(
+            ex_type=ex_type,
+            schema_version="announcement-producer-only",
+            field_errors=(str(exc),),
+        )
+    return result_model.ok(
+        ex_type=ex_type,
+        schema_version="announcement-producer-only",
+    )
+
+
+def _to_sdk_heartbeat_state(status: str) -> str:
+    if status == "ok":
+        return "healthy"
+    if status == "degraded":
+        return "degraded"
+    return "unhealthy"
 
 
 def _ensure_accepted(raw_result: Any, operation: str) -> None:

--- a/tests/test_parse_artifact.py
+++ b/tests/test_parse_artifact.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import tomllib
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,6 +19,11 @@ from subsystem_announcement.parse.artifact import (
 from subsystem_announcement.parse.errors import ParseNormalizationError
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _dependency_name(dependency: str) -> str:
+    head = dependency.split(";", maxsplit=1)[0].strip()
+    return re.split(r"[<>=!~\[]", head, maxsplit=1)[0].strip().lower()
 
 
 def _document(local_path: Path) -> AnnouncementDocumentArtifact:
@@ -72,16 +78,15 @@ def _artifact(local_path: Path) -> ParsedAnnouncementArtifact:
 def test_docling_dependency_is_exactly_pinned() -> None:
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     dependencies = pyproject["project"]["dependencies"]
-    docling_dependencies = [
-        dependency for dependency in dependencies if dependency.startswith("docling")
-    ]
+    dependencies_by_name = {
+        _dependency_name(dependency): dependency for dependency in dependencies
+    }
 
-    assert docling_dependencies == ["docling==2.15.1"]
-    assert not any(dependency.startswith("docling>=") for dependency in dependencies)
-    assert not any(
-        dependency.startswith("llama-index-node-parser-docling")
-        for dependency in dependencies
-    )
+    assert dependencies_by_name["docling"] == "docling==2.15.1"
+    assert dependencies_by_name["docling-core"] == "docling-core>=2.13.1,<3.0.0"
+    assert dependencies_by_name["llama-index-core"] == "llama-index-core==0.10.0"
+    assert "llama-index" not in dependencies_by_name
+    assert "llama-index-node-parser-docling" not in dependencies_by_name
 
 
 def test_parsed_artifact_round_trips_to_disk(tmp_path: Path) -> None:

--- a/tests/test_parse_artifact.py
+++ b/tests/test_parse_artifact.py
@@ -83,7 +83,7 @@ def test_docling_dependency_is_exactly_pinned() -> None:
     }
 
     assert dependencies_by_name["docling"] == "docling==2.15.1"
-    assert dependencies_by_name["docling-core"] == "docling-core>=2.13.1,<3.0.0"
+    assert dependencies_by_name["docling-core"] == "docling-core==2.13.1"
     assert dependencies_by_name["llama-index-core"] == "llama-index-core==0.10.0"
     assert "llama-index" not in dependencies_by_name
     assert "llama-index-node-parser-docling" not in dependencies_by_name

--- a/tests/test_runtime_sdk.py
+++ b/tests/test_runtime_sdk.py
@@ -187,6 +187,8 @@ def test_concurrent_heartbeats_keep_same_run_id() -> None:
 
 
 def test_sdk_missing_fails_without_explicit_test_stub() -> None:
+    if SDK_AVAILABLE:
+        pytest.skip("subsystem-sdk is installed in this environment")
     assert SDK_AVAILABLE is False
     with pytest.raises(SubsystemSdkUnavailableError, match="subsystem-sdk is required"):
         AnnouncementSubsystem(AnnouncementConfig())
@@ -195,6 +197,8 @@ def test_sdk_missing_fails_without_explicit_test_stub() -> None:
 def test_sdk_missing_fails_even_with_legacy_test_stub_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    if SDK_AVAILABLE:
+        pytest.skip("subsystem-sdk is installed in this environment")
     assert SDK_AVAILABLE is False
     monkeypatch.setenv("SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB", "1")
 
@@ -310,7 +314,7 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
             "domain": "announcement",
             "supported_ex_types": ("Ex-0", "Ex-1", "Ex-2", "Ex-3"),
             "owner": "subsystem-announcement",
-            "heartbeat_policy_ref": "interval:60s",
+            "heartbeat_policy_ref": "default",
             "capabilities": {
                 "parser_version": "not-configured",
                 "registration_ttl_seconds": 900,
@@ -321,10 +325,7 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
     assert (
         "heartbeat",
         {
-            "subsystem_id": "subsystem-announcement",
-            "version": "0.1.0",
-            "heartbeat_at": heartbeat.timestamp,
-            "status": "ok",
+            "status": "healthy",
             "last_output_at": None,
             "pending_count": 0,
         },
@@ -333,9 +334,10 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
     assert len(submit_calls) == 1
     submit_payload = submit_calls[0][1]
     assert submit_payload["ex_type"] == "Ex-0"
+    assert submit_payload["semantic"] == "metadata_or_heartbeat"
     assert submit_payload["subsystem_id"] == "subsystem-announcement"
     assert submit_payload["version"] == "0.1.0"
-    assert submit_payload["status"] == "ok"
+    assert submit_payload["status"] == "healthy"
     assert submit_payload["pending_count"] == 0
     assert "run_id" not in submit_payload
     assert "reason" not in submit_payload
@@ -362,7 +364,7 @@ def test_load_config_rejects_non_positive_runtime_intervals(
         load_config(config_path)
 
 
-def test_cli_ping_fails_when_sdk_is_unavailable() -> None:
+def test_cli_ping_uses_sdk_when_available_and_fails_without_it() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "subsystem_announcement", "ping"],
         cwd=ROOT,
@@ -372,12 +374,17 @@ def test_cli_ping_fails_when_sdk_is_unavailable() -> None:
         text=True,
     )
 
-    assert result.returncode == 1
-    assert result.stdout.strip() == ""
-    assert "subsystem-sdk is required" in result.stderr
+    if SDK_AVAILABLE:
+        assert result.returncode == 0
+        assert result.stdout.strip() == "ok"
+        assert result.stderr == ""
+    else:
+        assert result.returncode == 1
+        assert result.stdout.strip() == ""
+        assert "subsystem-sdk is required" in result.stderr
 
 
-def test_cli_ping_fails_when_legacy_test_stub_env_is_set() -> None:
+def test_cli_ping_ignores_legacy_stub_env_and_uses_or_requires_sdk() -> None:
     env = _cli_env()
     env["SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB"] = "1"
 
@@ -390,12 +397,17 @@ def test_cli_ping_fails_when_legacy_test_stub_env_is_set() -> None:
         text=True,
     )
 
-    assert result.returncode == 1
-    assert result.stdout.strip() == ""
-    assert "subsystem-sdk is required" in result.stderr
+    if SDK_AVAILABLE:
+        assert result.returncode == 0
+        assert result.stdout.strip() == "ok"
+        assert result.stderr == ""
+    else:
+        assert result.returncode == 1
+        assert result.stdout.strip() == ""
+        assert "subsystem-sdk is required" in result.stderr
 
 
-def test_cli_run_once_fails_when_sdk_is_unavailable() -> None:
+def test_cli_run_once_uses_sdk_when_available_and_fails_without_it() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "subsystem_announcement", "run", "--once"],
         cwd=ROOT,
@@ -405,6 +417,11 @@ def test_cli_run_once_fails_when_sdk_is_unavailable() -> None:
         text=True,
     )
 
-    assert result.returncode == 1
-    assert result.stdout.strip() == ""
-    assert "subsystem-sdk is required" in result.stderr
+    if SDK_AVAILABLE:
+        assert result.returncode == 0
+        assert result.stdout.strip() == "ok"
+        assert result.stderr == ""
+    else:
+        assert result.returncode == 1
+        assert result.stdout.strip() == ""
+        assert "subsystem-sdk is required" in result.stderr

--- a/tests/test_runtime_sdk.py
+++ b/tests/test_runtime_sdk.py
@@ -4,8 +4,10 @@ import asyncio
 import os
 import subprocess
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -20,6 +22,7 @@ from subsystem_announcement.runtime.sdk_adapter import (
     AnnouncementSubsystem,
     SDK_AVAILABLE,
     SubsystemSdkUnavailableError,
+    UnsupportedSubsystemSdkError,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -35,6 +38,15 @@ def _cli_env() -> dict[str, str]:
         else os.pathsep.join([str(SRC), existing_pythonpath])
     )
     return env
+
+
+def _assert_cli_requires_sdk_or_backend(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 1
+    assert result.stdout.strip() == ""
+    if SDK_AVAILABLE:
+        assert "sdk_endpoint is unset" in result.stderr
+    else:
+        assert "subsystem-sdk is required" in result.stderr
 
 
 def test_registration_spec_contains_module_ex_types_and_parser_version() -> None:
@@ -263,8 +275,8 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
         return FakeSubmitReceipt(
             accepted=True,
             receipt_id="heartbeat-receipt",
-            backend_kind="mock",
-            transport_ref=None,
+            backend_kind="lite_pg",
+            transport_ref="heartbeat-transport",
             validator_version="validator-v1",
         )
 
@@ -273,8 +285,8 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
         return FakeSubmitReceipt(
             accepted=True,
             receipt_id="sdk-receipt",
-            backend_kind="mock",
-            transport_ref=None,
+            backend_kind="lite_pg",
+            transport_ref="submit-transport",
             validator_version="validator-v1",
         )
 
@@ -343,6 +355,356 @@ def test_real_sdk_mode_delegates_official_registration_heartbeat_and_submit(
     assert "reason" not in submit_payload
 
 
+def test_real_sdk_mode_uses_preconfigured_runtime_without_building_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, object]] = []
+    configured_runtime = object()
+
+    class RuntimeNotConfiguredError(RuntimeError):
+        pass
+
+    class FakeBase:
+        pass
+
+    class FakeRegistrationSpec:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.kwargs = kwargs
+
+    class FakeSubmitReceipt:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.accepted = kwargs["accepted"]
+            self.receipt_id = kwargs["receipt_id"]
+            self.backend_kind = kwargs["backend_kind"]
+            self.transport_ref = kwargs["transport_ref"]
+            self.validator_version = kwargs["validator_version"]
+            self.warnings = tuple(kwargs.get("warnings", ()))
+            self.errors = tuple(kwargs.get("errors", ()))
+
+    def register_subsystem(spec):  # type: ignore[no-untyped-def]
+        calls.append(("register", spec.kwargs))
+
+    def get_runtime():  # type: ignore[no-untyped-def]
+        return configured_runtime
+
+    def configure_runtime(context):  # type: ignore[no-untyped-def]
+        raise AssertionError("preconfigured SDK runtime should be reused")
+
+    def build_submit_backend(config):  # type: ignore[no-untyped-def]
+        raise AssertionError("preconfigured SDK runtime should own the backend")
+
+    def send_heartbeat(payload):  # type: ignore[no-untyped-def]
+        calls.append(("heartbeat", payload))
+        return FakeSubmitReceipt(
+            accepted=True,
+            receipt_id="heartbeat-receipt",
+            backend_kind="lite_pg",
+            transport_ref="heartbeat-transport",
+            validator_version="validator-v1",
+        )
+
+    def submit(payload):  # type: ignore[no-untyped-def]
+        calls.append(("submit", payload))
+        return FakeSubmitReceipt(
+            accepted=True,
+            receipt_id="sdk-receipt",
+            backend_kind="lite_pg",
+            transport_ref="submit-transport",
+            validator_version="validator-v1",
+        )
+
+    def assert_producer_only(ex_type, payload):  # type: ignore[no-untyped-def]
+        calls.append(("validate", (ex_type, payload)))
+
+    fake_api = sdk_adapter._SdkApi(
+        subsystem_base_interface=FakeBase,
+        registration_spec=FakeRegistrationSpec,
+        submit_receipt=FakeSubmitReceipt,
+        register_subsystem=register_subsystem,
+        send_heartbeat=send_heartbeat,
+        submit=submit,
+        assert_producer_only=assert_producer_only,
+        configure_runtime=configure_runtime,
+        get_runtime=get_runtime,
+        runtime_not_configured_error=RuntimeNotConfiguredError,
+        build_submit_backend=build_submit_backend,
+    )
+    monkeypatch.setattr(sdk_adapter, "SDK_AVAILABLE", True)
+    monkeypatch.setattr(sdk_adapter, "_SDK_API", fake_api)
+    subsystem = AnnouncementSubsystem(AnnouncementConfig())
+
+    subsystem.on_register()
+    subsystem.on_heartbeat()
+    result = subsystem.submit(build_ex0_envelope(subsystem.run_id, "test"))
+
+    assert result.accepted is True
+    assert result.backend_kind == "lite_pg"
+    assert (
+        "heartbeat",
+        {"status": "healthy", "last_output_at": None, "pending_count": 0},
+    ) in calls
+    submit_calls = [call for call in calls if call[0] == "submit"]
+    assert len(submit_calls) == 1
+
+
+def test_real_sdk_mode_builds_non_mock_backend_from_sdk_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, object]] = []
+    active_context: Any | None = None
+
+    class RuntimeNotConfiguredError(RuntimeError):
+        pass
+
+    class FakeBase:
+        pass
+
+    class FakeRegistrationSpec:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.kwargs = kwargs
+
+    class FakeSubmitReceipt:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.accepted = kwargs["accepted"]
+            self.receipt_id = kwargs["receipt_id"]
+            self.backend_kind = kwargs["backend_kind"]
+            self.transport_ref = kwargs["transport_ref"]
+            self.validator_version = kwargs["validator_version"]
+            self.warnings = tuple(kwargs.get("warnings", ()))
+            self.errors = tuple(kwargs.get("errors", ()))
+
+    class FakeSubmitBackendConfig:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.backend_kind = kwargs["backend_kind"]
+            self.dsn = kwargs.get("dsn")
+
+    class FakeRealSubmitBackend:
+        backend_kind = "lite_pg"
+
+        def __init__(self) -> None:
+            self.submitted_payloads: list[dict[str, Any]] = []
+
+        def submit(self, payload):  # type: ignore[no-untyped-def]
+            self.submitted_payloads.append(dict(payload))
+            return {
+                "accepted": True,
+                "receipt_id": f"receipt-{len(self.submitted_payloads)}",
+                "transport_ref": f"queue-{len(self.submitted_payloads)}",
+                "warnings": (),
+                "errors": (),
+            }
+
+    class FakeSubmitClient:
+        def __init__(self, backend, validator):  # type: ignore[no-untyped-def]
+            self.backend = backend
+
+        def submit(self, payload):  # type: ignore[no-untyped-def]
+            backend_receipt = self.backend.submit(payload)
+            return FakeSubmitReceipt(
+                accepted=backend_receipt["accepted"],
+                receipt_id=backend_receipt["receipt_id"],
+                backend_kind=self.backend.backend_kind,
+                transport_ref=backend_receipt["transport_ref"],
+                validator_version="validator-v1",
+                warnings=backend_receipt["warnings"],
+                errors=backend_receipt["errors"],
+            )
+
+    class FakeHeartbeatAdapter:
+        def __init__(self, backend):  # type: ignore[no-untyped-def]
+            self.backend = backend
+            self.backend_kind = backend.backend_kind
+
+        def send(self, payload):  # type: ignore[no-untyped-def]
+            return self.backend.submit(payload)
+
+    class FakeHeartbeatClient:
+        def __init__(self, backend, validator):  # type: ignore[no-untyped-def]
+            self.backend = backend
+
+        def send_heartbeat(self, payload):  # type: ignore[no-untyped-def]
+            backend_receipt = self.backend.send(payload)
+            return FakeSubmitReceipt(
+                accepted=backend_receipt["accepted"],
+                receipt_id=backend_receipt["receipt_id"],
+                backend_kind=self.backend.backend_kind,
+                transport_ref=backend_receipt["transport_ref"],
+                validator_version="validator-v1",
+                warnings=backend_receipt["warnings"],
+                errors=backend_receipt["errors"],
+            )
+
+    class FakeBaseSubsystemContext:
+        def __init__(
+            self,
+            *,
+            registration,
+            submit_client,
+            heartbeat_client,
+            validator,
+        ):  # type: ignore[no-untyped-def]
+            self.registration = registration
+            self.submit_client = submit_client
+            self.heartbeat_client = heartbeat_client
+            self.validator = validator
+
+        def submit(self, payload):  # type: ignore[no-untyped-def]
+            return self.submit_client.submit(payload)
+
+        def send_heartbeat(self, status):  # type: ignore[no-untyped-def]
+            payload = {
+                "ex_type": "Ex-0",
+                "semantic": "metadata_or_heartbeat",
+                "subsystem_id": self.registration.kwargs["subsystem_id"],
+                "version": self.registration.kwargs["version"],
+                "heartbeat_at": datetime.now(timezone.utc),
+                **status,
+            }
+            return self.heartbeat_client.send_heartbeat(payload)
+
+    backend = FakeRealSubmitBackend()
+
+    def register_subsystem(spec):  # type: ignore[no-untyped-def]
+        calls.append(("register", spec.kwargs))
+
+    def get_runtime():  # type: ignore[no-untyped-def]
+        if active_context is None:
+            raise RuntimeNotConfiguredError()
+        return active_context
+
+    @contextmanager
+    def configure_runtime(context):  # type: ignore[no-untyped-def]
+        nonlocal active_context
+        assert active_context is None
+        active_context = context
+        try:
+            yield context
+        finally:
+            active_context = None
+
+    def build_submit_backend(config):  # type: ignore[no-untyped-def]
+        calls.append(("build_backend", (config.backend_kind, config.dsn)))
+        return backend
+
+    def send_heartbeat(payload):  # type: ignore[no-untyped-def]
+        return get_runtime().send_heartbeat(payload)
+
+    def submit(payload):  # type: ignore[no-untyped-def]
+        return get_runtime().submit(payload)
+
+    def assert_producer_only(ex_type, payload):  # type: ignore[no-untyped-def]
+        calls.append(("validate", (ex_type, payload["ex_type"])))
+
+    fake_api = sdk_adapter._SdkApi(
+        subsystem_base_interface=FakeBase,
+        registration_spec=FakeRegistrationSpec,
+        submit_receipt=FakeSubmitReceipt,
+        register_subsystem=register_subsystem,
+        send_heartbeat=send_heartbeat,
+        submit=submit,
+        assert_producer_only=assert_producer_only,
+        base_subsystem_context=FakeBaseSubsystemContext,
+        configure_runtime=configure_runtime,
+        get_runtime=get_runtime,
+        runtime_not_configured_error=RuntimeNotConfiguredError,
+        submit_client=FakeSubmitClient,
+        heartbeat_client=FakeHeartbeatClient,
+        submit_backend_config=FakeSubmitBackendConfig,
+        build_submit_backend=build_submit_backend,
+        submit_backend_heartbeat_adapter=FakeHeartbeatAdapter,
+        validation_result=object,
+    )
+    monkeypatch.setattr(sdk_adapter, "SDK_AVAILABLE", True)
+    monkeypatch.setattr(sdk_adapter, "_SDK_API", fake_api)
+    subsystem = AnnouncementSubsystem(
+        AnnouncementConfig(sdk_endpoint="postgresql://sdk.local/announcements")
+    )
+
+    subsystem.on_register()
+    subsystem.on_heartbeat()
+    result = subsystem.submit(build_ex0_envelope(subsystem.run_id, "test"))
+
+    assert result.accepted is True
+    assert result.backend_kind == "lite_pg"
+    assert result.transport_ref == "queue-2"
+    assert calls.count(
+        (
+            "build_backend",
+            ("lite_pg", "postgresql://sdk.local/announcements"),
+        )
+    ) == 1
+    assert [payload["ex_type"] for payload in backend.submitted_payloads] == [
+        "Ex-0",
+        "Ex-0",
+    ]
+    assert backend.backend_kind != "mock"
+
+
+def test_real_sdk_mode_rejects_mock_backend_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RuntimeNotConfiguredError(RuntimeError):
+        pass
+
+    class FakeBase:
+        pass
+
+    class FakeRegistrationSpec:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.kwargs = kwargs
+
+    class FakeSubmitReceipt:
+        pass
+
+    class FakeValidationResult:
+        pass
+
+    class FakeBackendConfig:
+        backend_kind = "mock"
+
+    def register_subsystem(spec):  # type: ignore[no-untyped-def]
+        return None
+
+    def get_runtime():  # type: ignore[no-untyped-def]
+        raise RuntimeNotConfiguredError()
+
+    def build_submit_backend(config):  # type: ignore[no-untyped-def]
+        raise AssertionError("mock backend config must be rejected before build")
+
+    def load_submit_backend_config(path):  # type: ignore[no-untyped-def]
+        assert path == Path("sdk-backend.toml")
+        return FakeBackendConfig()
+
+    fake_api = sdk_adapter._SdkApi(
+        subsystem_base_interface=FakeBase,
+        registration_spec=FakeRegistrationSpec,
+        submit_receipt=FakeSubmitReceipt,
+        register_subsystem=register_subsystem,
+        send_heartbeat=lambda payload: None,
+        submit=lambda payload: None,
+        assert_producer_only=lambda ex_type, payload: None,
+        base_subsystem_context=object,
+        configure_runtime=lambda context: context,
+        get_runtime=get_runtime,
+        runtime_not_configured_error=RuntimeNotConfiguredError,
+        submit_client=object,
+        heartbeat_client=object,
+        submit_backend_config=object,
+        build_submit_backend=build_submit_backend,
+        load_submit_backend_config=load_submit_backend_config,
+        submit_backend_heartbeat_adapter=object,
+        validation_result=FakeValidationResult,
+    )
+    monkeypatch.setattr(sdk_adapter, "SDK_AVAILABLE", True)
+    monkeypatch.setattr(sdk_adapter, "_SDK_API", fake_api)
+    subsystem = AnnouncementSubsystem(
+        AnnouncementConfig(sdk_endpoint="sdk-backend.toml")
+    )
+
+    with pytest.raises(UnsupportedSubsystemSdkError, match="backend_kind='mock'"):
+        subsystem.submit(build_ex0_envelope(subsystem.run_id, "test"))
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
@@ -364,7 +726,7 @@ def test_load_config_rejects_non_positive_runtime_intervals(
         load_config(config_path)
 
 
-def test_cli_ping_uses_sdk_when_available_and_fails_without_it() -> None:
+def test_cli_ping_requires_sdk_backend_when_sdk_is_available() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "subsystem_announcement", "ping"],
         cwd=ROOT,
@@ -374,17 +736,10 @@ def test_cli_ping_uses_sdk_when_available_and_fails_without_it() -> None:
         text=True,
     )
 
-    if SDK_AVAILABLE:
-        assert result.returncode == 0
-        assert result.stdout.strip() == "ok"
-        assert result.stderr == ""
-    else:
-        assert result.returncode == 1
-        assert result.stdout.strip() == ""
-        assert "subsystem-sdk is required" in result.stderr
+    _assert_cli_requires_sdk_or_backend(result)
 
 
-def test_cli_ping_ignores_legacy_stub_env_and_uses_or_requires_sdk() -> None:
+def test_cli_ping_ignores_legacy_stub_env_and_requires_sdk_backend() -> None:
     env = _cli_env()
     env["SUBSYSTEM_ANNOUNCEMENT_TEST_SDK_STUB"] = "1"
 
@@ -397,17 +752,10 @@ def test_cli_ping_ignores_legacy_stub_env_and_uses_or_requires_sdk() -> None:
         text=True,
     )
 
-    if SDK_AVAILABLE:
-        assert result.returncode == 0
-        assert result.stdout.strip() == "ok"
-        assert result.stderr == ""
-    else:
-        assert result.returncode == 1
-        assert result.stdout.strip() == ""
-        assert "subsystem-sdk is required" in result.stderr
+    _assert_cli_requires_sdk_or_backend(result)
 
 
-def test_cli_run_once_uses_sdk_when_available_and_fails_without_it() -> None:
+def test_cli_run_once_requires_sdk_backend_when_sdk_is_available() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "subsystem_announcement", "run", "--once"],
         cwd=ROOT,
@@ -417,11 +765,4 @@ def test_cli_run_once_uses_sdk_when_available_and_fails_without_it() -> None:
         text=True,
     )
 
-    if SDK_AVAILABLE:
-        assert result.returncode == 0
-        assert result.stdout.strip() == "ok"
-        assert result.stderr == ""
-    else:
-        assert result.returncode == 1
-        assert result.stdout.strip() == ""
-        assert "subsystem-sdk is required" in result.stderr
+    _assert_cli_requires_sdk_or_backend(result)


### PR DESCRIPTION
Closes #34

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `cross-cutting`, `src/subsystem_announcement/discovery/fetcher.py`, `src/subsystem_announcement/extract/entity_anchor.py`, `src/subsystem_announcement/graph/candidates.py`, `src/subsystem_announcement/graph/deltas.py`, `src/subsystem_announcement/index/retrieval_artifact.py`, `src/subsystem_announcement/index/vector_store.py`, `src/subsystem_announcement/parse/docling_client.py`, `src/subsystem_announcement/runtime/metrics.py`, `src/subsystem_announcement/runtime/pipeline.py`


---
## Background

CI \`pip install -e .\` fails with ResolutionImpossible:

\`\`\`
docling 2.15.1 depends on docling-core<3.0.0 and >=2.13.1
llama-index-node-parser-docling 0.1.0 depends on docling-core<2.0.0 and >=1.7.1
\`\`\`

I bumped \`llama-index-node-parser-docling\` to \`>=0.4\` but conflict persists (probably another sub-dep chain).

## Required fix

Reconcile docling-core version constraint across all docling-related packages. Likely needs:
1. Remove \`llama-index-node-parser-docling\` dependency entirely (use docling directly)
2. OR pin compatible versions of llama-index-* + docling
3. OR drop docling for an alternative (if not strictly needed)

## Verification

After fix:
- CI install step succeeds
- Existing tests still pass

## Files

- \`pyproject.toml\` (dependencies block)